### PR TITLE
Unset FLUSH_ENABLED

### DIFF
--- a/conf/manifests/api-dev.yml
+++ b/conf/manifests/api-dev.yml
@@ -21,4 +21,3 @@ applications:
     ALLOW_2FA_RESET: 1
     DISABLE_2FA: 1
     BASIC_ENABLED: 1
-    FLUSH_STORAGE: 1


### PR DESCRIPTION
Do not want the dev instance on cloud.gov to flush previously saved data on sign-in any longer.