### PR TITLE
give 404s when requesting a file that doesn't exist

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -55,12 +55,15 @@ http {
         listen                8080;
         listen                [::]:8080 default_server;
         root                  /usr/share/nginx/html;
-				client_max_body_size  5000000;
+        client_max_body_size  5000000;
 
         location / {
             autoindex on;
             try_files $uri /index.html;
         }
+
+        # requests for specific files (that have an extension)
+        location ~ "\.[a-zA-Z0-9]{2,4}$" {}
 
         # Transparent proxy to Go API
         location ~ ^/api/(.*)$ {


### PR DESCRIPTION
Closes #404 (ha!).

Previously, all requests (to somewhere other than `/api/*`) would return a 200. Now, nginx will give a 404 when making a request with an extension, such as `*.js` or `*.css`. New behavior:

```
$ curl -I http://localhost:8080/
HTTP/1.1 200 OK
...
$ curl -I http://localhost:8080/foo
HTTP/1.1 200 OK
...
$ curl -I http://localhost:8080/eqip.js
HTTP/1.1 200 OK
...
$ curl -I http://localhost:8080/foo.js
HTTP/1.1 404 Not Found
...
```

I would like to add a test for this, but blocked by #441.