### PR TITLE
Fixes #116 - set cookie domain via COOKIE_DOMAIN

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -60,6 +60,7 @@ When running the application using the provided [docker-compose.yml](docker-comp
 | [`ATTACHMENTS_ENABLED`](#attachments-enabled)                          |                 | X                      | X                     |
 | [`FILE_MAXIMUM_SIZE`](#file-maximum-size)                   |                 | X                      | X                     |
 | [`FILE_TYPES`](#file-types)                          |                 | X                      | X                     |
+| [`COOKIE_DOMAIN`](#cookie-domain)                    |                 |                        | X                     |
 
 ## `NODE_ENV`
 
@@ -422,3 +423,10 @@ Allowed file extensions for attachments.
 
 **Target** - Front-end (web), Back-end (api)<br>
 **Default** - `.tiff;.png;.pdf`<br>
+
+## `COOKIE_DOMAIN`
+
+The domain to scope the SAML authentication cookie to. Must be setable by the backend and readable by the frontend. A leading `.` indicates that any subdomains are in scope. For example, `.eapp.example.com` would allow `backend.eapp.example.com` to set the cookie and `frontend.eapp.example.com` to read it.
+
+**Target** - Back-end (api)<br>
+**Default** - The host component of the `API_REDIRECT` value<br>

--- a/api/http/saml.go
+++ b/api/http/saml.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	redirectTo = os.Getenv("API_REDIRECT")
+	cookieDomain = os.Getenv("COOKIE_DOMAIN")
 )
 
 // SamlRequestHandler is the handler for creating a SAML request.
@@ -108,11 +109,15 @@ func (service SamlResponseHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	}
 
 	service.Log.Info(api.SamlValid, api.LogFields{"account": account})
-	uri, _ := url.Parse(redirectTo)
-	domain := strings.Split(uri.Host, ":")[0]
+	if cookieDomain == "" {
+		service.Log.Warn(api.CookieDomainNotSet, api.LogFields{})
+		// Default to frontend host
+		uri, _ := url.Parse(redirectTo)
+		cookieDomain = strings.Split(uri.Host, ":")[0]
+        }
 	expiration := time.Now().Add(time.Duration(1) * time.Minute)
 	cookie := &http.Cookie{
-		Domain:   domain,
+		Domain:   cookieDomain,
 		Name:     "token",
 		Value:    signedToken,
 		HttpOnly: false,

--- a/api/log.go
+++ b/api/log.go
@@ -31,6 +31,7 @@ const (
 	BasicAuthMissingPassword                   = "Basic authentication failed because missing a password"
 	BasicAuthMissingUsername                   = "Basic authentication failed because missing a username"
 	CORSDenied                                 = "CORS request denied"
+	CookieDomainNotSet                         = "Cookie Domain is not set"
 	EntityError                                = "Error getting entity data"
 	EntitySaveError                            = "Error getting entity data"
 	InvalidJWT                                 = "Invalid JSON web token"


### PR DESCRIPTION
The cookie domain for the authentication cookie that conveys a token from the backend to the frontend after a SAML sign-on defaults to `API_REDIRECT` but can be optionally set via the `COOKIE_DOMAIN` environment variable.