### PR TITLE
[WORK IN PROGRESS] dramatically simplify use of AuthenticatedView

### DIFF
--- a/src/components/Form/Introduction/Introduction.jsx
+++ b/src/components/Form/Introduction/Introduction.jsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux'
 import { i18n } from '../../../config'
 import { updateApplication } from '../../../actions/ApplicationActions'
 import { logout } from '../../../actions/AuthActions'
-import AuthenticatedView from '../../../views/AuthenticatedView'
 import Branch from '../Branch'
 import Modal from '../Modal'
 import Show from '../Show'
@@ -86,4 +85,4 @@ function mapStateToProps (state) {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(Introduction))
+export default connect(mapStateToProps)(Introduction)

--- a/src/components/Form/TimeoutWarning/TimeoutWarning.jsx
+++ b/src/components/Form/TimeoutWarning/TimeoutWarning.jsx
@@ -5,7 +5,6 @@ import { api } from '../../../services'
 import { updateApplication } from '../../../actions/ApplicationActions'
 import { tokenError } from '../../../actions/AuthActions'
 import { saveSection } from '../../SavedIndicator/persistence-helpers'
-import AuthenticatedView from '../../../views/AuthenticatedView'
 import Modal from '../Modal'
 import Svg from '../Svg'
 
@@ -148,4 +147,4 @@ function mapStateToProps (state) {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(TimeoutWarning))
+export default connect(mapStateToProps)(TimeoutWarning)

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import AuthenticatedView from '../../views/AuthenticatedView'
 import { navigation } from '../../config'
 import SectionList from './SectionList'
 
