### PR TITLE
remove DAP

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -64,8 +64,5 @@
 
     <!-- Include scripts at the bottom for performance gains in some browsers -->
     <script type="text/javascript" language="javascript" src="/eqip.js"></script>
-
-    <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
-    <script type="text/javascript" language="javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js" id="_fed_an_ua_tag"></script>
   </body>
 </html>


### PR DESCRIPTION
Closes #390. Closes #391.

In the [docs for the Digital Analytics Program](https://github.com/digital-analytics-program/gov-wide-code#appropriate-placement), they say that "the DAP script tag should not be placed on pages visited
during logged-in sessions". The only pages where the user isn't logged in are the consent form and the login form, the latter of which we probably don't want an external script on anyway. Removing DAP for now, at least until there's a more extensive landing page and other unauthenticated parts of the site.