### PR TITLE
DRY the colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "redux-mock-store": "^1.3.0",
     "redux-thunk": "^2.1.0",
     "smoothscroll-polyfill": "^0.3.6",
-    "uswds": "^1.4.0",
+    "uswds": "^1.6.6",
     "webpack": "^4.12.0",
     "webpack-cli": "^3.0.4"
   },

--- a/src/components/Form/Accordion/Accordion.scss
+++ b/src/components/Form/Accordion/Accordion.scss
@@ -64,7 +64,7 @@ $breakpoints: (
     background-color: #fff;
     border-bottom: solid 1px #e5e5e5;
     font-weight: 600;
-    color: #5b606b;
+    color: $eapp-grey-darker;
 
     .svg {
       height: 2.5rem !important;
@@ -406,7 +406,7 @@ button.usa-button-outline {
 
             span.toggle {
               width: 4rem;
-              border-bottom: 1px dashed #0071bc;
+              border-bottom: 1px dashed $eapp-blue;
             }
           }
 

--- a/src/components/Form/Dropdown/Dropdown.scss
+++ b/src/components/Form/Dropdown/Dropdown.scss
@@ -14,9 +14,9 @@
     }
 
     input.usa-input-success {
-      border-top: 1px solid #5b616b;
-      border-left: 1px solid #5b616b;
-      border-right: 1px solid #5b616b;
+      border-top: 1px solid $color-gray;
+      border-left: 1px solid $color-gray;
+      border-right: 1px solid $color-gray;
       background: none;
     }
 

--- a/src/components/Form/EyeColor/EyeColor.scss
+++ b/src/components/Form/EyeColor/EyeColor.scss
@@ -37,7 +37,7 @@
     }
 
     .eye-icon.unknown svg path {
-      fill: #5b606b;
+      fill: $eapp-grey-darker;
     }
   }
 }

--- a/src/components/Form/HairColor/HairColor.scss
+++ b/src/components/Form/HairColor/HairColor.scss
@@ -5,7 +5,7 @@
     }
 
     .hair-icon.bald svg path {
-      fill: #5b606b;
+      fill: $eapp-grey-darker;
     }
 
     .hair-icon.black svg path {
@@ -61,7 +61,7 @@
     }
 
     .hair-icon.unknown svg path {
-      fill: #5b606b;
+      fill: $eapp-grey-darker;
     }
   }
 }

--- a/src/components/Form/MultipleDropdown/MultipleDropdown.scss
+++ b/src/components/Form/MultipleDropdown/MultipleDropdown.scss
@@ -2,7 +2,7 @@
   &.has-tokens {
     input {
       background: none !important;
-      border: 1px solid #5b616b !important;
+      border: 1px solid $color-gray !important;
     }
   }
 
@@ -15,7 +15,7 @@
     .token {
       display: inline-block;
       width: initial;
-      border: 3px solid #4aa564;
+      border: 3px solid $color-green-light;
       border-radius: 3px;
       margin-top: 1rem;
       margin-bottom: 0.1rem;
@@ -29,7 +29,7 @@
         &:focus,
         &:hover {
           outline: none;
-          color: #cd2026;
+          color: $color-red-dark;
         }
       }
 

--- a/src/components/Form/Radio/Radio.scss
+++ b/src/components/Form/Radio/Radio.scss
@@ -2,7 +2,7 @@
 // more like checkboxes as per the design. These styles were taken
 // from the USWDS source.
 [type='radio'] + label::before {
-  box-shadow: 0 0 0 2px #fff, 0 0 0 3px #757575;
+  box-shadow: 0 0 0 2px #fff, 0 0 0 3px $color-gray-medium;
   height: 1.6rem;
   line-height: 1.6rem;
   width: 1.6rem;
@@ -17,9 +17,9 @@
 }
 
 [type='radio']:focus + label::before {
-  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #0071bc;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px $eapp-blue;
 }
 
 [type='radio']:disabled + label {
-  color: #5b616b;
+  color: $color-gray;
 }

--- a/src/components/Form/Spinner/Spinner.scss
+++ b/src/components/Form/Spinner/Spinner.scss
@@ -23,7 +23,7 @@ $border-size: 0.75rem;
     border-top: $border-size solid rgba(71, 163, 98, 0.2);
     border-right: $border-size solid rgba(71, 163, 98, 0.2);
     border-bottom: $border-size solid rgba(71, 163, 98, 0.2);
