### PR TITLE
unignore the bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,6 @@ __snapshots__/
 .gitmessage
 .projectile
 /.cache-loader/
-/bin
-/api/bin
 /api/dist
 /api/checksum
 /api/api
@@ -84,6 +82,7 @@ TAGS
 *.cer
 *.crt
 *.key
+xmlsec1
 
 # Test artifacts
 /jest*


### PR DESCRIPTION
Makes it show up in searches in editors, etc. `xmlsec1` seems to be the only file in that directory that's not checked in.