### PR TITLE
move Identification navigation config to its own file

### DIFF
--- a/src/components/Section/Identification/navigation.js
+++ b/src/components/Section/Identification/navigation.js
@@ -1,0 +1,66 @@
+import * as validators from '../../../validators/index'
+
+const navigation = {
+  name: 'Information about you',
+  title: 'Information about you',
+  url: 'identification',
+  store: 'Identification',
+  showNumber: true,
+  locked: validators.formIsLocked,
+  subsections: [
+    {
+      name: 'Introduction',
+      url: 'intro',
+      exclude: true
+    },
+    {
+      name: 'Full name',
+      url: 'name',
+      store: 'ApplicantName',
+      validator: validators.IdentificationNameValidator
+    },
+    {
+      name: 'Other names used',
+      url: 'othernames',
+      store: 'OtherNames',
+      validator: validators.IdentificationOtherNamesValidator
+    },
+    {
+      name: 'Your contact information',
+      url: 'contacts',
+      store: 'Contacts',
+      validator: validators.IdentificationContactInformationValidator
+    },
+    {
+      name: 'Date of birth',
+      url: 'birthdate',
+      store: 'ApplicantBirthDate',
+      validator: validators.IdentificationBirthDateValidator
+    },
+    {
+      name: 'Place of birth',
+      url: 'birthplace',
+      store: 'ApplicantBirthPlace',
+      validator: validators.IdentificationBirthPlaceValidator
+    },
+    {
+      name: 'Social security number',
+      url: 'ssn',
+      store: 'ApplicantSSN',
+      validator: validators.IdentificationSSNValidator
+    },
+    {
+      name: 'Your identifying information',
+      url: 'physical',
+      store: 'Physical',
+      validator: validators.IdentificationPhysicalValidator
+    },
+    {
+      name: 'Review',
+      url: 'review',
+      exclude: true
+    }
+  ]
+}
+
+export default navigation

--- a/src/config/navigation.js
+++ b/src/config/navigation.js
@@ -1,26 +1,9 @@
 import env from './environment'
 import * as validators from '../validators/index'
+import Identification from '../components/Section/Identification/navigation'
 
 const navigation = [
-  {
-    name: 'Information about you',
-    title: 'Information about you',
-    url: 'identification',
-    store: 'Identification',
-    showNumber: true,
-    locked: validators.formIsLocked,
-    subsections: [
-      { exclude: true, name: 'Introduction', url: 'intro' },
-      { name: 'Full name', url: 'name', store: 'ApplicantName', validator: validators.IdentificationNameValidator },
-      { name: 'Other names used', url: 'othernames', store: 'OtherNames', validator: validators.IdentificationOtherNamesValidator },
-      { name: 'Your contact information', url: 'contacts', store: 'Contacts', validator: validators.IdentificationContactInformationValidator },
-      { name: 'Date of birth', url: 'birthdate', store: 'ApplicantBirthDate', validator: validators.IdentificationBirthDateValidator },
-      { name: 'Place of birth', url: 'birthplace', store: 'ApplicantBirthPlace', validator: validators.IdentificationBirthPlaceValidator },
-      { name: 'Social security number', url: 'ssn', store: 'ApplicantSSN', validator: validators.IdentificationSSNValidator },
-      { name: 'Your identifying information', url: 'physical', store: 'Physical', validator: validators.IdentificationPhysicalValidator },
-      { exclude: true, name: 'Review', url: 'review' }
-    ]
-  },
+  Identification,
   {
     name: 'Your history',
     title: 'Your history',


### PR DESCRIPTION
Extracted from #605.

The navigation configuration, [as it was](https://github.com/18F/e-QIP-prototype/blob/efb5531c47bc0ee63723e6e1be513524a8e35e41/src/config/navigation.js), was pretty dense and hard to work with. This pull request moves the configuration for the Identification section to its own file and formats it in an easier-to-read fashion, which I would do with the others if you like the idea.

On the fence about whether this section-specific navigation configuration should live with the other section-specific files (under [`src/components/Section/Identification/`](https://github.com/18F/e-QIP-prototype/tree/develop/src/components/Section/Identification) like the stylesheets, even though it's not a "component"), or stay under [`src/config/`](https://github.com/18F/e-QIP-prototype/tree/develop/src/config). Thoughts?