### PR TITLE
Fix xml tests by adding soft link to testdata

### DIFF
--- a/api/xml/testdata
+++ b/api/xml/testdata
@@ -1,0 +1,1 @@
+../testdata


### PR DESCRIPTION
Shared test JSON files are at top-level of the api package, but tests
are executed with the working dir set to the sub-dir (e.g., api/xml).