### PR TITLE
Fixes for printing and instruction to reset locked form

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ To create the e-QIP questionnaire prototype, the project team is employing a use
        - [Building the application](#building-the-application)
        - [Executing tests and coverage reports](#executing-tests-and-coverage-reports)
        - [Running a local server](#running-a-local-server)
+       - [Reset locked app submission](#reset-locked-submission)
  - [Docker containers](#docker-containers)
  - [Architectural diagram](#architectural-diagram)
  - [Additional](#additional)
@@ -97,6 +98,19 @@ make run
 ```
 
 Then direct your browser at [http://localhost:8080](http://localhost:8080). The access the site in development use the username `test01` and password `password01`. If you make changes to frontend files, the site will automatically rebuild after ~10 seconds.
+
+### Reset locked app submission
+In the terminal run the following:
+
+1. `docker ps -a | grep e-qip-prototype_db_1` and use the db value in the next command.
+1. `docker exec -it <DB HERE> /bin/bash`
+1. `su - postgres`
+1. `psql`
+1. `begin;`
+1. `update accounts set locked = false where username = 'test01';`
+1. `commit;`
+
+The submission will be unlocked and you can go back through the application.
 
 #### How it works
 

--- a/src/sass/print.scss
+++ b/src/sass/print.scss
@@ -100,11 +100,11 @@
       }
     }
 
-    .eapp-core {
+    .eapp-structure-wrap .eapp-core {
         width: auto;
         padding: 0;
     }
-    hr.section-divider {
+    .section-view hr.section-divider {
       margin-bottom: 1rem;
     }
 

--- a/src/sass/print.scss
+++ b/src/sass/print.scss
@@ -101,8 +101,8 @@
     }
 
     .eapp-structure-wrap .eapp-core {
-        width: auto;
-        padding: 0;
+      width: auto;
+      padding: 0;
     }
     .section-view hr.section-divider {
       margin-bottom: 1rem;

--- a/src/sass/print.scss
+++ b/src/sass/print.scss
@@ -99,6 +99,15 @@
         display: table-cell;
       }
     }
+
+    .eapp-core {
+        width: auto;
+        padding: 0;
+    }
+    hr.section-divider {
+      margin-bottom: 1rem;
+    }
+
   }
 
   // The very last page needs the footer at the very bottom just like every


### PR DESCRIPTION
This closes #141 

Fixed the alignment of the print page.
Also added instruction to the readme for how to unlock the form after submitting 👍 

**In general there a a lot of potential ways to streamline the printed form** 
- Make the headers text a bit smaller for print
- Don't show unselected options in print (for example showing the suffix at print takes up space)
- Close the large margins between sections 
- for multi-select just show the option that was selected and not all possible options that could have been selected (hair color)
- Don't show example text for printed  form

### Screenshot (left aligned)
![screen shot 2018-06-19 at 9 53 18 am](https://user-images.githubusercontent.com/1449852/41601577-d28a1cd2-73a6-11e8-86d3-e3cb8d14e1e2.png)
