### PR TITLE
use the Redux DevTools Extension for troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ All of the documentation may then be found in the respective directories under `
 
 ### Troubleshooting
 
-- Use of [React Developer Tools](https://github.com/facebook/react-devtools) is recommended for frontend work.
-- With that extension, the Redux store can be inspected by running `$r.store.getState();` in your browser's JavaScript console.
+- Use of the [React Developer Tools](https://github.com/facebook/react-devtools) and [Redux DevTools Extension](http://extension.remotedev.io/) are recommended for frontend work.
+- With the React extension, the Redux store can be inspected by running `$r.store.getState();` in your browser's JavaScript console.
 
 ### Tooling
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -5819,14 +5819,6 @@ This is a collection of dependencies within the project and their associated lic
 
 [View license](node_modules/redux/LICENSE.md)
 
-### redux-logger
-
- - **License**: MIT
- - **Year**:    2016
- - **Author**:  Eugene Rodionov
-
-[View license](node_modules/redux-logger/LICENSE)
-
 ### redux-mock-store
 
  - **License**: MIT

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-test-renderer": "^15.6.1",
     "react-tokeninput": "^2.4.0",
     "redux": "^3.6.0",
-    "redux-logger": "^3.0.6",
+    "redux-devtools-extension": "^2.13.2",
     "redux-mock-store": "^1.3.0",
     "redux-thunk": "^2.1.0",
     "smoothscroll-polyfill": "^0.3.6",

--- a/src/store.js
+++ b/src/store.js
@@ -1,17 +1,23 @@
 import thunk from 'redux-thunk'
 import rootReducer from './reducers'
 import { createStore, applyMiddleware } from 'redux'
-import logger from 'redux-logger'
+import { composeWithDevTools } from 'redux-devtools-extension'
 import { historyMiddleware, sectionMiddleware, saveMiddleware, settingsMiddleware, clearErrorsMiddleware } from './middleware/history'
 
-let middleware = []
-if (process.env.NODE_ENV !== 'production') {
-  middleware.push(logger)
-}
-middleware = [thunk, ...middleware, historyMiddleware, sectionMiddleware, saveMiddleware, settingsMiddleware, clearErrorsMiddleware]
+const middleware = [thunk, historyMiddleware, sectionMiddleware, saveMiddleware, settingsMiddleware, clearErrorsMiddleware]
 
 // Creates a redux store that defines the state tree for the application.
 // See rootReducer for all sub-states.
-const store = process.env.NODE_ENV === 'test' ? createStore(rootReducer) : createStore(rootReducer, applyMiddleware(...middleware))
+let store
+switch (process.env.NODE_ENV) {
+case 'test':
+  store = createStore(rootReducer)
+  break
+case 'production':
+  store = createStore(rootReducer, applyMiddleware(...middleware))
+  break
+default:
+  store = createStore(rootReducer, composeWithDevTools(applyMiddleware(...middleware)))
+}
 
 export default store

--- a/yarn.lock
+++ b/yarn.lock
@@ -2380,10 +2380,6 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
-deep-diff@^0.3.5:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
-
 deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -6871,11 +6867,9 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-redux-logger@^3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
-  dependencies:
-    deep-diff "^0.3.5"
+redux-devtools-extension@^2.13.2:
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.2.tgz#e0f9a8e8dfca7c17be92c7124958a3b94eb2911d"
 
 redux-mock-store@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
Having the log message output to the console is noisy, and not helpful if not dealing with Redux. Switched to using the browser extension, which has more features.