-    border-left: $border-size solid #47a362;
+    border-left: $border-size solid $eapp-green;
   }
 
   .spin {
@@ -54,7 +54,7 @@ $border-size: 0.75rem;
     display: block;
     width: 100%;
     text-align: center;
-    color: #47a362;
+    color: $eapp-green;
     font-size: 11rem;
   }
 

--- a/src/components/Form/Telephone/Telephone.scss
+++ b/src/components/Form/Telephone/Telephone.scss
@@ -59,7 +59,7 @@
 
     a {
       font-weight: 600;
-      border-bottom: 1px #0071bc dashed;
+      border-bottom: 1px $eapp-blue dashed;
       text-decoration: none;
     }
   }

--- a/src/components/Navigation/NavigationToggle.scss
+++ b/src/components/Navigation/NavigationToggle.scss
@@ -26,7 +26,7 @@
   left: 0;
   right: 0;
   height: 5.5rem;
-  background-color: #194b88;
+  background-color: $eapp-blue-darkest;
 
   .logout {
     position: absolute;

--- a/src/components/Section/History/History.scss
+++ b/src/components/Section/History/History.scss
@@ -4,7 +4,7 @@
   .view-review {
     .section-heading {
       font-weight: 600;
-      color: #5b606b;
+      color: $eapp-grey-darker;
       padding: 1rem 0;
       margin-bottom: 1rem;
       display: block;

--- a/src/components/Section/Package/Print.scss
+++ b/src/components/Section/Package/Print.scss
@@ -30,7 +30,7 @@
     vertical-align: top;
 
     svg {
-      fill: #47a362;
+      fill: $eapp-green;
     }
   }
 

--- a/src/components/Section/Package/SubmissionStatus.scss
+++ b/src/components/Section/Package/SubmissionStatus.scss
@@ -55,7 +55,7 @@
       .progress {
         height: 2rem;
         width: 0;
-        background-color: #5b606b;
+        background-color: $eapp-grey-darker;
         border-radius: 4px;
       }
 
@@ -93,7 +93,7 @@
       }
 
       .icon svg {
-        fill: #5b606b;
+        fill: $eapp-grey-darker;
         position: absolute;
       }
     }
@@ -103,11 +103,11 @@
 .submission-status.valid {
   .progress-container {
     .progress-outline .progress-default .progress {
-      background-color: #47a362;
+      background-color: $eapp-green;
     }
 
     .icon-container .icon svg {
-      fill: #47a362;
+      fill: $eapp-green;
     }
   }
 }
@@ -115,11 +115,11 @@
 .submission-status.invalid {
   .progress-container {
     .progress-outline .progress-default .progress {
-      background-color: #e21c3c;
+      background-color: $eapp-red;
     }
 
     .icon-container .icon svg {
-      fill: #e21c3c;
+      fill: $eapp-red;
     }
   }
 }

