### PR TITLE
clear state on logout

### DIFF
--- a/src/reducers/authentication.js
+++ b/src/reducers/authentication.js
@@ -49,15 +49,6 @@ const authentication = function (state = defaultState, action) {
       error: action.error
     }
 
-  case AuthConstants.LOGOUT:
-    return {
-      ...state,
-      authenticated: false,
-      twofactor: false,
-      token: null,
-      qrcode: null
-    }
-
   default:
     return state
   }

--- a/src/reducers/authentication.test.js
+++ b/src/reducers/authentication.test.js
@@ -26,21 +26,6 @@ describe('Authentication Reducer', function () {
     expect(authentication(defaultState, action)).toEqual(expectedState)
   })
 
-  it('should handle logout', function () {
-    const expectedState = {
-      authenticated: false,
-      token: null,
-      twofactor: false,
-      qrcode: null
-    }
-
-    const action = {
-      type: AuthConstants.LOGOUT
-    }
-
-    expect(authentication(defaultState, action)).toEqual(expectedState)
-  })
-
   it('should handle login error', function () {
     const expectedState = {
       authenticated: false,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,11 +2,22 @@ import { combineReducers } from 'redux'
 import authentication from './authentication'
 import section from './section'
 import application from './application'
+import AuthConstants from '../actions/AuthConstants'
 
-const rootReducer = combineReducers({
+const appReducer = combineReducers({
   authentication: authentication,
   section: section,
   application: application
 })
+
+const rootReducer = (state, action) => {
+  // clear data on logout
+  // https://netbasal.com/how-to-secure-your-users-data-after-logout-in-redux-30468c6848e8
+  if (action.type === AuthConstants.LOGOUT) {
+    state = undefined;
+  }
+
+  return appReducer(state, action)
+}
 
 export default rootReducer

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -36,4 +36,23 @@ describe('Root Reducer', function () {
     const action = { type: 'unknown' }
     expect(rootReducer(startState, action)).toEqual(defaultState)
   })
+
+  it('should handle logout', function () {
+    const startState = {
+      application: {
+        AddressBooks: { foo: 'bar' }
+      },
+      authentication: {
+        authenticated: true,
+        token: 'dummytoken'
+      },
+      section: {
+        section: "identification",
+        subsection: ""
+      }
+    }
+
+    const action = { type: AuthConstants.LOGOUT }
+    expect(rootReducer(startState, action)).toEqual(defaultState)
+  })
 })

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -1,0 +1,39 @@
+import rootReducer from './index'
+import AuthConstants from '../actions/AuthConstants'
+
+describe('Root Reducer', function () {
+  const defaultState = {
+    application: {
+      AddressBooks: { },
+      Citizenship: { },
+      Completed: { },
+      Errors: { },
+      Financial: { },
+      Foreign: { },
+      History: { },
+      Identification: { },
+      Legal: { },
+      Military: { },
+      Psychological: { },
+      Relationships: { },
+      Settings: { },
+      Submission: { },
+      Substance: { },
+      TBD: { }
+    },
+    authentication: {
+      authenticated: false,
+      token: null
+    },
+    section: {
+      section: "identification",
+      subsection: ""
+    }
+  }
+
+  it('should populate the state', function () {
+    const startState = {}
+    const action = { type: 'unknown' }
+    expect(rootReducer(startState, action)).toEqual(defaultState)
+  })
+})


### PR DESCRIPTION
Previously, only the `authentication` section of the state (in memory) was being cleared when the user logs out, but none of the rest of the keys. Now, a logout causes the entire state to be reset.

Before:

![screen shot 2018-06-27 at 2 36 12 pm](https://user-images.githubusercontent.com/86842/41992822-80530f74-7a17-11e8-84df-2a89c8d1f2c1.png)

After:

![screen shot 2018-06-27 at 2 22 22 pm](https://user-images.githubusercontent.com/86842/41992558-cf75f9f0-7a16-11e8-8f2f-5844606993b3.png)

_Screenshots of the logout action and resulting state change in [Redux DevTools](http://extension.remotedev.io/)._