### PR TITLE
improve build speed of frontend Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -7,6 +7,4 @@ COPY package.json package.json
 COPY yarn.lock yarn.lock
 RUN yarn install
 
-COPY . .
-
 CMD yarn build

--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ make test
 make coverage
 ```
 
+### Adding/updating NPM packages
+
+Whenever the `dependencies` list in [`package.json`](package.json) is changed, make sure the [`yarn.lock`](yarn.lock) gets updated as well:
+
+```shell
+docker-compose run js yarn
+```
+
 ## Architectural diagram
 
 ![eapparchitecture](https://user-images.githubusercontent.com/12962390/37600234-1ecdb4ba-2b5d-11e8-99b3-a07f46aef611.png)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
     command: yarn watch-js
     volumes:
       - .:/usr/src/app
+      # ensure node_modules aren't shared with host system
+      # https://michalzalecki.com/docker-compose-for-nodejs-and-postresql/#docker-compose
       - /usr/src/app/node_modules
     networks:
       - eapp
@@ -62,6 +64,7 @@ services:
     command: yarn watch-css
     volumes:
       - .:/usr/src/app
+      # ditto above
       - /usr/src/app/node_modules
     networks:
       - eapp


### PR DESCRIPTION
Don't upload the `node_modules` to the Docker daemon, and don't bother copying the repository files into the image. Also added some documentation.