### PR TITLE
create the rest of the Identification subsections dynamically

### DIFF
--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -15,8 +15,6 @@ import OtherNames from './OtherNames'
 import Physical from './Physical'
 import ContactInformation from './ContactInformation'
 
-const section = 'identification'
-
 const storeToComponentMap = {
   ApplicantBirthDate,
   ApplicantBirthPlace,
@@ -40,7 +38,7 @@ class Identification extends SectionElement {
   }
 
   createReviewGroups () {
-    const subsections = getSectionConfig(section).subsections
+    const subsections = getSectionConfig(this.props.section).subsections
 
     let components = subsections.map((subsection) => {
       if (subsection.exclude) {
@@ -48,7 +46,7 @@ class Identification extends SectionElement {
       }
 
       const extraProps = {
-        section,
+        section: this.props.section,
         subsection: subsection.url,
         required: true,
         scrollIntoView: false
@@ -70,7 +68,7 @@ class Identification extends SectionElement {
 
   // Returns an array of SectionViews with their corresponding child component, based on the navigation
   createSectionViews () {
-    const subsections = getSectionConfig(section).subsections
+    const subsections = getSectionConfig(this.props.section).subsections
 
     const views = subsections.map((subsection, i) => {
       if (subsection.exclude) {
@@ -82,12 +80,12 @@ class Identification extends SectionElement {
       const ssComponent = this.createSubsection(subsection)
 
       return (
-        <SectionView key={`${section}/${subsection.url}`}
+        <SectionView key={`${this.props.section}/${subsection.url}`}
           name={subsection.url}
-          back={`${section}/${prev.url}`}
-          backLabel={i18n.t(`${section}.destination.${prev.url}`)}
-          next={`${section}/${next.url}`}
-          nextLabel={i18n.t(`${section}.destination.${next.url}`)}>
+          back={`${this.props.section}/${prev.url}`}
+          backLabel={i18n.t(`${this.props.section}.destination.${prev.url}`)}
+          next={`${this.props.section}/${next.url}`}
+          nextLabel={i18n.t(`${this.props.section}.destination.${next.url}`)}>
           {ssComponent}
         </SectionView>
       )

--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -15,6 +15,8 @@ import OtherNames from './OtherNames'
 import Physical from './Physical'
 import ContactInformation from './ContactInformation'
 
+const section = 'identification'
+
 const storeToComponentMap = {
   ApplicantBirthDate,
   ApplicantBirthPlace,
@@ -26,6 +28,10 @@ const storeToComponentMap = {
 }
 
 class Identification extends SectionElement {
+  getSectionConfig () {
+    return navigation.find(n => n.url === section)
+  }
+
   getSubsectionComponent (name) {
     // https://reactjs.org/docs/jsx-in-depth.html#choosing-the-type-at-runtime
     const SubsectionComponent = storeToComponentMap[name]
@@ -52,9 +58,7 @@ class Identification extends SectionElement {
 
   // Returns an array of SectionViews with their corresponding child component, based on the navigation
   createSectionViews () {
-    const section = 'identification'
-    const sectionNav = navigation.find(n => n.url === section)
-    const subsections = sectionNav.subsections
+    const subsections = this.getSectionConfig().subsections
 
     const views = subsections.map((subsection, i) => {
       if (subsection.exclude) {

--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -42,18 +42,52 @@ class Identification extends SectionElement {
   }
 
   // Returns the component corresponding to the provided subsection object
-  createSubsection (subsection) {
+  createSubsection (subsection, extraProps = {}) {
     const SubsectionComponent = this.getSubsectionComponent(subsection.store)
 
     const props = {
       ...this.props[subsection.store],
+      key: subsection.url,
       name: subsection.url,
       dispatch: this.props.dispatch,
       onUpdate: this.handleUpdate.bind(this, subsection.store),
-      onError: this.handleError
+      onError: this.handleError,
+      ...extraProps
     }
 
     return React.createElement(SubsectionComponent, props)
+  }
+
+  createReviewGroups () {
+    const subsections = this.getSectionConfig().subsections
+
+    const components = subsections.map((subsection, i) => {
+      if (subsection.exclude) {
+        return null
+      }
+
+      return this.createSubsection(subsection, {
+        section,
+        subsection: subsection.url,
+        required: true,
+        scrollIntoView: false
+      })
+    })
+
+    // insert section dividers after each
+    const componentsWithDividers = []
+    components.forEach((component) => {
+      // exclude nulls
+      if (!component) {
+        return
+      }
+      componentsWithDividers.push(component)
+
+      const divider = <hr key={`${component.key}-divider`} className="section-divider" />
+      componentsWithDividers.push(divider)
+    })
+
+    return componentsWithDividers
   }
 
   // Returns an array of SectionViews with their corresponding child component, based on the navigation
@@ -86,7 +120,9 @@ class Identification extends SectionElement {
   }
 
   render () {
+    const reviewComponents = this.createReviewGroups()
     const sectionViews = this.createSectionViews()
+
     return (
       <div>
         <SectionViews current={this.props.subsection} dispatch={this.props.dispatch} update={this.props.update}>
@@ -109,88 +145,7 @@ class Identification extends SectionElement {
                        backLabel={i18n.t('identification.destination.physical')}
                        next="history/intro"
                        nextLabel={i18n.t('history.destination.intro')}>
-            <ApplicantName name="name"
-                           {...this.props.ApplicantName}
-                           section="identification"
-                           subsection="name"
-                           dispatch={this.props.dispatch}
-                           onUpdate={this.handleUpdate.bind(this, 'ApplicantName')}
-                           onError={this.handleError}
-                           required={true}
-                           scrollIntoView={false}
-                           />
-            <hr className="section-divider" />
-            <OtherNames name="othernames"
-                        {...this.props.OtherNames}
-                        section="identification"
-                        subsection="othernames"
-                        defaultState={false}
-                        dispatch={this.props.dispatch}
-                        onUpdate={this.handleUpdate.bind(this, 'OtherNames')}
-                        onError={this.handleError}
-                        required={true}
-                        scrollIntoView={false}
-                        />
-            <hr className="section-divider" />
-            <ContactInformation name="contacts"
-                                {...this.props.Contacts}
-                                section="identification"
-                                subsection="contacts"
-                                minimumPhoneNumbers={1}
-                                minimumEmails={1}
-                                shouldFilterEmptyItems={true}
-                                defaultState={false}
-                                dispatch={this.props.dispatch}
-                                onUpdate={this.handleUpdate.bind(this, 'Contacts')}
-                                onError={this.handleError}
-                                required={true}
-                                scrollIntoView={false}
-                                />
-            <hr className="section-divider" />
-            <ApplicantBirthDate name="birthdate"
-                                {...this.props.ApplicantBirthDate}
-                                section="identification"
-                                subsection="birthdate"
-                                dispatch={this.props.dispatch}
-                                onUpdate={this.handleUpdate.bind(this, 'ApplicantBirthDate')}
-                                onError={this.handleError}
-                                required={true}
-                                scrollIntoView={false}
-                                />
-            <hr className="section-divider" />
-            <ApplicantBirthPlace name="birthplace"
-                                 {...this.props.ApplicantBirthPlace}
-                                 section="identification"
-                                 subsection="birthplace"
-                                 dispatch={this.props.dispatch}
-                                 onUpdate={this.handleUpdate.bind(this, 'ApplicantBirthPlace')}
-                                 onError={this.handleError}
-                                 required={true}
-                                 scrollIntoView={false}
-                                 />
-            <hr className="section-divider" />
-            <ApplicantSSN name="ssn"
-                          {...this.props.ApplicantSSN}
-                          section="identification"
-                          subsection="ssn"
-                          dispatch={this.props.dispatch}
-                          onUpdate={this.handleUpdate.bind(this, 'ApplicantSSN')}
-                          onError={this.handleError}
-                          required={true}
-                          scrollIntoView={false}
-                          />
-            <hr className="section-divider" />
-            <Physical name="physical"
-                      {...this.props.Physical}
-                      section="identification"
-                      subsection="physical"
-                      dispatch={this.props.dispatch}
-                      onUpdate={this.handleUpdate.bind(this, 'Physical')}
-                      onError={this.handleError}
-                      required={true}
-                      scrollIntoView={false}
-                      />
-            <hr className="section-divider" />
+            {reviewComponents}
             <SectionComments name="comments"
                              {...this.props.Comments}
                              section="identification"

--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -168,70 +168,49 @@ Identification.defaultProps = {
 }
 
 export class IdentificationSections extends React.Component {
+  createSubsection(subsection) {
+    const extraProps = {
+      ...this.props[subsection.store],
+      dispatch: this.props.dispatch,
+      onError: this.props.onError,
+      required: true,
+      scrollIntoView: false
+    }
+
+    // TODO figure out a better way to handle these special properties
+    switch (subsection.url) {
+      case 'contacts':
+        extraProps.defaultState = false
+        extraProps.shouldFilterEmptyItems = true
+        break
+      case 'othernames':
+        extraProps.defaultState = false
+    }
+
+    return createSubsection(storeToComponentMap, subsection, extraProps)
+  }
+
+  createSubsections () {
+    const subsections = getSectionConfig('identification').subsections
+
+    const components = subsections.map((subsection, i) => {
+      if (subsection.exclude) {
+        return null
+      }
+
+      return this.createSubsection(subsection)
+    })
+
+    // exclude nulls
+    return components.filter(v => !!v)
+  }
+
   render () {
+    const components = addDividers(this.createSubsections())
+
     return (
       <div>
-        <ApplicantName name="name"
-                       {...this.props.ApplicantName}
-                       dispatch={this.props.dispatch}
-                       onError={this.props.onError}
-                       required={true}
-                       scrollIntoView={false}
-                       />
-        <hr className="section-divider" />
-        <OtherNames name="othernames"
-                    {...this.props.OtherNames}
-                    defaultState={false}
-                    dispatch={this.props.dispatch}
-                    onError={this.props.onError}
-                    required={true}
-                    scrollIntoView={false}
-                    />
-        <hr className="section-divider" />
-        <ContactInformation name="contacts"
-                            {...this.props.Contacts}
-                            minimumPhoneNumbers={1}
-                            minimumEmails={1}
-                            shouldFilterEmptyItems={true}
-                            defaultState={false}
-                            dispatch={this.props.dispatch}
-                            onError={this.props.onError}
-                            required={true}
-                            scrollIntoView={false}
-                            />
-        <hr className="section-divider" />
-        <ApplicantBirthDate name="birthdate"
-                            {...this.props.ApplicantBirthDate}
-                            dispatch={this.props.dispatch}
-                            onError={this.props.onError}
-                            required={true}
-                            scrollIntoView={false}
-                            />
-        <hr className="section-divider" />
-        <ApplicantBirthPlace name="birthplace"
-                             {...this.props.ApplicantBirthPlace}
-                             dispatch={this.props.dispatch}
-                             onError={this.props.onError}
-                             required={true}
-                             scrollIntoView={false}
-                             />
-        <hr className="section-divider" />
-        <ApplicantSSN name="ssn"
-                      {...this.props.ApplicantSSN}
-                      dispatch={this.props.dispatch}
-                      onError={this.props.onError}
-                      required={true}
-                      scrollIntoView={false}
-                      />
-        <hr className="section-divider" />
-        <Physical name="physical"
-                  {...this.props.Physical}
-                  dispatch={this.props.dispatch}
-                  onError={this.props.onError}
-                  required={true}
-                  scrollIntoView={false}
-                  />
-        <hr className="section-divider" />
+        {components}
         <SectionComments name="comments"
                          {...this.props.Comments}
                          title={i18n.t('identification.review.comments')}

--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -61,17 +61,24 @@ class Identification extends SectionElement {
   createReviewGroups () {
     const subsections = this.getSectionConfig().subsections
 
-    const components = subsections.map((subsection, i) => {
+    const components = subsections.map((subsection) => {
       if (subsection.exclude) {
         return null
       }
 
-      return this.createSubsection(subsection, {
+      const props = {
         section,
         subsection: subsection.url,
         required: true,
         scrollIntoView: false
-      })
+      }
+
+      // TODO figure out a better way to handle these special properties
+      if (subsection.url === 'contacts') {
+        props.shouldFilterEmptyItems = true
+      }
+
+      return this.createSubsection(subsection, props)
     })
 
     // insert section dividers after each

--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -6,7 +6,8 @@ import SectionElement from '../SectionElement'
 import SectionComments from '../SectionComments'
 import AuthenticatedView from '../../../views/AuthenticatedView'
 import { Field } from '../../Form'
-import { addDividers, createSubsection, getSectionConfig } from '../generators'
+import { addDividers, createSubsection } from '../generators'
+import navigation from './navigation'
 import ApplicantName from './ApplicantName'
 import ApplicantSSN from './ApplicantSSN'
 import ApplicantBirthPlace from './ApplicantBirthPlace'
@@ -38,7 +39,7 @@ class Identification extends SectionElement {
   }
 
   createReviewGroups () {
-    const subsections = getSectionConfig(this.props.section).subsections
+    const subsections = navigation.subsections
 
     let components = subsections.map((subsection) => {
       if (subsection.exclude) {
@@ -68,7 +69,7 @@ class Identification extends SectionElement {
 
   // Returns an array of SectionViews with their corresponding child component, based on the navigation
   createSectionViews () {
-    const subsections = getSectionConfig(this.props.section).subsections
+    const subsections = navigation.subsections
 
     const views = subsections.map((subsection, i) => {
       if (subsection.exclude) {
@@ -191,7 +192,7 @@ export class IdentificationSections extends React.Component {
   }
 
   createSubsections () {
-    const subsections = getSectionConfig('identification').subsections
+    const subsections = navigation.subsections
 
     const components = subsections.map((subsection, i) => {
       if (subsection.exclude) {

--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -58,15 +58,29 @@ class Identification extends SectionElement {
     return React.createElement(SubsectionComponent, props)
   }
 
+  // Returns a new array with section dividers after each component
+  addDividers (components) {
+    // essentially this is a flatMap()
+    const componentsWithDividers = []
+    components.forEach((component) => {
+      componentsWithDividers.push(component)
+
+      const divider = <hr key={`${component.key}-divider`} className="section-divider" />
+      componentsWithDividers.push(divider)
+    })
+
+    return componentsWithDividers
+  }
+
   createReviewGroups () {
     const subsections = this.getSectionConfig().subsections
 
-    const components = subsections.map((subsection) => {
+    let components = subsections.map((subsection) => {
       if (subsection.exclude) {
         return null
       }
 
-      const props = {
+      const extraProps = {
         section,
         subsection: subsection.url,
         required: true,
@@ -75,26 +89,16 @@ class Identification extends SectionElement {
 
       // TODO figure out a better way to handle these special properties
       if (subsection.url === 'contacts') {
-        props.shouldFilterEmptyItems = true
+        extraProps.shouldFilterEmptyItems = true
       }
 
-      return this.createSubsection(subsection, props)
+      return this.createSubsection(subsection, extraProps)
     })
 
-    // insert section dividers after each
-    const componentsWithDividers = []
-    components.forEach((component) => {
-      // exclude nulls
-      if (!component) {
-        return
-      }
-      componentsWithDividers.push(component)
+    // exclude nulls
+    components = components.filter(c => !!c)
 
-      const divider = <hr key={`${component.key}-divider`} className="section-divider" />
-      componentsWithDividers.push(divider)
-    })
-
-    return componentsWithDividers
+    return this.addDividers(components)
   }
 
   // Returns an array of SectionViews with their corresponding child component, based on the navigation

--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -6,7 +6,7 @@ import SectionElement from '../SectionElement'
 import SectionComments from '../SectionComments'
 import AuthenticatedView from '../../../views/AuthenticatedView'
 import { Field } from '../../Form'
-import navigation from '../../../config/navigation'
+import { addDividers, createSubsection, getSectionConfig } from '../generators'
 import ApplicantName from './ApplicantName'
 import ApplicantSSN from './ApplicantSSN'
 import ApplicantBirthPlace from './ApplicantBirthPlace'
@@ -28,52 +28,19 @@ const storeToComponentMap = {
 }
 
 class Identification extends SectionElement {
-  getSectionConfig () {
-    return navigation.find(n => n.url === section)
-  }
-
-  getSubsectionComponent (name) {
-    // https://reactjs.org/docs/jsx-in-depth.html#choosing-the-type-at-runtime
-    const SubsectionComponent = storeToComponentMap[name]
-    if (!SubsectionComponent) {
-      console.error(`${name} component not found`)
-    }
-    return SubsectionComponent
-  }
-
-  // Returns the component corresponding to the provided subsection object
-  createSubsection (subsection, extraProps = {}) {
-    const SubsectionComponent = this.getSubsectionComponent(subsection.store)
-
-    const props = {
+  createSubsection (subsection, extraExtraProps = {}) {
+    const extraProps = {
       ...this.props[subsection.store],
-      key: subsection.url,
-      name: subsection.url,
       dispatch: this.props.dispatch,
       onUpdate: this.handleUpdate.bind(this, subsection.store),
       onError: this.handleError,
-      ...extraProps
+      ...extraExtraProps
     }
-
-    return React.createElement(SubsectionComponent, props)
-  }
-
-  // Returns a new array with section dividers after each component
-  addDividers (components) {
-    // essentially this is a flatMap()
-    const componentsWithDividers = []
-    components.forEach((component) => {
-      componentsWithDividers.push(component)
-
-      const divider = <hr key={`${component.key}-divider`} className="section-divider" />
-      componentsWithDividers.push(divider)
-    })
-
-    return componentsWithDividers
+    return createSubsection(storeToComponentMap, subsection, extraProps)
   }
 
   createReviewGroups () {
-    const subsections = this.getSectionConfig().subsections
+    const subsections = getSectionConfig(section).subsections
 
     let components = subsections.map((subsection) => {
       if (subsection.exclude) {
@@ -98,12 +65,12 @@ class Identification extends SectionElement {
     // exclude nulls
     components = components.filter(c => !!c)
 
-    return this.addDividers(components)
+    return addDividers(components)
   }
 
   // Returns an array of SectionViews with their corresponding child component, based on the navigation
   createSectionViews () {
-    const subsections = this.getSectionConfig().subsections
+    const subsections = getSectionConfig(section).subsections
 
     const views = subsections.map((subsection, i) => {
       if (subsection.exclude) {

--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -27,7 +27,7 @@ const storeToComponentMap = {
 }
 
 class Identification extends SectionElement {
-  createSubsection (subsection, extraExtraProps = {}) {
+  createSubsection(subsection, extraExtraProps = {}) {
     const extraProps = {
       ...this.props[subsection.store],
       dispatch: this.props.dispatch,
@@ -38,10 +38,10 @@ class Identification extends SectionElement {
     return createSubsection(storeToComponentMap, subsection, extraProps)
   }
 
-  createReviewGroups () {
+  createReviewGroups() {
     const subsections = navigation.subsections
 
-    let components = subsections.map((subsection) => {
+    let components = subsections.map(subsection => {
       if (subsection.exclude) {
         return null
       }
@@ -68,7 +68,7 @@ class Identification extends SectionElement {
   }
 
   // Returns an array of SectionViews with their corresponding child component, based on the navigation
-  createSectionViews () {
+  createSectionViews() {
     const subsections = navigation.subsections
 
     const views = subsections.map((subsection, i) => {
@@ -76,12 +76,13 @@ class Identification extends SectionElement {
         return null
       }
 
-      const prev = subsections[i-1]
-      const next = subsections[i+1]
+      const prev = subsections[i - 1]
+      const next = subsections[i + 1]
       const ssComponent = this.createSubsection(subsection)
 
       return (
-        <SectionView key={`${this.props.section}/${subsection.url}`}
+        <SectionView
+          key={`${this.props.section}/${subsection.url}`}
           name={subsection.url}
           back={`${this.props.section}/${prev.url}`}
           backLabel={i18n.t(`${this.props.section}.destination.${prev.url}`)}
@@ -96,44 +97,51 @@ class Identification extends SectionElement {
     return views.filter(v => !!v)
   }
 
-  render () {
+  render() {
     const reviewComponents = this.createReviewGroups()
     const sectionViews = this.createSectionViews()
 
     return (
       <div>
-        <SectionViews current={this.props.subsection} dispatch={this.props.dispatch} update={this.props.update}>
-          <SectionView name="intro"
-                       next="identification/name"
-                       nextLabel={i18n.t('identification.destination.name')}>
-            <Field title={i18n.t('identification.intro.title')}
-                   titleSize="h2"
-                   optional={true}
-                   className="no-margin-bottom">
+        <SectionViews
+          current={this.props.subsection}
+          dispatch={this.props.dispatch}
+          update={this.props.update}>
+          <SectionView
+            name="intro"
+            next="identification/name"
+            nextLabel={i18n.t('identification.destination.name')}>
+            <Field
+              title={i18n.t('identification.intro.title')}
+              titleSize="h2"
+              optional={true}
+              className="no-margin-bottom">
               {i18n.m('identification.intro.body')}
             </Field>
           </SectionView>
 
-          <SectionView name="review"
-                       title={i18n.t('review.title')}
-                       para={i18n.m('review.para')}
-                       showTop={true}
-                       back="identification/physical"
-                       backLabel={i18n.t('identification.destination.physical')}
-                       next="history/intro"
-                       nextLabel={i18n.t('history.destination.intro')}>
+          <SectionView
+            name="review"
+            title={i18n.t('review.title')}
+            para={i18n.m('review.para')}
+            showTop={true}
+            back="identification/physical"
+            backLabel={i18n.t('identification.destination.physical')}
+            next="history/intro"
+            nextLabel={i18n.t('history.destination.intro')}>
             {reviewComponents}
-            <SectionComments name="comments"
-                             {...this.props.Comments}
-                             section="identification"
-                             subsection="name"
-                             title={i18n.t('identification.review.comments')}
-                             dispatch={this.props.dispatch}
-                             onUpdate={this.handleUpdate.bind(this, 'Comments')}
-                             onError={this.handleError}
-                             required={false}
-                             scrollIntoView={false}
-                             />
+            <SectionComments
+              name="comments"
+              {...this.props.Comments}
+              section="identification"
+              subsection="name"
+              title={i18n.t('identification.review.comments')}
+              dispatch={this.props.dispatch}
+              onUpdate={this.handleUpdate.bind(this, 'Comments')}
+              onError={this.handleError}
+              required={false}
+              scrollIntoView={false}
+            />
           </SectionView>
 
           {sectionViews}
@@ -143,7 +151,7 @@ class Identification extends SectionElement {
   }
 }
 
-function mapStateToProps (state) {
+function mapStateToProps(state) {
   const app = state.application || {}
   const identification = app.Identification || {}
   const errors = app.Errors || {}
@@ -191,7 +199,7 @@ export class IdentificationSections extends React.Component {
     return createSubsection(storeToComponentMap, subsection, extraProps)
   }
 
-  createSubsections () {
+  createSubsections() {
     const subsections = navigation.subsections
 
     const components = subsections.map((subsection, i) => {
@@ -206,20 +214,21 @@ export class IdentificationSections extends React.Component {
     return components.filter(v => !!v)
   }
 
-  render () {
+  render() {
     const components = addDividers(this.createSubsections())
 
     return (
       <div>
         {components}
-        <SectionComments name="comments"
-                         {...this.props.Comments}
-                         title={i18n.t('identification.review.comments')}
-                         dispatch={this.props.dispatch}
-                         onError={this.props.onError}
-                         required={false}
-                         scrollIntoView={false}
-                         />
+        <SectionComments
+          name="comments"
+          {...this.props.Comments}
+          title={i18n.t('identification.review.comments')}
+          dispatch={this.props.dispatch}
+          onError={this.props.onError}
+          required={false}
+          scrollIntoView={false}
+        />
       </div>
     )
   }

--- a/src/components/Section/generators.js
+++ b/src/components/Section/generators.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import navigation from '../../config/navigation'
+
+export const getSectionConfig = (section) => {
+  return navigation.find(n => n.url === section)
+}
+
+export const getSubsectionComponent = (storeToComponentMap, name) => {
+  // https://reactjs.org/docs/jsx-in-depth.html#choosing-the-type-at-runtime
+  const SubsectionComponent = storeToComponentMap[name]
+  if (!SubsectionComponent) {
+    console.error(`${name} component not found`)
+  }
+  return SubsectionComponent
+}
+
+// Returns the component corresponding to the provided subsection object
+export const createSubsection = (storeToComponentMap,subsection, extraProps = {}) => {
+  const SubsectionComponent = getSubsectionComponent(storeToComponentMap, subsection.store)
+
+  const props = {
+    key: subsection.url,
+    name: subsection.url,
+    ...extraProps
+  }
+
+  return React.createElement(SubsectionComponent, props)
+}
+
+// Returns a new array with section dividers after each component
+export const addDividers = (components) => {
+  // essentially this is a flatMap()
+  const componentsWithDividers = []
+  components.forEach((component) => {
+    componentsWithDividers.push(component)
+
+    const divider = <hr key={`${component.key}-divider`} className="section-divider" />
+    componentsWithDividers.push(divider)
+  })
+
+  return componentsWithDividers
+}

--- a/src/components/Section/generators.js
+++ b/src/components/Section/generators.js
@@ -1,9 +1,4 @@
 import React from 'react'
-import navigation from '../../config/navigation'
-
-export const getSectionConfig = (section) => {
-  return navigation.find(n => n.url === section)
-}
 
 export const getSubsectionComponent = (storeToComponentMap, name) => {
   // https://reactjs.org/docs/jsx-in-depth.html#choosing-the-type-at-runtime

--- a/src/components/Section/generators.js
+++ b/src/components/Section/generators.js
@@ -10,8 +10,15 @@ export const getSubsectionComponent = (storeToComponentMap, name) => {
 }
 
 // Returns the component corresponding to the provided subsection object
-export const createSubsection = (storeToComponentMap,subsection, extraProps = {}) => {
-  const SubsectionComponent = getSubsectionComponent(storeToComponentMap, subsection.store)
+export const createSubsection = (
+  storeToComponentMap,
+  subsection,
+  extraProps = {}
+) => {
+  const SubsectionComponent = getSubsectionComponent(
+    storeToComponentMap,
+    subsection.store
+  )
 
   const props = {
     key: subsection.url,
@@ -23,13 +30,15 @@ export const createSubsection = (storeToComponentMap,subsection, extraProps = {}
 }
 
 // Returns a new array with section dividers after each component
-export const addDividers = (components) => {
+export const addDividers = components => {
   // essentially this is a flatMap()
   const componentsWithDividers = []
-  components.forEach((component) => {
+  components.forEach(component => {
     componentsWithDividers.push(component)
 
-    const divider = <hr key={`${component.key}-divider`} className="section-divider" />
+    const divider = (
+      <hr key={`${component.key}-divider`} className="section-divider" />
+    )
     componentsWithDividers.push(divider)
   })
 


### PR DESCRIPTION
Following up on #595, this pull request takes the remaining instantiations of the subsection components for the Identification section and generates them dynamically from the navigation config. There are still improvements I want to make, tests I want to add, etc., but I don't want this pull request to get even bigger.

I recommend ignoring whitespace when viewing the diff.