@@ -15,4 +14,4 @@ class Navigation extends React.Component {
 
 Navigation.propTypes = {}
 
-export default AuthenticatedView(Navigation)
+export default Navigation

--- a/src/components/Navigation/NavigationToggle.jsx
+++ b/src/components/Navigation/NavigationToggle.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { updateApplication } from '../../actions/ApplicationActions'
-import AuthenticatedView from '../../views/AuthenticatedView'
 
 export class NavigationToggle extends React.Component {
   constructor (props) {
@@ -49,4 +48,4 @@ function mapStateToProps (state) {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(NavigationToggle))
+export default connect(mapStateToProps)(NavigationToggle)

--- a/src/components/ProgressBar/ProgressBar.jsx
+++ b/src/components/ProgressBar/ProgressBar.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import AuthenticatedView from '../../views/AuthenticatedView'
 import { sectionsTotal, sectionsCompleted } from '../Navigation/navigation-helpers'
 
 class ProgressBar extends React.Component {
@@ -28,4 +27,4 @@ function mapStateToProps (state) {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(ProgressBar))
+export default connect(mapStateToProps)(ProgressBar)

--- a/src/components/SavedIndicator/SavedIndicator.jsx
+++ b/src/components/SavedIndicator/SavedIndicator.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { i18n } from '../../config'
-import AuthenticatedView from '../../views/AuthenticatedView'
 import { Show } from '../Form'
 import { saveSection } from './persistence-helpers'
 import { formIsLocked } from '../../validators'
@@ -183,4 +182,4 @@ function mapStateToProps (state) {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(SavedIndicator))
+export default connect(mapStateToProps)(SavedIndicator)

--- a/src/components/ScoreCard/ScoreCard.jsx
+++ b/src/components/ScoreCard/ScoreCard.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { i18n } from '../../config'
-import AuthenticatedView from '../../views/AuthenticatedView'
 import { sectionsTotal, sectionsCompleted } from '../Navigation/navigation-helpers'
 
 class ScoreCard extends React.Component {
@@ -31,4 +30,4 @@ function mapStateToProps (state) {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(ScoreCard))
+export default connect(mapStateToProps)(ScoreCard)

--- a/src/components/Section/Citizenship/Citizenship.jsx
+++ b/src/components/Section/Citizenship/Citizenship.jsx
@@ -4,7 +4,6 @@ import { i18n } from '../../../config'
 import SectionElement from '../SectionElement'
 import SectionComments from '../SectionComments'
 import { SectionViews, SectionView } from '../SectionView'
-import AuthenticatedView from '../../../views/AuthenticatedView'
 import { Field } from '../../Form'
 import Status from './Status'
 import Multiple from './Multiple'
@@ -199,4 +198,4 @@ export class CitizenshipSections extends React.Component {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(Citizenship))
+export default connect(mapStateToProps)(Citizenship)

--- a/src/components/Section/Financial/Financial.jsx
+++ b/src/components/Section/Financial/Financial.jsx
@@ -4,7 +4,6 @@ import { i18n } from '../../../config'
 import { SectionViews, SectionView } from '../SectionView'
 import SectionElement from '../SectionElement'
 import SectionComments from '../SectionComments'
-import AuthenticatedView from '../../../views/AuthenticatedView'
 import { Field } from '../../Form'
 import Gambling from './Gambling'
 import Bankruptcies from './Bankruptcy'
@@ -364,4 +363,4 @@ export class FinancialSections extends React.Component {
     )
   }
 }
-export default connect(mapStateToProps)(AuthenticatedView(Financial))
+export default connect(mapStateToProps)(Financial)

--- a/src/components/Section/Foreign/Foreign.jsx
+++ b/src/components/Section/Foreign/Foreign.jsx
@@ -5,7 +5,6 @@ import { i18n } from '../../../config'
 import { SectionViews, SectionView } from '../SectionView'
 import SectionElement from '../SectionElement'
 import SectionComments from '../SectionComments'
-import AuthenticatedView from '../../../views/AuthenticatedView'
 import { Field } from '../../Form'
 import Passport from './Passport'
 import Contacts from './Contacts'
@@ -853,4 +852,4 @@ export class ForeignSections extends React.Component {
   }
 }
 
-export default withRouter(connect(mapStateToProps)(AuthenticatedView(Foreign)))
+export default withRouter(connect(mapStateToProps)(Foreign))

--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -6,7 +6,6 @@ import { i18n } from '../../../config'
 import { SectionViews, SectionView } from '../SectionView'
 import SectionElement from '../SectionElement'
 import SectionComments from '../SectionComments'
-import AuthenticatedView from '../../../views/AuthenticatedView'
 import { Field, Svg, Show, Branch } from '../../Form'
 import SummaryProgress from './SummaryProgress'
 import SummaryCounter from './SummaryCounter'
@@ -738,4 +737,4 @@ export class HistorySections extends React.Component {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(History))
+export default connect(mapStateToProps)(History)

--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -4,7 +4,6 @@ import { i18n } from '../../../config'
 import { SectionViews, SectionView } from '../SectionView'
 import SectionElement from '../SectionElement'
 import SectionComments from '../SectionComments'
-import AuthenticatedView from '../../../views/AuthenticatedView'
 import { Field } from '../../Form'
 import { addDividers, createSubsection } from '../generators'
 import navigation from './navigation'
@@ -234,4 +233,4 @@ export class IdentificationSections extends React.Component {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(Identification))
+export default connect(mapStateToProps)(Identification)

--- a/src/components/Section/Legal/Legal.jsx
+++ b/src/components/Section/Legal/Legal.jsx
@@ -4,7 +4,6 @@ import { i18n } from '../../../config'
 import { SectionViews, SectionView } from '../SectionView'
 import SectionElement from '../SectionElement'
 import SectionComments from '../SectionComments'
-import AuthenticatedView from '../../../views/AuthenticatedView'
 import { Field } from '../../Form'
 import Offenses from './Police/Offenses'
 import OtherOffenses from './Police/OtherOffenses'
@@ -937,4 +936,4 @@ export class LegalSections extends React.Component {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(Legal))
+export default connect(mapStateToProps)(Legal)

--- a/src/components/Section/Military/Military.jsx
+++ b/src/components/Section/Military/Military.jsx
@@ -4,7 +4,6 @@ import { i18n } from '../../../config'
 import { SectionViews, SectionView } from '../SectionView'
 import SectionElement from '../SectionElement'
 import SectionComments from '../SectionComments'
-import AuthenticatedView from '../../../views/AuthenticatedView'
 import { hideDisciplinaryProcedures } from '../../../validators/militarydisciplinary'
 import { hideSelectiveService } from '../../../validators/selectiveservice'
 import { Show, Field } from '../../Form'
@@ -284,4 +283,4 @@ export class MilitarySections extends React.Component {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(Military))
+export default connect(mapStateToProps)(Military)

--- a/src/components/Section/Package/Package.jsx
+++ b/src/components/Section/Package/Package.jsx
@@ -5,7 +5,6 @@ import { i18n, navigationWalker } from '../../../config'
 import { hideHippa } from '../../../validators/releases'
 import { SectionViews, SectionView } from '../SectionView'
 import SectionElement from '../SectionElement'
-import AuthenticatedView from '../../../views/AuthenticatedView'
 import ValidForm from './ValidForm'
 import InvalidForm from './InvalidForm'
 import SubmissionStatus from './SubmissionStatus'
@@ -273,4 +272,4 @@ Package.defaultProps = {
   store: 'Submission'
 }
 
-export default withRouter(connect(mapStateToProps)(AuthenticatedView(Package)))
+export default withRouter(connect(mapStateToProps)(Package))

--- a/src/components/Section/Package/Print.jsx
+++ b/src/components/Section/Package/Print.jsx
@@ -17,7 +17,6 @@ import { ForeignSections } from '../Foreign'
 import { SubstanceUseSections } from '../SubstanceUse'
 import { LegalSections } from '../Legal'
 import { PsychologicalSections } from '../Psychological'
-import AuthenticatedView from '../../../views/AuthenticatedView'
 
 class Print extends SectionElement {
   constructor (props) {
@@ -275,4 +274,4 @@ const blobFromBase64 = (base64, contentType = '', size = 512) => {
 }
 
 
-export default connect(mapStateToProps)(AuthenticatedView(Print))
+export default connect(mapStateToProps)(Print)

--- a/src/components/Section/Psychological/Psychological.jsx
+++ b/src/components/Section/Psychological/Psychological.jsx
@@ -4,7 +4,6 @@ import { i18n, env } from '../../../config'
 import { SectionViews, SectionView } from '../SectionView'
 import SectionElement from '../SectionElement'
 import SectionComments from '../SectionComments'
-import AuthenticatedView from '../../../views/AuthenticatedView'
 import { Show, Field } from '../../Form'
 import Competence from './Competence/Competence'
 import Consultation from './Consultation/Consultation'
@@ -307,4 +306,4 @@ export class PsychologicalSections extends React.Component {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(Psychological))
+export default connect(mapStateToProps)(Psychological)

--- a/src/components/Section/Relationships/Relationships.jsx
+++ b/src/components/Section/Relationships/Relationships.jsx
@@ -5,7 +5,6 @@ import { i18n } from '../../../config'
 import { SectionViews, SectionView } from '../SectionView'
 import SectionElement from '../SectionElement'
 import SectionComments from '../SectionComments'
-import AuthenticatedView from '../../../views/AuthenticatedView'
 import { Field } from '../../Form'
 import Relatives from './Relatives'
 import Marital from './RelationshipStatus/Marital'
@@ -305,4 +304,4 @@ export class RelationshipSections extends React.Component {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(Relationships))
+export default connect(mapStateToProps)(Relationships)

--- a/src/components/Section/Section.jsx
+++ b/src/components/Section/Section.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { withRouter } from 'react-router'
-import AuthenticatedView from '../../views/AuthenticatedView'
+import { connect } from 'react-redux'
 import Identification from './Identification'
 import Financial from './Financial'
 import Relationships from './Relationships'
@@ -72,4 +72,4 @@ class Section extends React.Component {
   }
 }
 
-export default withRouter(AuthenticatedView(Section))
+export default withRouter(connect()(Section))

--- a/src/components/Section/SubstanceUse/SubstanceUse.jsx
+++ b/src/components/Section/SubstanceUse/SubstanceUse.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 import { i18n } from '../../../config'
-import AuthenticatedView from '../../../views/AuthenticatedView'
 import { SectionViews, SectionView } from '../SectionView'
 import SectionElement from '../SectionElement'
 import SectionComments from '../SectionComments'
@@ -594,4 +593,4 @@ export class SubstanceUseSections extends React.Component {
   }
 }
 
-export default withRouter(connect(mapStateToProps)(AuthenticatedView(SubstanceUse)))
+export default withRouter(connect(mapStateToProps)(SubstanceUse))


### PR DESCRIPTION
Only needed on the top-level view components, which are the `Form` and `Help`. Also removed some unused `import`s.