### PR TITLE
Updating intro modal for small screens

### DIFF
--- a/src/components/Form/Introduction/Introduction.scss
+++ b/src/components/Form/Introduction/Introduction.scss
@@ -29,8 +29,7 @@
 
   .modal {
     .introduction-content {
-      width: 50%;
-      min-width: 100rem;
+      max-width: 100rem;
       padding: 1rem;
       border: none;
       box-shadow: none;

--- a/src/sass/phone.scss
+++ b/src/sass/phone.scss
@@ -38,7 +38,6 @@
         margin-bottom: 0 !important;
 
         .consent-legal {
-          padding: 0;
           height: 70vh;
         }
 
@@ -50,11 +49,6 @@
   }
 
   // Form introduction
-  .introduction-modal {
-    display: none;
-    z-index: -1;
-  }
-
   .modal-open .introduction-modal {
     display: block;
     position: unset;
@@ -121,7 +115,6 @@
 
       .auth {
         display: block !important;
-        min-width: 45rem;
         height: auto;
         margin-left: auto;
         margin-right: auto;

--- a/src/views/Login/Login.scss
+++ b/src/views/Login/Login.scss
@@ -53,7 +53,7 @@
 
       .auth {
         display: block;
-        max-width: 64rem;
+        max-width: 43rem;
         margin-right: auto;
         margin-left: auto;
       }
@@ -79,7 +79,7 @@
   .auth {
     display: inline-block;
     vertical-align: top;
-    width: 48%;
+    max-width: 43rem;
     height: 50vh;
     padding-left: 1rem;
     padding-right: 1rem;


### PR DESCRIPTION
Fixes #456 

The intro modal now shows for all screen sizes. 👍 

<img width="445" alt="screen shot 2018-07-09 at 4 58 30 pm" src="https://user-images.githubusercontent.com/1449852/42475694-65225210-8399-11e8-8196-ef99628fc23e.png">



<img width="479" alt="screen shot 2018-07-09 at 4 58 02 pm" src="https://user-images.githubusercontent.com/1449852/42475693-6512e55a-8399-11e8-9934-2d7105fbb997.png">