### PR TITLE
allow data URIs to be shown

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -47,7 +47,7 @@ http {
     add_header X-Frame-Options           "SAMEORIGIN";
     add_header X-XSS-Protection          "1; mode=block";
     add_header X-Content-Type-Options    nosniff;
-    add_header Content-Security-Policy   "default-src 'self' *.google.com *.amazon.com dap.digitalgov.gov *.google-analytics.com fonts.googleapis.com fonts.gstatic.com;";
+    add_header Content-Security-Policy   "default-src 'self' *.google.com *.amazon.com dap.digitalgov.gov *.google-analytics.com fonts.googleapis.com fonts.gstatic.com; img-src 'self' data: *.google-analytics.com";
     index      index.html;
 
     server {


### PR DESCRIPTION
Previously, `data:image` URIs were blocked, resulting in a browser error when trying to display the QR code:

> Refused to load the image 'data:image/svg+xml;base64,...' because it violates the following Content Security Policy directive: "default-src 'self' *.google.com *.amazon.com dap.digitalgov.gov *.google-analytics.com fonts.googleapis.com fonts.gstatic.com". Note that 'img-src' was not explicitly set, so 'default-src' is used as a fallback.

This fix is not ideal, for security reasons:

> This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src

but at least fixes the error for now. We might want to make an issue to figure out a different way to display them, so we can disallow data URIs.