--- a/src/components/Section/Package/ValidForm.scss
+++ b/src/components/Section/Package/ValidForm.scss
@@ -10,7 +10,7 @@
   }
 
   .submit.usa-button:disabled {
-    background-color: #0071bc;
+    background-color: $eapp-blue;
   }
 
   .next-release {

--- a/src/sass/_eqip-colors.scss
+++ b/src/sass/_eqip-colors.scss
@@ -3,8 +3,8 @@
 /* blues */
 $eapp-blue-darkest: #194b88;
 $eapp-blue-dark: #205493;
-$eapp-blue: #0071bc;
-$eapp-blue-light: #00a6d2;
+$eapp-blue: $color-blue;
+$eapp-blue-light: $color-aqua-dark;
 $eapp-blue-lighter: #9bdaf0;
 $eapp-blue-lightest: #e0f3f8;
 
@@ -14,7 +14,7 @@ $eapp-green: #47a362;
 $eapp-selected: #2b8746;
 
 /* reds */
-$eapp-red-lightest: #f9dede;
+$eapp-red-lightest: $color-red-lightest;
 $eapp-red-light: #e3b3b3;
 $eapp-red: #e21c3c;
 
@@ -22,7 +22,7 @@ $eapp-red: #e21c3c;
 $eapp-grey-placeholder: #5c5c5c;
 $eapp-grey-lightest: #dce3ee;
 $eapp-grey-light: #f7f7f7;
-$eapp-grey: #d6d7d9;
-$eapp-grey-dark: #212121;
+$eapp-grey: $color-gray-lighter;
+$eapp-grey-dark: $color-black-light;
 $eapp-grey-darker: #5b606b;
-$eapp-grey-disabled: #757575;
+$eapp-grey-disabled: $color-gray-medium;

--- a/src/sass/eqip.scss
+++ b/src/sass/eqip.scss
@@ -124,7 +124,7 @@ a:focus {
     .eapp-logo {
       height: 14.5rem;
       background: $eapp-blue-darkest;
-      color: #9bdaf0;
+      color: $eapp-blue-lighter;
 
       .eapp-logo-icon {
         display: inline-block;

--- a/src/sass/phone.scss
+++ b/src/sass/phone.scss
@@ -269,8 +269,8 @@
         font-size: 1.6rem;
 
         > span {
-          color: #0071bc;
-          border-bottom: 1px dashed #0071bc;
+          color: $eapp-blue;
+          border-bottom: 1px dashed $eapp-blue;
         }
       }
     }

--- a/src/views/Form/Form.scss
+++ b/src/views/Form/Form.scss
@@ -122,7 +122,7 @@ input[type='checkbox'], input[type='radio'] {
   }
 
   .block > label {
-    border: 2px solid #cd2026;
+    border: 2px solid $color-red-dark;
   }
 }
 
@@ -210,7 +210,7 @@ select {
     }
 
     &.usa-input-focus {
-      outline: 2px dotted #aeb0b5;
+      outline: 2px dotted $color-gray-light;
       outline-offset: 3px;
     }
 
@@ -228,7 +228,7 @@ select {
     &.checked:focus,
     input [type='checkbox'].usa-input-focus,
     input [type='checkbox']:focus {
-      outline: 2px dotted #aeb0b5;
+      outline: 2px dotted $color-gray-light;
       outline-offset: 3px;
     }
 
@@ -411,7 +411,7 @@ select {
     font-weight: normal;
     vertical-align: text-top;
     margin-left: 0.4rem;
-    color: #981b1e;
+    color: $color-red-darkest;
     content: '*';
   }
 
@@ -425,7 +425,7 @@ select {
         font-weight: normal;
         vertical-align: text-top;
         margin-left: 0.4rem;
-        color: #981b1e;
+        color: $color-red-darkest;
         content: '*';
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,9 +26,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@types/node@^8.0.14":
-  version "8.0.51"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.51.tgz#b31d716fb8d58eeb95c068a039b9b6292817d5fb"
+"@types/node@^8.5.5":
+  version "8.10.20"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.20.tgz#fe674ea52e13950ab10954433a7824438aabbcac"
 
 "@webassemblyjs/ast@1.5.12":
   version "1.5.12"
@@ -8165,11 +8165,11 @@ user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
 
-uswds@^1.4.0:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/uswds/-/uswds-1.4.2.tgz#a64617a83d79deff20503cc5b879072e547a3c29"
+uswds@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/uswds/-/uswds-1.6.6.tgz#f8b64b4fe3541eaf4dd6d8eb2422e815a1645633"
   dependencies:
-    "@types/node" "^8.0.14"
+    "@types/node" "^8.5.5"
     array-filter "^1.0.0"
     array-foreach "^1.0.2"
     browserify "^13.0.0"


### PR DESCRIPTION
Partially extracted from #482.

Leverages [Sass variables](https://sass-lang.com/guide#topic-2) `@import`ed from USWDS to reduce the number of hard-coded color values in the stylesheets. This should make it a bit easier to understand the relationships of the colors throughout the app. Also upgrades USWDS.

Confirmed that the output stylesheets are the same:

```shell
git checkout 2efbe263a
node-sass-chokidar --include-path src/sass src/eqip.scss dist/css/eqip.css.old
git checkout 2611e9195
node-sass-chokidar --include-path src/sass src/eqip.scss dist/css/eqip.css
diff dist/css/eqip.css.old dist/css/eqip.css
```

There was no `diff`.