### PR TITLE
Fixes go buildpack error on cloud.gov deploy

### DIFF
--- a/conf/manifests/api-dev.yml
+++ b/conf/manifests/api-dev.yml
@@ -14,6 +14,7 @@ applications:
   env:
     PATH: /bin:/usr/bin:$HOME/bin
     GOVERSION: go1.10
+    GOPACKAGENAME: github.com/18F/e-QIP-prototype
     GOLANG_ENV: development
     CORS_ALLOWED: https://eqip-prototype-dev.fr.cloud.gov
     API_REDIRECT: https://eqip-prototype-dev.fr.cloud.gov

--- a/conf/manifests/api-staging.yml
+++ b/conf/manifests/api-staging.yml
@@ -14,6 +14,7 @@ applications:
   env:
     PATH: /bin:/usr/bin:$HOME/bin
     GOVERSION: go1.10
+    GOPACKAGENAME: github.com/18F/e-QIP-prototype
     GOLANG_ENV: development
     LOG_LEVEL: debug
     CORS_ALLOWED: https://eqip-prototype-staging.fr.cloud.gov

--- a/conf/manifests/api.yml
+++ b/conf/manifests/api.yml
@@ -14,6 +14,7 @@ applications:
   env:
     PATH: /bin:/usr/bin:$HOME/bin
     GOVERSION: go1.10
+    GOPACKAGENAME: github.com/18F/e-QIP-prototype
     GOLANG_ENV: production
     CORS_ALLOWED: https://eqip-prototype.fr.cloud.gov
     API_REDIRECT: https://eqip-prototype.fr.cloud.gov


### PR DESCRIPTION
Fixes `To use go native vendoring set the $GOPACKAGENAME` error and
`Unable to determine import path: GOPACKAGENAME unset`.