### PR TITLE
move top-level components to their own directory

### DIFF
--- a/src/boot.jsx
+++ b/src/boot.jsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import App from './App'
-import { Login, Loading, AccessDenied, Locked, TokenRefresh, Help, Form } from './views'
+import Main from './components/Main/Main'
+import AppWithForm from './components/Main/AppWithForm'
+import { Login, Loading, AccessDenied, Locked, TokenRefresh, Help } from './views'
 import { Router, Switch, Route } from 'react-router'
 import { Provider } from 'react-redux'
 import { env } from './config'
@@ -92,22 +93,6 @@ var observer = new MutationObserver(callback)
 observer.observe(targetNode, config)
 
 const app = document.getElementById('app')
-
-class Main extends React.Component {
-  render () {
-    return this.props.children
-  }
-}
-
-class AppWithForm extends React.Component {
-  render () {
-    return (
-      <App {...this.props}>
-        <Form {...this.props} />
-      </App>
-    )
-  }
-}
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/components/Main/App.jsx
+++ b/src/components/Main/App.jsx
@@ -1,12 +1,10 @@
 import React from 'react'
-import { i18n } from './config'
-import { SectionTitle, ProgressBar, Sticky, ScoreCard, Navigation, NavigationToggle } from './components'
-import { Introduction } from './components/Form'
-import StickyHeader from './components/Sticky/StickyHeader'
+import { i18n } from '../../config'
+import { SectionTitle, ProgressBar, Sticky, ScoreCard, Navigation, NavigationToggle } from '..'
+import { Introduction } from '../Form'
+import StickyHeader from '../Sticky/StickyHeader'
 import { connect } from 'react-redux'
-import { env } from './config'
-import { api } from './services/api'
-import { logout } from './actions/AuthActions'
+import { logout } from '../../actions/AuthActions'
 
 /*
            1/6-ish                                 2/3-ish                               1/6-ish

--- a/src/components/Main/App.test.jsx
+++ b/src/components/Main/App.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import App from '../src/App'
+import App from './App'
 import renderer from 'react-test-renderer'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'

--- a/src/components/Main/AppWithForm.jsx
+++ b/src/components/Main/AppWithForm.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import App from './App'
+import { Form } from '../../views'
+
+class AppWithForm extends React.Component {
+  render () {
+    return (
+      <App {...this.props}>
+        <Form {...this.props} />
+      </App>
+    )
+  }
+}
+
+export default AppWithForm

--- a/src/components/Main/Main.jsx
+++ b/src/components/Main/Main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+class Main extends React.Component {
+  render () {
+    return this.props.children
+  }
+}
+
+export default Main

--- a/src/config/environment.js
+++ b/src/config/environment.js
@@ -14,8 +14,8 @@ const parseBool = (val) => {
 
 class Env {
   History () {
-    const useHashRouting = parseBool(process.env.HASH_ROUTING)
     if (!this.history) {
+      const useHashRouting = parseBool(process.env.HASH_ROUTING)
       this.history = useHashRouting ? createHashHistory() : createBrowserHistory()
     }
     return this.history


### PR DESCRIPTION
Just a small refactor, so that all(?) React components now live under `src/components/`.