### PR TITLE
Fix modal scroll issue

### DIFF
--- a/src/components/Form/Consent/Consent.scss
+++ b/src/components/Form/Consent/Consent.scss
@@ -1,8 +1,6 @@
 @import 'eqip-colors';
 
 .consent-modal .modal {
-  background-color: rgba(255, 255, 255, 0.95) !important;
-  z-index: 9999;
 
   .modal-wrap {
     // Originally this is a `table-cell` but the consent form is not embed within
@@ -13,7 +11,6 @@
   .consent-content {
     width: 50%;
     min-width: 100rem;
-    height: 90vh;
     margin-top: 5vh !important;
     margin-bottom: 5vh !important;
     padding: 0;
@@ -21,7 +18,6 @@
     box-shadow: none;
 
     @media only screen and (max-height: 800px) {
-      height: 100vh;
       margin-top: 0 !important;
       margin-bottom: 0 !important;
     }

--- a/src/components/Form/Introduction/Introduction.scss
+++ b/src/components/Form/Introduction/Introduction.scss
@@ -31,18 +31,9 @@
     .introduction-content {
       width: 50%;
       min-width: 100rem;
-      height: 90vh;
-      margin-top: 5vh !important;
-      margin-bottom: 5vh !important;
       padding: 0;
       border: none;
       box-shadow: none;
-
-      @media only screen and (max-height: 800px) {
-        height: 100vh;
-        margin-top: 0 !important;
-        margin-bottom: 0 !important;
-      }
 
       .introduction-legal {
         overflow-y: scroll;
@@ -63,7 +54,6 @@
       }
 
       .introduction-acceptance {
-        max-height: 40vh;
         padding-top: 2rem;
         margin: 4rem 5rem 0 5rem;
         border-top: 1px solid $eapp-grey;

--- a/src/components/Form/Modal/Modal.scss
+++ b/src/components/Form/Modal/Modal.scss
@@ -12,14 +12,13 @@
   top: 0;
   width: 100%;
   height: 100vh;
-  overflow: hidden;
-  background-color: rgb(255, 255, 255);
-  background-color: rgba(255, 255, 255, 0.9);
+  overflow-y: scroll;
+  background-color: rgb(0, 0, 0);
+  background-color: rgba(0, 0, 0, 0.8);
 
   .modal-wrap {
     display: table-cell;
     width: 100vw;
-    height: 100vh;
     vertical-align: middle;
   }
 


### PR DESCRIPTION
There is a lot of conflicting CSS for the modal, so it took me a bit to track down.
I cleaned up some of the unneeded styles and as a bonus also set the background when the modal is active to something darker which is more typically seen.  There is still a lot of CSS cleanup work to do 

### Modal with darker background 
![screen shot 2018-06-06 at 3 51 54 pm](https://user-images.githubusercontent.com/1449852/41061669-5e182f9c-69a1-11e8-983b-26c87217c54f.png)

### Modal scroll in IE11
![modal-scroll](https://user-images.githubusercontent.com/1449852/41061628-3dfafd98-69a1-11e8-9d35-d69cf502550f.gif)
