### PR TITLE
make route change detection less aggressive

### DIFF
--- a/src/components/Navigation/navigation-helpers.js
+++ b/src/components/Navigation/navigation-helpers.js
@@ -151,3 +151,9 @@ export const findPosition = (el) => {
 
   return [currentTop]
 }
+
+// Compares location objects from React Router
+export const didRouteChange = (loc, prevLoc) => {
+  // https://stackoverflow.com/questions/41911309/how-to-listen-to-route-changes-in-react-router-v4/44410281#comment80823795_44410281
+  return loc.pathname !== prevLoc.pathname
+}

--- a/src/components/Navigation/navigation-helpers.test.js
+++ b/src/components/Navigation/navigation-helpers.test.js
@@ -1,4 +1,4 @@
-import { validations, isActive, hasErrors, isValid, sectionsTotal, sectionsCompleted, findPosition } from './navigation-helpers'
+import { validations, isActive, hasErrors, isValid, sectionsTotal, sectionsCompleted, findPosition, didRouteChange } from './navigation-helpers'
 
 describe('Navigation component validation', function () {
   it('can count number of validations', () => {
@@ -108,5 +108,31 @@ describe('UI helpers', () => {
     }
     const top = findPosition(el)
     expect(top).toEqual([12])
+  })
+})
+
+describe("didRouteChange()", () => {
+  it("considers locations with the same pathname the same", function () {
+    const loc = {
+      pathname: '/foo',
+      otherprop: 'bar'
+    }
+    const prevLoc = {
+      pathname: '/foo',
+      otherprop: 'baz'
+    }
+    expect(didRouteChange(loc, prevLoc)).toEqual(false)
+  })
+
+  it("considers locations with different pathnames to be different", function () {
+    const loc = {
+      pathname: '/foo',
+      otherprop: 'bar'
+    }
+    const prevLoc = {
+      pathname: '/baz',
+      otherprop: 'bar'
+    }
+    expect(didRouteChange(loc, prevLoc)).toEqual(true)
   })
 })

--- a/src/views/Form/Form.jsx
+++ b/src/views/Form/Form.jsx
@@ -30,7 +30,7 @@ class Form extends React.Component {
     this.defaultRedirect()
 
     // https://stackoverflow.com/a/44410281/358804
-    if (this.props.location !== prevProps.location) {
+    if (this.props.location.pathname !== prevProps.location.pathname) {
       this.onRouteChanged(prevProps.location);
     }
   }

--- a/src/views/Form/Form.jsx
+++ b/src/views/Form/Form.jsx
@@ -6,7 +6,7 @@ import { clearErrors, updateApplication } from '../../actions/ApplicationActions
 import AuthenticatedView from '../AuthenticatedView'
 import { Section, SavedIndicator, TimeoutWarning } from '../../components'
 import { env } from '../../config'
-import { findPosition, parseFormUrl } from '../../components/Navigation/navigation-helpers'
+import { didRouteChange, findPosition, parseFormUrl } from '../../components/Navigation/navigation-helpers'
 import { tokenError } from '../../actions/AuthActions'
 import { updateSection } from '../../actions/SectionActions'
 
@@ -29,8 +29,7 @@ class Form extends React.Component {
   componentDidUpdate(prevProps) {
     this.defaultRedirect()
 
-    // https://stackoverflow.com/a/44410281/358804
-    if (this.props.location.pathname !== prevProps.location.pathname) {
+    if (didRouteChange(this.props.location, prevProps.location)) {
       this.onRouteChanged(prevProps.location);
     }
   }


### PR DESCRIPTION
Fixes #585.

The component was previously detecting changes to all `location` object changes, which would trigger more often than route changes. Specifically, this change will stop the token from being refreshed when logging out. It should also have a side benefit of reducing the number of re-renders.

Paired with @ryanhofdotgov.