### PR TITLE
get rid of a bunch of (unused) scrolling logic

### DIFF
--- a/src/actions/AuthActions.test.js
+++ b/src/actions/AuthActions.test.js
@@ -43,7 +43,7 @@ describe('Auth actions', function () {
     const store = mockStore({ authentication: [] })
     const expectedAction = [
       { type: AuthConstants.LOGOUT },
-      { type: 'PUSH', to: '/login', scrollTo: 'scrollTo' }
+      { type: 'PUSH', to: '/login' }
     ]
     store.dispatch(logout()).then(() => {
       expect(store.getActions()).toEqual(expectedAction)
@@ -101,8 +101,7 @@ describe('Auth actions', function () {
       },
       {
         type: 'PUSH',
-        to: '/loading',
-        scrollTo: 'scrollTo'
+        to: '/loading'
       }
     ]
 

--- a/src/actions/SectionActions.js
+++ b/src/actions/SectionActions.js
@@ -10,12 +10,11 @@ export function updateSection (section, subsection) {
   }
 }
 
-export function handleSectionUpdate (section, subsection, previous = {}, scrollTo = 'scrollTo') {
+export function handleSectionUpdate (section, subsection, previous = {}) {
   return {
     type: SectionConstants.SECTION_UPDATE,
     section: section,
     subsection: subsection,
-    previous: previous,
-    scrollTo: scrollTo
+    previous: previous
   }
 }

--- a/src/middleware/history.js
+++ b/src/middleware/history.js
@@ -26,11 +26,10 @@ export const PUSH_STATE = 'PUSH'
 /**
  * Action requesting a history push state
  */
-export const push = (path, scrollTo = 'scrollTo') => {
+export const push = (path) => {
   return {
     type: PUSH_STATE,
-    to: path,
-    scrollTo: scrollTo
+    to: path
   }
 }
 
@@ -94,7 +93,7 @@ export const sectionMiddleware = store => next => action => {
 // Save the previous section's answers
 export const saveMiddleware = store => next => action => {
   if (action.type === SectionConstants.SECTION_UPDATE || action.type === SectionConstants.SUBSECTION_UPDATE) {
-    window.scroll(0, findPosition(document.getElementById(action.scrollTo || 'scrollTo')))
+    window.scroll(0, findPosition(document.getElementById('scrollTo')))
     unstickAll()
 
     if (action.previous && action.previous.section && action.previous.application) {

--- a/src/middleware/history.test.js
+++ b/src/middleware/history.test.js
@@ -7,7 +7,7 @@ describe('history middleware', function () {
 
   it('should create an action to handle a history push', function () {
     const path = '/'
-    const expectedAction = { type: PUSH_STATE, to: path, scrollTo: 'scrollTo' }
+    const expectedAction = { type: PUSH_STATE, to: path }
     expect(push(path)).toEqual(expectedAction)
   })
 


### PR DESCRIPTION
The page still does the scrolling behavior, but took out the per-action configurability that wasn't actually used anywhere.