### PR TITLE
Update citizenship spec

### DIFF
--- a/specs/features/step_definitions/citizenship.js
+++ b/specs/features/step_definitions/citizenship.js
@@ -119,7 +119,7 @@ const completeCitizenshipForeignPassports = (promise) => {
 }
 
 const navigateToSection = (section) => {
-  const selector = '.usa-sidenav-list a[aria-controls="/form/' + 'citizenship' + '"]'
+  const selector = '.usa-sidenav-list a[aria-controls="/form/' + section + '"]'
   return client
     .assert.visible(selector)
     .click(selector)

--- a/specs/features/step_definitions/citizenship.js
+++ b/specs/features/step_definitions/citizenship.js
@@ -119,7 +119,7 @@ const completeCitizenshipForeignPassports = (promise) => {
 }
 
 const navigateToSection = (section) => {
-  const selector = '.section a[title="' + section + '"]'
+  const selector = '.usa-sidenav-list a[aria-controls="/form/' + 'citizenship' + '"]'
   return client
     .assert.visible(selector)
     .click(selector)
@@ -128,7 +128,7 @@ const navigateToSection = (section) => {
 }
 
 const navigateToSubsection = (section, subsection) => {
-  const selector = '.subsection a[href="/form/' + section + '/' + subsection + '"]'
+  const selector = '.usa-sidenav-sub_list a[href="/form/' + section + '/' + subsection + '"]'
   return client
     .assert.visible(selector)
     .click(selector)


### PR DESCRIPTION
Update nav item selections

- During testing the first time the test ran for citizenship everything passed. 
- The second time (because answered items were not cleared) some of the test items failed
- We need a way to flush the test data after every test. 

This continues to chip away at #441
