### PR TITLE
use action functions to construct actions in tests

### DIFF
--- a/src/actions/ApplicationActions.js
+++ b/src/actions/ApplicationActions.js
@@ -87,7 +87,7 @@ export function validateApplication (dispatch, application = {}) {
   })
 }
 
-// Special action which should only be called from the clearErrorsMiddleware. It provides a way to flush all errors for a section+subsection upon entry so it may be stored with the re-validated data.
+// Special action that provides a way to flush all errors for a section+subsection upon entry so it may be stored with the re-validated data.
 export function clearErrors (property, subsection) {
   const section = 'Errors'
   return {

--- a/src/actions/ApplicationActions.js
+++ b/src/actions/ApplicationActions.js
@@ -92,9 +92,9 @@ export function clearErrors (property, subsection) {
   const section = 'Errors'
   return {
     type: `${section}.${property}`,
-    section: section,
-    property: property,
-    subsection: subsection,
+    section,
+    property,
+    subsection,
     clear: true
   }
 }

--- a/src/reducers/application.test.js
+++ b/src/reducers/application.test.js
@@ -1,4 +1,5 @@
 import { reducer } from './application'
+import { updateApplication } from '../actions/ApplicationActions'
 
 describe('Application reducers', () => {
   it('reducer should return default state', () => {
@@ -8,11 +9,7 @@ describe('Application reducers', () => {
   it('can update new property', () => {
     const sectionName = 'test'
     const defaultState = {}
-    const action = {
-      section: sectionName,
-      property: 'value',
-      values: 42
-    }
+    const action = updateApplication(sectionName, 'value', 42)
     expect(reducer(sectionName)(defaultState, action)[action.property]).toEqual(action.values)
   })
 
@@ -21,11 +18,7 @@ describe('Application reducers', () => {
     const defaultState = {
       value: 42
     }
-    const action = {
-      section: sectionName,
-      property: 'value',
-      values: 3.14159
-    }
+    const action = updateApplication(sectionName, 'value', 3.14159)
     expect(reducer(sectionName)(defaultState, action)[action.property]).toEqual(action.values)
   })
 })

--- a/src/reducers/authentication.test.js
+++ b/src/reducers/authentication.test.js
@@ -1,5 +1,5 @@
 import authentication from './authentication'
-import AuthConstants from '../actions/AuthConstants'
+import { handleLoginError, handleLoginSuccess } from '../actions/AuthActions'
 
 describe('Authentication Reducer', function () {
   const defaultState = {
@@ -18,10 +18,7 @@ describe('Authentication Reducer', function () {
       error: ''
     }
 
-    const action = {
-      type: AuthConstants.LOGIN_SUCCESS,
-      token: 'faketoken'
-    }
+    const action = handleLoginSuccess('faketoken')
     expect(authentication(defaultState, action)).toEqual(expectedState)
   })
 
@@ -32,9 +29,7 @@ describe('Authentication Reducer', function () {
       error: undefined
     }
 
-    const action = {
-      type: AuthConstants.LOGIN_ERROR
-    }
+    const action = handleLoginError()
     expect(authentication(defaultState, action)).toEqual(expectedState)
   })
 })

--- a/src/reducers/error.test.js
+++ b/src/reducers/error.test.js
@@ -1,4 +1,5 @@
 import errorReducer from './error'
+import { clearErrors, updateApplication } from '../actions/ApplicationActions'
 
 describe('Error reducer', () => {
   it('should return default state', () => {
@@ -8,27 +9,22 @@ describe('Error reducer', () => {
   it('can add new error', () => {
     const sectionName = 'errorTest'
     const defaultState = {}
-    const action = {
-      section: sectionName,
-      property: 'identification',
-      subsection: 'othernames',
-      values: [
-        {
-          section: 'identification',
-          subsection: 'othernames',
-          uid: '1',
-          code: 'something.looks.off',
-          valid: false
-        },
-        {
-          section: 'identification',
-          subsection: 'othernames',
-          uid: '2',
-          code: 'something.smells',
-          valid: false
-        }
-      ]
-    }
+    const action = updateApplication(sectionName, 'identification', [
+      {
+        section: 'identification',
+        subsection: 'othernames',
+        uid: '1',
+        code: 'something.looks.off',
+        valid: false
+      },
+      {
+        section: 'identification',
+        subsection: 'othernames',
+        uid: '2',
+        code: 'something.smells',
+        valid: false
+      }
+    ])
     expect(errorReducer(sectionName)(defaultState, action)[action.property].length).toBe(2)
   })
 
@@ -45,26 +41,20 @@ describe('Error reducer', () => {
         }
       ]
     }
-    const action = {
-      section: sectionName,
-      property: 'identification',
-      subsection: 'othernames',
-      values: [
-        {
-          section: 'identification',
-          subsection: 'othernames',
-          uid: '1',
-          code: 'something.looks.off',
-          valid: true
-        }
-      ]
-    }
+    const action = updateApplication(sectionName, 'identification', [
+      {
+        section: 'identification',
+        subsection: 'othernames',
+        uid: '1',
+        code: 'something.looks.off',
+        valid: true
+      }
+    ])
     expect(errorReducer(sectionName)(defaultState, action)[action.property].length).toBe(1)
     expect(errorReducer(sectionName)(defaultState, action)[action.property][0].valid).toBe(true)
   })
 
   it('can clear errors for a section', () => {
-    const sectionName = 'errorTest'
     const defaultState = {
       identification: [
         {
@@ -85,13 +75,8 @@ describe('Error reducer', () => {
         }
       ]
     }
-    const action = {
-      section: sectionName,
-      property: 'identification',
-      subsection: 'othernames',
-      clear: true
-    }
-    expect(errorReducer(sectionName)(defaultState, action)[action.property].length).toBe(0)
-    expect(errorReducer(sectionName)(defaultState, action)['foreign'].length).toBe(1)
+    const action = clearErrors('identification', 'othernames')
+    expect(errorReducer('Errors')(defaultState, action)[action.property].length).toBe(0)
+    expect(errorReducer('Errors')(defaultState, action)['foreign'].length).toBe(1)
   })
 })

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -4,11 +4,7 @@ import section from './section'
 import application from './application'
 import AuthConstants from '../actions/AuthConstants'
 
-const appReducer = combineReducers({
-  authentication: authentication,
-  section: section,
-  application: application
-})
+const appReducer = combineReducers({ application, authentication, section })
 
 const rootReducer = (state, action) => {
   // clear data on logout


### PR DESCRIPTION
In support of #179.

Rather than constructing the [actions](https://redux.js.org/basics/actions) from scratch in the tests, use the action functions to do it for us. This makes it easier to modify the structure of the actions in one place.

I recommend ignoring whitespace changes when reviewing the diff.