### PR TITLE
improve JavaScript build speed/workflow

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -9,4 +9,4 @@ RUN yarn install
 
 COPY . .
 
-CMD yarn watch
+CMD yarn build

--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,7 @@ start:
 stop:
 	docker-compose stop
 run:
+	$(info Running local development server)
 	docker-compose up web js css api db
 docs:
 	docker-compose up docs

--- a/Makefile
+++ b/Makefile
@@ -210,11 +210,11 @@ seccomp-post:
 down:
 	docker-compose down
 start:
-	docker-compose start web api db
+	docker-compose start web frontend api db
 stop:
 	docker-compose stop
 run:
-	docker-compose up web api db
+	docker-compose up web frontend api db
 docs:
 	docker-compose up docs
 tag:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ clean: stop reset-permissions
 setup: stop setup-containers setup-certificates setup-dependencies reset-permissions
 setup-containers:
 	$(info Building containers)
-	@docker-compose build deps frontend web db api
+	@docker-compose build deps js css web db api
 setup-certificates:
 	$(info Generating test certificates)
 	@docker-compose run --rm deps ./bin/test-certificates
@@ -54,10 +54,10 @@ setup-dependencies:
 lint: lint-js lint-css lint-go
 lint-js:
 	$(info Running JavaScript linter)
-	@docker-compose run --rm frontend ./node_modules/.bin/eslint src/
+	@docker-compose run --rm js ./node_modules/.bin/eslint src/
 lint-css:
 	$(info Running SCSS linter)
-	@docker-compose run --rm frontend yarn lint
+	@docker-compose run --rm css yarn lint
 lint-go:
 	$(info Running Go linter)
 	@docker-compose run --rm api ./bin/lint
@@ -68,7 +68,7 @@ lint-go:
 test: test-react test-go
 test-react:
 	$(info Running React test suite)
-	@docker-compose run --rm frontend yarn test
+	@docker-compose run --rm js yarn test
 test-go:
 	$(info Running Go test suite)
 	@docker-compose run --rm api make test
@@ -93,7 +93,8 @@ coverage:
 build: build-frontend build-go reset-permissions
 build-frontend:
 	$(info Compiling frontend)
-	@docker-compose run --rm frontend yarn build
+	@docker-compose run --rm css yarn build-css
+	@docker-compose run --rm js yarn build-js
 build-go:
 	$(info Compiling Go application)
 	@docker-compose run --rm api make build
@@ -210,11 +211,11 @@ seccomp-post:
 down:
 	docker-compose down
 start:
-	docker-compose start web frontend api db
+	docker-compose start web js css api db
 stop:
 	docker-compose stop
 run:
-	docker-compose up web frontend api db
+	docker-compose up web js css api db
 docs:
 	docker-compose up docs
 tag:

--- a/README.md
+++ b/README.md
@@ -51,18 +51,20 @@ GitHub commits can be traced back to their corresponding tasks through commit co
 
 To view the items completed during each development sprint and to view the burndown charts for each respective sprint, please visit the [Sprint Backlogs][26] page.
 
-## Getting to know the code
+## Development
 
