### PR TITLE
clear containers that may have dependency changes on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ start:
 stop:
 	docker-compose stop
 run:
+	docker-compose rm -f api css js
 	$(info Running local development server)
 	docker-compose up --abort-on-container-exit --build
 identity:


### PR DESCRIPTION
This should solve (🤞) the issue of starting of and finding out that the containers haven't been rebuilt.