### PR TITLE
don't collect coverage when running Jest by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   },
   "jest": {
     "coverageDirectory": "./coverage/",
-    "collectCoverage": true,
     "verbose": false,
     "bail": false,
     "clearMocks": true,


### PR DESCRIPTION
It's already enabled in the `test` NPM script (which is used in CI), so take it out when running Jest is being run in isolation (locally). This will make local testing faster.