-### Dependencies
+### Initial setup
+
+#### Dependencies
 
  - [git](https://git-scm.com)
  - [docker][21]
  - [docker-compose][20]
  - [make](https://www.gnu.org/software/make/)
 
-For more information on licenses and third-party source code please refer to the [dependencies](DEPENDENCIES.md) documentation.
+For more information on licenses and third-party source code please refer to the [dependencies](docs/DEPENDENCIES.md) documentation.
 
-### Clone all things
+#### Clone all things
 
 Clone the repository and `cd` into it:
 
@@ -81,22 +83,27 @@ cp .env.example .env
 
 For more information on the various settings, examples, and values please refer to the [configuration](docs/CONFIGURATION.md) documentation.
 
+#### Tests
 
-## Running the application
-
-To avoid manually running separate commands for [setup](#setup), [building](#building-the-application), and [testing](#executing-tests-and-coverage-reports) you can instead execute:
+To do the initial setup and ensure that all tests pass locally:
 
 ``` shell
 make
 ```
 
-### Setup
+### Running a local server
 
-Configure prerequisites using:
+To run a local server, we are using [docker][21] containers leveraging the [docker-compose][20] tool via the command:
 
 ```shell
-make setup
+make run
 ```
+
+Then direct your browser at [http://localhost:8080](http://localhost:8080). The access the site in development use the username `test01` and password `password01`. If you make changes to frontend files, the site will automatically rebuild after ~10 seconds.
+
+#### How it works
+
+The Make target calls Docker Compose, which then runs containers for various parts of the system. Frontend assets are built from their own containers into the `dist/` folder, which are then served by nginx. Nginx also proxies API requests to an API backend written in Go, which has a PostgreSQL container behind it.
 
 ### Building the application
 
@@ -106,6 +113,8 @@ Compiling all of the assets can be done simply using the command:
 make build
 ```
 
+This is generally only needed for deployment.
+
 ### Executing tests and coverage reports
 
 To make a single pass through the test suite use the command:
@@ -114,27 +123,6 @@ To make a single pass through the test suite use the command:
 make test
 make coverage
 ```
-
-### Running a local server
-
-To run a local server we are using [docker][21] containers leveraging the [docker-compose][20] tool via the command:
-
-```shell
-make run
-```
-
-Then direct your browser at [http://localhost:8080](http://localhost:8080). The access the site in development use the username `test01` and password `password01`.
-
-## Docker containers
-
-| Container | Image               |
-| --------  | ------------------- |
-| api       | [Dockerfile.api](Dockerfile.api) |
-| db        | postgres:9.6.5      |
-| web       | nginx:alpine        |
-| frontend  | node:8.5.0          |
-
-The IdAM solution **is not** part of this project.
 
 ## Architectural diagram
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# intended for local development
+
 version: '2'
 
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,12 +38,26 @@ services:
     depends_on:
       - api
 
-  frontend:
+  js:
     build:
       context: .
       dockerfile: Dockerfile.frontend
     env_file:
       - .env
+    command: yarn watch-js
+    volumes:
+      - .:/usr/src/app
+      - /usr/src/app/node_modules
+    networks:
+      - eapp
+
+  css:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    env_file:
+      - .env
+    command: yarn watch-css
     volumes:
       - .:/usr/src/app
       - /usr/src/app/node_modules

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,3 @@
-var webpack = require('webpack-stream')
 var del = require('del')
 var gulp = require('gulp')
 var concat = require('gulp-concat')
@@ -7,10 +6,6 @@ var sasslint = require('@18f/stylelint-rules')
 require('dotenv').config()
 
 var paths = {
-  entry: ['./src/boot.jsx'],
-  js: [
-    './src/**/*.js*'
-  ],
   sassvars: './src/sass',
   sass: {
     rules: {
@@ -46,8 +41,7 @@ var paths = {
     css: './dist/css',
     fonts: './dist/fonts',
     images: './dist/img'
-  },
-  webpack: './webpack.config.js'
+  }
 }
 
 gulp.task('clean', clean)
@@ -56,7 +50,7 @@ gulp.task('fonts', ['clean'], fonts)
 gulp.task('images', ['clean'], images)
 gulp.task('lint', [], sasslint(paths.sass.local[0], paths.sass.rules))
 gulp.task('sass', ['clean'], convert)
-gulp.task('build', ['clean', 'copy', 'fonts', 'images', 'sass'], compile)
+gulp.task('build', ['clean', 'copy', 'fonts', 'images', 'sass'])
 gulp.task('watchdog', ['build'], watchdog)
 gulp.task('default', ['build'])
 
@@ -88,14 +82,6 @@ function images () {
     .pipe(gulp.dest(paths.destination.images))
 }
 
-function compile () {
-  'use strict'
-  return gulp
-    .src(paths.entry)
-    .pipe(webpack(require(paths.webpack)))
-    .pipe(gulp.dest(paths.destination.root))
-}
-
 function convert () {
   'use strict'
   return gulp
@@ -109,5 +95,5 @@ function convert () {
 
 function watchdog () {
   'use strict'
-  return gulp.watch([paths.js, paths.sass.local], ['build'])
+  return gulp.watch([paths.sass.local], ['build'])
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,7 +57,9 @@ gulp.task('default', ['build'])
 function clean () {
   'use strict'
   return del([
-    paths.destination.root + '/*'
+    paths.destination.root + '/*',
+    // don't delete JS files created by Webpack
+    '!' + paths.destination.root + '/eqip.js'
   ])
 }
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "build-js": "webpack -p --progress",
     "build-css": "gulp build",
     "build": "npm run build-css && npm run build-js",
-    "watch-js": "echo \"Starting JS compilation - takes ~60 seconds until ready\" && webpack --watch --progress",
+    "watch-js": "echo \"Starting JS compilation... (Will be ready once you see 'eqip.js' message, after ~60 seconds.)\" && webpack --watch --progress",
     "watch-css": "gulp watchdog",
     "docs": "jsdoc ./src -r -d ./doc/frontend"
   }

--- a/package.json
+++ b/package.json
@@ -76,8 +76,7 @@
     "redux-thunk": "^2.1.0",
     "smoothscroll-polyfill": "^0.3.6",
     "uswds": "^1.4.0",
-    "webpack": "^3.6.0",
-    "webpack-stream": "^4.0.0"
+    "webpack": "^3.6.0"
   },
   "jest": {
     "coverageDirectory": "./coverage/",
@@ -90,8 +89,11 @@
     "test": "NODE_ENV=test jest -u --logHeapUsage --coverage --silent",
     "lint": "gulp lint",
     "coverage": "NODE_ENV=test codecov",
-    "build": "gulp build",
-    "watch": "gulp watchdog",
+    "build-js": "webpack -p --progress",
+    "build-css": "gulp build",
+    "build": "npm run build-css && npm run build-js",
+    "watch-js": "webpack --watch --progress",
+    "watch-css": "gulp watchdog",
     "docs": "jsdoc ./src -r -d ./doc/frontend"
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "build-js": "webpack -p --progress",
     "build-css": "gulp build",
     "build": "npm run build-css && npm run build-js",
-    "watch-js": "webpack --watch --progress",
+    "watch-js": "echo \"Starting JS compilation - takes ~60 seconds until ready\" && webpack --watch --progress",
     "watch-css": "gulp watchdog",
     "docs": "jsdoc ./src -r -d ./doc/frontend"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1710,10 +1710,6 @@ clone@^1.0.0, clone@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
 
-clone@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
-
 cloneable-readable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cloneable-readable/-/cloneable-readable-1.0.0.tgz#a6290d413f217a61232f95e458ff38418cfb0117"
@@ -4629,10 +4625,6 @@ lodash.bind@^4.1.4:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
 
-lodash.clone@^4.3.2:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
-
 lodash.clonedeep@^4.3.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -4727,7 +4719,7 @@ lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
-lodash.some@^4.2.2, lodash.some@^4.4.0:
+lodash.some@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
@@ -4868,7 +4860,7 @@ memoizee@0.4.X:
     next-tick "1"
     timers-ext "^0.1.2"
 
-memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
+memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
   dependencies:
@@ -6890,7 +6882,7 @@ through2@^0.6.1, through2@^0.6.3, through2@~0.6.1:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
-"through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8, through@~2.3.4:
+"through@>=2.2.7 <3", through@^2.3.6, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -7209,17 +7201,6 @@ vinyl@^2.0.0:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-vinyl@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.1.0.tgz#021f9c2cf951d6b939943c89eb5ee5add4fd924c"
-  dependencies:
-    clone "^2.1.1"
-    clone-buffer "^1.0.0"
-    clone-stats "^1.0.0"
-    cloneable-readable "^1.0.0"
-    remove-trailing-separator "^1.0.1"
-    replace-ext "^1.0.0"
-
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
@@ -7269,19 +7250,7 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-stream@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/webpack-stream/-/webpack-stream-4.0.0.tgz#f3673dd907d6d9b1ea7bf51fcd1db85b5fd9e0f2"
-  dependencies:
-    gulp-util "^3.0.7"
-    lodash.clone "^4.3.2"
-    lodash.some "^4.2.2"
-    memory-fs "^0.4.1"
-    through "^2.3.8"
-    vinyl "^2.1.0"
-    webpack "^3.4.1"
-
-webpack@^3.4.1, webpack@^3.6.0:
+webpack@^3.6.0:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.8.1.tgz#b16968a81100abe61608b0153c9159ef8bb2bd83"
   dependencies:


### PR DESCRIPTION
This is an alternative to #387, taking a more incremental approach of tweaking the existing tooling rather than replacing it. What's changed:

* Watching for asset builds has been incorporated into `make run` - separate top-level `build`/`watch` process no longer needed
* Using Webpack (rather than Gulp) for watching JS changes.
    * This means faster build times, because it's smart enough to only rebuild what's necessary, rather than the entire frontend
    * Split JS and CSS building into their own containers, since each now has its own process
* Clarified/expanded development documentation

**Time for frontend changes to be reflected are down from 60 seconds to ~14,** and there this could be further improved without too much effort.