### PR TITLE
create subsections dynamically

### DIFF
--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -52,25 +52,26 @@ class Identification extends SectionElement {
 
   // Returns an array of SectionViews with their corresponding child component, based on the navigation
   createSectionViews () {
-    const sectionNav = navigation.find(n => n.url === 'identification')
+    const section = 'identification'
+    const sectionNav = navigation.find(n => n.url === section)
     const subsections = sectionNav.subsections
 
-    const views = subsections.map((ss, i) => {
-      if (ss.exclude) {
+    const views = subsections.map((subsection, i) => {
+      if (subsection.exclude) {
         return null
       }
 
       const prev = subsections[i-1]
       const next = subsections[i+1]
-      const ssComponent = this.createSubsection(ss)
+      const ssComponent = this.createSubsection(subsection)
 
       return (
-        <SectionView key={`identification/${ss.url}`}
-          name={ss.url}
-          back={`identification/${prev.url}`}
-          backLabel={i18n.t(`identification.destination.${prev.url}`)}
-          next={`identification/${next.url}`}
-          nextLabel={i18n.t(`identification.destination.${next.url}`)}>
+        <SectionView key={`${section}/${subsection.url}`}
+          name={subsection.url}
+          back={`${section}/${prev.url}`}
+          backLabel={i18n.t(`${section}.destination.${prev.url}`)}
+          next={`${section}/${next.url}`}
+          nextLabel={i18n.t(`${section}.destination.${next.url}`)}>
           {ssComponent}
         </SectionView>
       )

--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -54,12 +54,14 @@ class Identification extends SectionElement {
   createSectionViews () {
     const sectionNav = navigation.find(n => n.url === 'identification')
     const subsections = sectionNav.subsections
-    // exclude the intro and review sections
-    const renderedSubsections = subsections.slice(1, subsections.length - 2)
 
-    return renderedSubsections.map((ss, i) => {
-      const prev = subsections[i]
-      const next = subsections[i+2]
+    const views = subsections.map((ss, i) => {
+      if (ss.exclude) {
+        return null
+      }
+
+      const prev = subsections[i-1]
+      const next = subsections[i+1]
       const ssComponent = this.createSubsection(ss)
 
       return (
@@ -73,6 +75,9 @@ class Identification extends SectionElement {
         </SectionView>
       )
     })
+
+    // exclude nulls
+    return views.filter(v => !!v)
   }
 
   render () {


### PR DESCRIPTION
This is a proof of concept for DRYing the section components. Here, the list of subsection components is now built dynamically from the [navigation configuration](https://github.com/18F/e-QIP-prototype/blob/develop/src/config/navigation.js), rather than having each component written out by hand. This is a step towards having the _entire_ form specified by manifest, like the [US Forms System configuration](https://github.com/usds/us-forms-system/blob/master/docs/building-a-form/quick-start-example-formjs-file.md) (cc #381).

Note that this is a net removal of 23 lines of code, but this is only one (of three) lists of those components in this file, in one (of eight) sections. In other words, using this approach throughout will result in _~2000 fewer lines of code_ 🎉 

In order to achieve this change, I had to do some trickier React stuff, so I understand if it's harder to review. Let me know what you think!

cc @michaelccata 