### PR TITLE
[WORK IN PROGRESS] check for circular dependencies in webpack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ jobs:
           name: Lint
           command: make lint
       - run:
+          name: Build
+          command: make build
+      - run:
           name: Test
           command: make test
       - run:

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-2": "^6.24.1",
     "cache-loader": "^1.2.2",
+    "circular-dependency-plugin": "^5.0.2",
     "codecov": "^3.0.4",
     "dotenv": "^4.0.0",
     "enzyme": "^2.9.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "lint": "npm run lint-css && npm run lint-js",
     "coverage": "NODE_ENV=test codecov",
     "build-assets": "gulp build",
-    "build-js": "webpack -p --progress",
+    "build-js": "webpack -p",
     "build-css": "npm run build-assets && node-sass-chokidar --include-path src/sass --output-style compressed --source-map true src/eqip.scss dist/css/eqip.css",
     "build": "npm run build-assets && npm run build-css && npm run build-js",
     "watch-js": "echo \"Starting JS compilation... (Will be ready once you see 'eqip.js' message, after ~60 seconds.)\" && webpack --watch --progress",

--- a/src/components/Form/BranchCollection/BranchCollection.jsx
+++ b/src/components/Form/BranchCollection/BranchCollection.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Branch } from '../../Form'
+import Branch from '../../Form/Branch/Branch'
 import { newGuid } from '../ValidationElement/ValidationElement'
 import { scrollToBottom } from '../Accordion/Accordion'
 

--- a/src/components/Form/Location/Address.jsx
+++ b/src/components/Form/Location/Address.jsx
@@ -13,7 +13,7 @@ import Show from '../Show'
 import Suggestions from '../Suggestions'
 import { AddressSuggestion } from './AddressSuggestion'
 import { countryString } from '../../../validators/location'
