### PR TITLE
fix logging out

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -29,7 +29,9 @@ const getSplitValue = (key, raw, delim1, delim2) => {
 }
 
 export const deleteCookie = (name) => {
-  document.cookie = `${name}=; domain=${window.location.hostname}; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;`
+  const domain = process.env.COOKIE_DOMAIN || window.location.hostname
+  // TODO complain if cookie not present
+  document.cookie = `${name}=; domain=${domain}; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;`
 }
 
 class Api {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = {
   devtool: debug ? 'cheap-module-source-map' : false,
   plugins: [
     new webpack.EnvironmentPlugin([
-      'API_BASE_URL', 'ALLOW_2FA_RESET', 'HASH_ROUTING', 'DISABLE_2FA',
+      'API_BASE_URL', 'ALLOW_2FA_RESET', 'COOKIE_DOMAIN', 'HASH_ROUTING', 'DISABLE_2FA',
       'BASIC_ENABLED', 'SAML_ENABLED', 'SESSION_TIMEOUT',
       'ATTACHMENTS_ENABLED', 'FILE_MAXIMUM_SIZE', 'FILE_TYPES'
     ])


### PR DESCRIPTION
...when `COOKIE_DOMAIN` is set to something other than the hostname of the frontend. This means `COOKIE_DOMAIN` and `window.location.hostname` don't match, so the cookie would fail to be deleted. Going back to the login page would see that cookie, and you'd be immediately logged in again.

Fixes #275.