### PR TITLE
remove Docker Compose config incompatible with v2

### DIFF
--- a/docker-compose.identity.yml
+++ b/docker-compose.identity.yml
@@ -11,10 +11,6 @@ services:
     ports:
       - 9763:9763
       - 9443:9443
-    healthcheck:
-      test: ["CMD", "curl", "-k", "-f", "https://localhost:9443/carbon/admin/login.jsp"]
-      interval: 5s
-      timeout: 240s
     volumes:
       # persist the embedded databases
       # https://docs.wso2.com/display/ADMIN44x/Working+with+Databases


### PR DESCRIPTION
Follow-up to 7eee4b682e444d5acd3635ffeaa9ba94bcb9b740.