-import { countryValueResolver } from './Location'
+import { countryValueResolver } from './location-helpers'
 
 export default class Address extends ValidationElement {
   constructor (props) {

--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -15,40 +15,7 @@ import { LocationValidator } from '../../../validators'
 import { countryString } from '../../../validators/location'
 import { AddressSuggestion } from './AddressSuggestion'
 import Layouts from './Layouts'
-
-export const timeout = (fn, milliseconds = 400, w = window) => {
-  if (!w) {
-    return
-  }
-
-  w.setTimeout(fn, milliseconds)
-}
-
-export const country = (obj) => {
-  if (obj === null) {
-    return null
-  }
-
-  if (obj instanceof Object) {
-    if ('value' in obj) {
-      return obj.value
-    }
-  }
-
-  return obj
-}
-
-export const countryValueResolver = (props) => {
-  if (typeof props.country === 'string') {
-    let valueArr = props.country ? [props.country] : []
-    let comments = props.countryComments || ''
-    return {
-      value: valueArr,
-      comments: comments
-    }
-  }
-  return props.country
-}
+import { countryValueResolver, timeout } from './location-helpers'
 
 export default class Location extends ValidationElement {
   constructor (props) {

--- a/src/components/Form/Location/Location.test.jsx
+++ b/src/components/Form/Location/Location.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import Location, { timeout, countryValueResolver, country } from './Location'
+import Location from './Location'
 
 describe('The Address component', () => {
   it('Renders without errors', () => {
@@ -214,85 +214,6 @@ describe('The Address component', () => {
     }
     const component = mount(<Location {...props} />)
     expect(component.find('.suggestions').length).toBe(1)
-  })
-
-  it('can set timeout function', () => {
-    let called = false
-    const w = {
-      setTimeout: (fn, ms) => { called = true }
-    }
-    timeout(null, 0, w)
-    expect(called).toBe(true)
-  })
-
-  it('timeout does nothing if window does not exist', () => {
-    let called = false
-    const w = null
-    timeout(null, 0, w)
-    expect(called).toBe(false)
-  })
-
-  it('can handle various country inputs', () => {
-    const tests = [
-      {
-        props: {
-          country: {
-            value: ['Germany'],
-            comments: 'My comment'
-          }
-        },
-        expect: {
-          value: ['Germany'],
-          comments: 'My comment'
-        }
-      },
-      {
-        props: {
-          country: 'Germany',
-          countryComments: 'My comment'
-        },
-        expect: {
-          value: ['Germany'],
-          comments: 'My comment'
-        }
-      },
-      {
-        props: {
-          country: ''
-        },
-        expect: {
-          value: [],
-          comments: ''
-        }
-      }
-    ]
-
-    tests.forEach(test => {
-      expect(countryValueResolver(test.props)).toEqual(test.expect)
-    })
-  })
-
-  it('can process extracting country', () => {
-    const tests = [
-      {
-        data: {
-          value: 'United States'
-        },
-        expect: 'United States'
-      },
-      {
-        data: null,
-        expect: null
-      },
-      {
-        data: 'United States',
-        expect: 'United States'
-      }
-    ]
-
-    tests.forEach(test => {
-      expect(country(test.data)).toEqual(test.expect)
-    })
   })
 
   it('can append to address book', () => {

--- a/src/components/Form/Location/ToggleableLocation.jsx
+++ b/src/components/Form/Location/ToggleableLocation.jsx
@@ -10,7 +10,7 @@ import ZipCode from '../ZipCode'
 import Show from '../Show'
 import Radio from '../Radio'
 import RadioGroup from '../RadioGroup'
-import { country, countryValueResolver } from './Location'
+import { country, countryValueResolver } from './location-helpers'
 import { countryString } from '../../../validators/location'
 
 const mappingWarning = (property) => {

--- a/src/components/Form/Location/location-helpers.js
+++ b/src/components/Form/Location/location-helpers.js
@@ -1,0 +1,33 @@
+export const timeout = (fn, milliseconds = 400, w = window) => {
+  if (!w) {
+    return
+  }
+
+  w.setTimeout(fn, milliseconds)
+}
+
+export const country = (obj) => {
+  if (obj === null) {
+    return null
+  }
+
+  if (obj instanceof Object) {
+    if ('value' in obj) {
+      return obj.value
+    }
+  }
+
+  return obj
+}
+
+export const countryValueResolver = (props) => {
+  if (typeof props.country === 'string') {
+    let valueArr = props.country ? [props.country] : []
+    let comments = props.countryComments || ''
+    return {
+      value: valueArr,
+      comments: comments
+    }
+  }
+  return props.country
+}

--- a/src/components/Form/Location/location-helpers.test.js
+++ b/src/components/Form/Location/location-helpers.test.js
@@ -1,0 +1,82 @@
+import { country, countryValueResolver, timeout } from './location-helpers'
+
+describe('Location helpers', () => {
+  it('can set timeout function', () => {
+    let called = false
+    const w = {
+      setTimeout: (fn, ms) => { called = true }
+    }
+    timeout(null, 0, w)
+    expect(called).toBe(true)
+  })
+
+  it('timeout does nothing if window does not exist', () => {
+    let called = false
+    const w = null
+    timeout(null, 0, w)
+    expect(called).toBe(false)
+  })
+
+  it('can handle various country inputs', () => {
+    const tests = [
+      {
+        props: {
+          country: {
+            value: ['Germany'],
+            comments: 'My comment'
+          }
+        },
+        expect: {
+          value: ['Germany'],
+          comments: 'My comment'
+        }
+      },
+      {
+        props: {
+          country: 'Germany',
+          countryComments: 'My comment'
+        },
+        expect: {
+          value: ['Germany'],
+          comments: 'My comment'
+        }
+      },
+      {
+        props: {
+          country: ''
+        },
+        expect: {
+          value: [],
+          comments: ''
+        }
+      }
+    ]
+
+    tests.forEach(test => {
+      expect(countryValueResolver(test.props)).toEqual(test.expect)
+    })
+  })
+
+  it('can process extracting country', () => {
+    const tests = [
+      {
+        data: {
+          value: 'United States'
+        },
+        expect: 'United States'
+      },
+      {
+        data: null,
+        expect: null
+      },
+      {
+        data: 'United States',
+        expect: 'United States'
+      }
+    ]
+
+    tests.forEach(test => {
+      expect(country(test.data)).toEqual(test.expect)
+    })
+  })
+})

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -19,34 +19,6 @@ import NotApplicable from './NotApplicable'
 import Accordion, { AccordionItem } from './Accordion'
 import Field from './Field'
 
-// Composite components
-import City from './City'
-import County from './County'
-import Country from './Country'
-import MilitaryState from './MilitaryState'
-import MaidenName from './MaidenName'
-import Name from './Name'
-import DateRange from './DateRange'
-import RadioGroup from './RadioGroup'
-import CheckboxGroup from './CheckboxGroup'
-import Comments from './Comments'
-import Height from './Height'
-import Weight from './Weight'
-import HairColor from './HairColor'
-import EyeColor from './EyeColor'
-import Sex from './Sex'
-import Introduction from './Introduction'
-import Consent from './Consent'
-import Branch from './Branch'
-import Show from './Show'
-import BranchCollection from './BranchCollection'
-import SSN from './SSN'
-import ForeignBornDocuments from './ForeignBornDocuments/ForeignBornDocuments'
-import Currency from './Currency'
-import Location from './Location'
-import Spinner, { SpinnerAction } from './Spinner'
-import TimeoutWarning from './TimeoutWarning'
-
 export {
   ValidationElement,
   Generic,
@@ -60,37 +32,10 @@ export {
   Checkbox,
   Radio,
   DateControl,
-  City,
-  County,
-  Country,
-  MilitaryState,
-  MaidenName,
-  Name,
-  DateRange,
-  RadioGroup,
-  CheckboxGroup,
-  Comments,
-  Height,
-  Weight,
-  HairColor,
-  EyeColor,
-  Sex,
-  Introduction,
-  Consent,
-  Branch,
-  Show,
   Svg,
-  BranchCollection,
   Suggestions,
   NotApplicable,
   Accordion,
   AccordionItem,
-  Field,
-  SSN,
-  ForeignBornDocuments,
-  Currency,
-  Location,
-  Spinner,
-  SpinnerAction,
-  TimeoutWarning
+  Field
 }

--- a/src/components/Navigation/navigation-helpers.js
+++ b/src/components/Navigation/navigation-helpers.js
@@ -1,4 +1,4 @@
-import { navigation } from '../../config'
+import { navigation } from '../../config/navigation'
 
 export const validations = (section, props = {}) => {
   if (!section || !section.subsections) {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -4,7 +4,7 @@ import { SectionTitle } from './SectionTitle'
 import Section from './Section'
 import { SavedIndicator } from './SavedIndicator'
 import { ProgressBar } from './ProgressBar'
-import { TimeoutWarning } from './Form'
+import TimeoutWarning from './Form/TimeoutWarning/TimeoutWarning'
 
 export {
   ScoreCard,

--- a/src/schema/form/index.js
+++ b/src/schema/form/index.js
@@ -15,7 +15,6 @@ import { employmentactivity } from './employmentactivity'
 import { foreignborndocument } from './foreignborndocument'
 import { general } from './general'
 import { height } from './height'
-import { index } from './index'
 import { location } from './location'
 import { name } from './name'
 import { notapplicable } from './notapplicable'
@@ -50,7 +49,6 @@ export {
   foreignborndocument,
   general,
   height,
-  index,
   location,
   name,
   notapplicable,

--- a/src/validators/index.js
+++ b/src/validators/index.js
@@ -1,4 +1,3 @@
-import validate, { walkValidationTree } from './validate'
 import DateControlValidator from './datecontrol'
 import DateRangeValidator from './daterange'
 import BankruptcyValidator, { BankruptcyItemValidator } from './bankruptcy'
@@ -104,9 +103,7 @@ import { nameIsEmpty, validBranch, validGenericTextfield, validPhoneNumber, vali
 import OrderValidator, { CompetenceOrderValidator, ConsultationOrderValidator } from './order'
 import { hideReleases, hideHippa, formIsSigned, formIsLocked } from './releases'
 
-export default validate
 export {
-  walkValidationTree,
   DateControlValidator,
   DateRangeValidator,
   IdentificationNameValidator,

--- a/src/views/Login/Login.jsx
+++ b/src/views/Login/Login.jsx
@@ -5,7 +5,7 @@ import Cookies from 'js-cookie'
 import { i18n, env } from '../../config'
 import { api, getQueryValue, deleteCookie } from '../../services'
 import { login, handleLoginSuccess } from '../../actions/AuthActions'
-import { Consent } from '../../components/Form'
+import Consent from '../../components/Form/Consent/Consent'
 
 export class Login extends React.Component {
   constructor (props) {

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -4,6 +4,6 @@ import { AccessDenied } from './AccessDenied'
 import { Locked } from './Locked'
 import { TokenRefresh } from './TokenRefresh'
 import { Help } from './Help'
-import { Form } from './Form'
+import Form from './Form/Form'
 
 export { Login, Loading, AccessDenied, Locked, TokenRefresh, Help, Form }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const staging = process.env.NODE_ENV === 'staging'
 const debug = !production && !staging
 const webpack = require('webpack')
 const path = require('path')
+const CircularDependencyPlugin = require('circular-dependency-plugin')
 
 module.exports = {
   mode: production ? 'production' : 'development',
@@ -32,6 +33,12 @@ module.exports = {
       'API_BASE_URL', 'COOKIE_DOMAIN', 'HASH_ROUTING',
       'BASIC_ENABLED', 'SAML_ENABLED', 'SESSION_TIMEOUT',
       'ATTACHMENTS_ENABLED', 'FILE_MAXIMUM_SIZE', 'FILE_TYPES'
-    ])
+    ]),
+    new CircularDependencyPlugin({
+      exclude: /node_modules/,
+      failOnError: true,
+      // set the current working directory for displaying module paths
+      cwd: process.cwd(),
+    })
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1946,6 +1946,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+circular-dependency-plugin@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/circular-dependency-plugin/-/circular-dependency-plugin-5.0.2.tgz#da168c0b37e7b43563fb9f912c1c007c213389ef"
+
 circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"


### PR DESCRIPTION
Builds on #602.

In #605 I was running into problems with circular dependencies. Babel/Webpack seem to handle them _sometimes_, but not others, and I keep getting unlucky 😁 

* https://stackoverflow.com/questions/49116860/webpack-es6-modules-circular-dependencies-when-using-index-files
* https://stackoverflow.com/questions/38841469/how-to-fix-this-es6-module-circular-dependency

This pull request adds an automatic check for circular `import`s. Turns out we already have some! 