### PR TITLE
[WAIT TO MERGE] use React Router instead of push() for navigation

### DIFF
--- a/src/actions/ApplicationActions.js
+++ b/src/actions/ApplicationActions.js
@@ -1,8 +1,7 @@
-import { navigationWalker } from '../config'
+import { env, navigationWalker } from '../config'
 import { api } from '../services'
 import schema, { unschema } from '../schema'
 import validate from '../validators'
-import { push } from '../middleware/history'
 
 export function getApplicationState (done) {
   return function (dispatch, getState) {
@@ -17,7 +16,7 @@ export function getApplicationState (done) {
 
         if (statusData.Locked) {
           locked = true
-          dispatch(push('/locked'))
+          env.History().push('/locked')
         }
       })
       .then(() => {

--- a/src/actions/AuthActions.js
+++ b/src/actions/AuthActions.js
@@ -1,7 +1,6 @@
 import { env } from '../config'
 import { api } from '../services/api'
 import AuthConstants from './AuthConstants'
-import { push } from '../middleware/history'
 
 /**
  * Executes a request to log in the user and then
@@ -18,7 +17,7 @@ export function login (username, password) {
         dispatch(handleLoginSuccess(response.data))
 
         if (!mfa.enabled) {
-          dispatch(push('/loading'))
+          env.History().push('/loading')
         }
       })
       .catch(error => {
@@ -38,7 +37,7 @@ export function logout (error = '') {
     const clear = () => {
       api.setToken('')
       dispatch({ type: AuthConstants.LOGOUT })
-      dispatch(push(`/login${error ? '?error=' : ''}${error || ''}`))
+      env.History().push(`/login${error ? '?error=' : ''}${error || ''}`)
     }
     return api.logout().then(clear).catch(clear)
   }
@@ -49,7 +48,7 @@ export function tokenError () {
     const clear = () => {
       api.setToken('')
       dispatch({ type: AuthConstants.LOGOUT })
-      dispatch(push('/token'))
+      env.History().push('/token')
     }
     return api.logout().then(clear).catch(clear)
   }
@@ -72,7 +71,7 @@ export function twofactor (token) {
       .then(response => {
         api.setToken(response.data)
         dispatch(handleTwoFactorSuccess())
-        dispatch(push('/loading'))
+        env.History().push('/loading')
       })
       .catch(error => {
         api.setToken('')

--- a/src/actions/AuthActions.test.js
+++ b/src/actions/AuthActions.test.js
@@ -42,8 +42,7 @@ describe('Auth actions', function () {
 
     const store = mockStore({ authentication: [] })
     const expectedAction = [
-      { type: AuthConstants.LOGOUT },
-      { type: 'PUSH', to: '/login' }
+      { type: AuthConstants.LOGOUT }
     ]
     store.dispatch(logout()).then(() => {
       expect(store.getActions()).toEqual(expectedAction)
@@ -98,10 +97,6 @@ describe('Auth actions', function () {
     const expectedActions = [
       {
         type: AuthConstants.TWOFACTOR_SUCCESS
-      },
-      {
-        type: 'PUSH',
-        to: '/loading'
       }
     ]
 

--- a/src/components/Section/Foreign/Foreign.jsx
+++ b/src/components/Section/Foreign/Foreign.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { withRouter } from 'react-router'
 import { i18n } from '../../../config'
-import { push } from '../../../middleware/history'
 import { SectionViews, SectionView } from '../SectionView'
 import SectionElement from '../SectionElement'
 import SectionComments from '../SectionComments'
@@ -40,7 +40,7 @@ class Foreign extends SectionElement {
   componentWillReceiveProps (next) {
     // Redirect to direct control
     if (next.subsection === 'activities') {
-      this.props.dispatch(push(`/form/foreign/activities/direct`))
+      this.props.history.push('/form/foreign/activities/direct')
     }
   }
 
@@ -853,4 +853,4 @@ export class ForeignSections extends React.Component {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(Foreign))
+export default withRouter(connect(mapStateToProps)(AuthenticatedView(Foreign)))

--- a/src/components/Section/Foreign/Foreign.test.jsx
+++ b/src/components/Section/Foreign/Foreign.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import MockAdapter from 'axios-mock-adapter'
 import configureMockStore from 'redux-mock-store'
+import { MemoryRouter } from 'react-router'
 import thunk from 'redux-thunk'
 import { Provider } from 'react-redux'
 import Foreign from './Foreign'
@@ -9,12 +9,6 @@ import { mount } from 'enzyme'
 
 const applicationState = {
   Foreign: {}
-}
-
-const applicationState2 = {
-  Foreign: {
-    Passport: {}
-  }
 }
 
 describe('The foreign section', () => {
@@ -26,20 +20,20 @@ describe('The foreign section', () => {
   it('hidden when not authenticated', () => {
     window.token = ''
     const store = mockStore({ authentication: [], application: applicationState })
-    const component = mount(<Provider store={store}><Foreign /></Provider>)
+    const component = mount(<Provider store={store}><MemoryRouter><Foreign /></MemoryRouter></Provider>)
     expect(component.find('div').length).toEqual(0)
     window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {
     const store = mockStore({ authentication: { authenticated: true, twofactor: true, application: applicationState } })
-    const component = mount(<Provider store={store}><Foreign /></Provider>)
+    const component = mount(<Provider store={store}><MemoryRouter><Foreign /></MemoryRouter></Provider>)
     expect(component.find('div').length).toBeGreaterThan(0)
   })
 
   it('can review all subsections', () => {
     const store = mockStore({ authentication: { authenticated: true, twofactor: true } })
-    const component = mount(<Provider store={store}><Foreign subsection="review" /></Provider>)
+    const component = mount(<Provider store={store}><MemoryRouter><Foreign subsection="review" /></MemoryRouter></Provider>)
     expect(component.find('div').length).toBeGreaterThan(0)
   })
 
@@ -125,7 +119,7 @@ describe('The foreign section', () => {
     ]
 
     tests.forEach((test) => {
-      const component = mount(<Provider store={store}><Foreign section="foreign" subsection={test.section} /></Provider>)
+      const component = mount(<Provider store={store}><MemoryRouter><Foreign section="foreign" subsection={test.section} /></MemoryRouter></Provider>)
       test.action(component)
       expect(component.find('div').length).toBeGreaterThan(0)
     })
@@ -158,7 +152,7 @@ describe('The foreign section', () => {
         }
       }
     })
-    const component = mount(<Provider store={store}><Foreign subsection="passport" /></Provider>)
+    const component = mount(<Provider store={store}><MemoryRouter><Foreign subsection="passport" /></MemoryRouter></Provider>)
     expect(component.find(Passport).props().suggestedNames.length).toBe(1)
   })
 })

--- a/src/components/Section/Package/Package.jsx
+++ b/src/components/Section/Package/Package.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { withRouter } from 'react-router'
 import { i18n, navigationWalker } from '../../../config'
 import { hideHippa } from '../../../validators/releases'
 import { SectionViews, SectionView } from '../SectionView'
@@ -10,7 +11,6 @@ import InvalidForm from './InvalidForm'
 import SubmissionStatus from './SubmissionStatus'
 import Print from './Print'
 import Attachments from './Attachments'
-import { push } from '../../../middleware/history'
 import { updateApplication } from '../../../actions/ApplicationActions'
 import axios from 'axios'
 import { api } from '../../../services'
@@ -86,7 +86,7 @@ class Package extends SectionElement {
         // route to `package/errors`. By only pushing the new location we keep
         // the navigation element marking `/review` as active but allow us to
         // display a different internal route.
-        this.props.dispatch(push('/form/package/errors'))
+        this.props.history.push('/form/package/errors')
         return
       }
     }
@@ -273,4 +273,4 @@ Package.defaultProps = {
   store: 'Submission'
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(Package))
+export default withRouter(connect(mapStateToProps)(AuthenticatedView(Package)))

--- a/src/components/Section/Package/Package.test.jsx
+++ b/src/components/Section/Package/Package.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { MemoryRouter } from 'react-router'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import { Provider } from 'react-redux'
@@ -32,7 +33,7 @@ describe('The Package form component', () => {
       authentication: { authenticated: true, twofactor: true },
       application: applicationState
     })
-    const component = mount(<Provider store={store}><Package Application={applicationState} /></Provider>)
+    const component = mount(<Provider store={store}><MemoryRouter><Package Application={applicationState} /></MemoryRouter></Provider>)
     expect(component.find('div').length).toBeGreaterThan(0)
   })
 

--- a/src/components/Section/SectionElement.jsx
+++ b/src/components/Section/SectionElement.jsx
@@ -1,7 +1,5 @@
 import React from 'react'
-import { push } from '../../middleware/history'
 import { updateApplication, reportErrors, save } from '../../actions/ApplicationActions'
-import schema from '../../schema'
 
 export default class SectionElement extends React.Component {
   constructor (props) {

--- a/src/components/Section/SectionView.jsx
+++ b/src/components/Section/SectionView.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { push } from '../../middleware/history'
 import { ErrorList } from '../ErrorList'
 
 export class SectionViews extends React.Component {

--- a/src/components/Section/SubstanceUse/SubstanceUse.jsx
+++ b/src/components/Section/SubstanceUse/SubstanceUse.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { withRouter } from 'react-router'
 import { i18n } from '../../../config'
-import { push } from '../../../middleware/history'
 import AuthenticatedView from '../../../views/AuthenticatedView'
 import { SectionViews, SectionView } from '../SectionView'
 import SectionElement from '../SectionElement'
@@ -40,10 +40,10 @@ class SubstanceUse extends SectionElement {
     // Redirect to first alcohol subsection if root subsection is accessed
     switch (next.subsection) {
     case 'alcohol':
-      this.props.dispatch(push(`/form/substance/alcohol/negative`))
+      this.props.history.push('/form/substance/alcohol/negative')
       break
     case 'drugs':
-      this.props.dispatch(push(`/form/substance/drugs/usage`))
+      this.props.history.push('/form/substance/drugs/usage')
       break
     }
   }
@@ -594,4 +594,4 @@ export class SubstanceUseSections extends React.Component {
   }
 }
 
-export default connect(mapStateToProps)(AuthenticatedView(SubstanceUse))
+export default withRouter(connect(mapStateToProps)(AuthenticatedView(SubstanceUse)))

--- a/src/components/Section/SubstanceUse/SubstanceUse.test.jsx
+++ b/src/components/Section/SubstanceUse/SubstanceUse.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { MemoryRouter } from 'react-router'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import { Provider } from 'react-redux'
@@ -17,21 +18,21 @@ describe('The substance use section', () => {
   it('hidden when not authenticated', () => {
     window.token = ''
     const store = mockStore({ authentication: [], application: applicationState })
-    const component = mount(<Provider store={store}><SubstanceUse /></Provider>)
+    const component = mount(<Provider store={store}><MemoryRouter><SubstanceUse /></MemoryRouter></Provider>)
     expect(component.find('div').length).toEqual(0)
   })
 
   it('visible when authenticated', () => {
     window.token = 'fake-token'
     const store = mockStore({ authentication: { authenticated: true, twofactor: true, application: applicationState } })
-    const component = mount(<Provider store={store}><SubstanceUse /></Provider>)
+    const component = mount(<Provider store={store}><MemoryRouter><SubstanceUse /></MemoryRouter></Provider>)
     expect(component.find('div').length).toBeGreaterThan(0)
   })
 
   it('can review all subsections', () => {
     window.token = 'fake-token'
     const store = mockStore({ authentication: { authenticated: true, twofactor: true } })
-    const component = mount(<Provider store={store}><SubstanceUse subsection="review" /></Provider>)
+    const component = mount(<Provider store={store}><MemoryRouter><SubstanceUse subsection="review" /></MemoryRouter></Provider>)
     expect(component.find('div').length).toBeGreaterThan(0)
   })
 
@@ -51,7 +52,7 @@ describe('The substance use section', () => {
     const store = mockStore({ authentication: { authenticated: true, twofactor: true } })
 
     sections.forEach((section) => {
-      const component = mount(<Provider store={store}><SubstanceUse subsection={section} /></Provider>)
+      const component = mount(<Provider store={store}><MemoryRouter><SubstanceUse subsection={section} /></MemoryRouter></Provider>)
       component.find('.no input').simulate('change')
       expect(component.find('div').length).toBeGreaterThan(0)
     })

--- a/src/config/environment.js
+++ b/src/config/environment.js
@@ -1,4 +1,4 @@
-import { createHashHistory, createBrowserHistory } from 'history'
+import { createHashHistory, createBrowserHistory, createMemoryHistory } from 'history'
 
 const parseBool = (val) => {
   const str = `${val || ''}`
@@ -16,7 +16,13 @@ class Env {
   History () {
     if (!this.history) {
       const useHashRouting = parseBool(process.env.HASH_ROUTING)
-      this.history = useHashRouting ? createHashHistory() : createBrowserHistory()
+      if (useHashRouting) {
+        this.history = createHashHistory()
+      } else if (this.IsTest()) {
+        this.history = createMemoryHistory()
+      } else {
+        this.history = createBrowserHistory()
+      }
     }
     return this.history
   }

--- a/src/middleware/history.js
+++ b/src/middleware/history.js
@@ -1,5 +1,4 @@
 import axios from 'axios'
-import { env } from '../config'
 import { updateApplication } from '../actions/ApplicationActions'
 import { sectionData } from '../components/Section/sectionData'
 import schema from '../schema'
@@ -16,32 +15,6 @@ export const findPosition = (el) => {
   }
 
   return [currentTop]
-}
-
-export const PUSH_STATE = 'PUSH'
-
-/**
- * Action requesting a history push state
- */
-export const push = (path) => {
-  return {
-    type: PUSH_STATE,
-    to: path
-  }
-}
-
-/**
- * historyMiddleware is a custom middleware function for redux that allows history actions to be
- * dispatched in order to change router paths.
- */
-export const historyMiddleware = store => next => action => {
-  // If we get a PUSH_STATE type, modify hisory
-  if (action.type === PUSH_STATE) {
-    env.History().push(action.to)
-  }
-
-  // Allow redux to continue the flow and executing the next middleware
-  next(action)
 }
 
 export const saveSection = (application, section, subsection, dispatch, done) => {

--- a/src/middleware/history.test.js
+++ b/src/middleware/history.test.js
@@ -1,29 +1,6 @@
-import { PUSH_STATE, historyMiddleware, push, findPosition } from './history'
+import { findPosition } from './history'
 
 describe('history middleware', function () {
-  const dispatch = () => {}
-  const getState = () => {}
-  const nextHandler = historyMiddleware({dispatch: dispatch, getState: getState})
-
-  it('should create an action to handle a history push', function () {
-    const path = '/'
-    const expectedAction = { type: PUSH_STATE, to: path }
-    expect(push(path)).toEqual(expectedAction)
-  })
-
-  it('should return a function for next handler', function () {
-    expect(typeof nextHandler).toBe('function')
-  })
-
-  it('should run the action function with dispatch and getState', function () {
-    const actionHandler = nextHandler(dispatch, getState)
-
-    actionHandler((d, s) => {
-      expect(d).toEqual(dispatch)
-      expect(s).toEqual(getState)
-    })
-  })
-
   it('should find the position', function () {
     const el = {
       offsetTop: 10,

--- a/src/services/store.js
+++ b/src/services/store.js
@@ -2,9 +2,8 @@ import thunk from 'redux-thunk'
 import rootReducer from '../reducers'
 import { createStore, applyMiddleware } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
-import { historyMiddleware } from '../middleware/history'
 
-const middleware = [thunk, historyMiddleware]
+const middleware = [thunk]
 
 // Creates a redux store that defines the state tree for the application.
 // See rootReducer for all sub-states.

--- a/src/views/AuthenticatedView.js
+++ b/src/views/AuthenticatedView.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { env } from '../config'
 import { api } from '../services/api'
-import { push } from '../middleware/history'
 
 /**
  * AuthenticatedView is a higher-order component that wraps a component
@@ -25,7 +24,7 @@ const AuthenticatedView = (WrappedComponent) => {
       const token = api.getToken()
       const mfa = this.props.mfa || env.MultipleFactorAuthentication()
       if (!token || !this.props.authenticated || !(mfa.enabled ? this.props.twofactor : true)) {
-        this.props.dispatch(push('/login'))
+        env.History().push('/login')
       }
     }
 

--- a/src/views/Form/Form.jsx
+++ b/src/views/Form/Form.jsx
@@ -43,7 +43,7 @@ class Form extends React.Component {
   defaultRedirect () {
     const params = this.getParams()
     if (!params.section) {
-      this.props.dispatch(push('form/identification/intro'))
+      this.props.history.push('form/identification/intro')
     }
   }
 

--- a/src/views/Loading/Loading.jsx
+++ b/src/views/Loading/Loading.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { withRouter } from 'react-router'
 import { i18n } from '../../config'
-import { push } from '../../middleware/history'
 import { getApplicationState } from '../../actions/ApplicationActions'
 import { Spinner, SpinnerAction } from '../../components/Form'
 import { timeout } from '../../components/Form/Location/Location'
@@ -23,7 +23,7 @@ class Loading extends React.Component {
 
   componentWillMount () {
     if (!this.props.authenticated) {
-      this.props.dispatch(push('/login'))
+      this.props.history.push('/login')
     }
   }
 
@@ -44,7 +44,7 @@ class Loading extends React.Component {
         // Grow the green arrow
         this.setState({spinner: true, spinnerAction: SpinnerAction.Grow}, () => {
           timeout(() => {
-            this.props.dispatch(push('/form/identification/intro'))
+            this.props.history.push('/form/identification/intro')
           }, 1000)
         })
       })
@@ -89,4 +89,4 @@ function mapStateToProps (state) {
 
 // Wraps the the App component with connect() which adds the dispatch()
 // function to the props property for this component
-export default connect(mapStateToProps)(Loading)
+export default withRouter(connect(mapStateToProps)(Loading))

--- a/src/views/Login/Login.jsx
+++ b/src/views/Login/Login.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
+import { withRouter } from 'react-router'
 import { TwoFactor } from '../../components'
 import { connect } from 'react-redux'
 import { i18n, env } from '../../config'
 import { api, getQueryValue, getCookieValue, deleteCookie } from '../../services'
 import { login, handleLoginSuccess } from '../../actions/AuthActions'
-import { push } from '../../middleware/history'
 import { Consent, Show } from '../../components/Form'
 
 export class Login extends React.Component {
@@ -38,7 +38,7 @@ export class Login extends React.Component {
   redirect () {
     // If user is authenticated, redirect to home page
     if (this.props.authenticated && this.props.twofactor) {
-      this.props.dispatch(push('/loading'))
+      this.props.history.push('/loading')
       return
     }
 
@@ -47,7 +47,7 @@ export class Login extends React.Component {
       deleteCookie('token')
       api.setToken(token)
       this.props.dispatch(handleLoginSuccess())
-      this.props.dispatch(push('/loading'))
+      this.props.history.push('/loading')
       return
     }
 
@@ -55,10 +55,10 @@ export class Login extends React.Component {
     if (err) {
       switch (err) {
       case 'token':
-        this.props.dispatch(push('/token'))
+        this.props.history.push('/token')
         return
       case 'access_denied':
-        this.props.dispatch(push('/accessdenied'))
+        this.props.history.push('/accessdenied')
         return
       }
     }
@@ -286,4 +286,4 @@ function mapStateToProps (state) {
 
 // Wraps the the App component with connect() which adds the dispatch()
 // function to the props property for this component
-export default connect(mapStateToProps)(Login)
+export default withRouter(connect(mapStateToProps)(Login))


### PR DESCRIPTION
Part of #475. Builds on #476.

**Plain-ish language version:** Use React Router as the source of truth for navigation state.

**Nitty gritty:** The `dispatch(push())` calls are using Redux actions to trigger [`history`](https://reacttraining.com/react-router/web/api/history) changes, meaning that Redux is the source of truth for navigation. This is contrary to how React Router is meant to be used. Now, navigation is triggered in these cases by updating the `history` directly.