### PR TITLE
add component snapshots to the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,6 @@ package-lock.json
 # Optional REPL history
 .node_repl_history
 
-# ReactJS caches
-__snapshots__/
-
 # Go vendoring
 # We will just track the vendor.json file to rehydrate packages during development
 # For release all vendored packages should be frozen

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ make test
 make coverage
 ```
 
-Frontend tests are written in [Jest](https://facebook.github.io/jest/), while the API tests use [Go's `testing` package](https://golang.org/pkg/testing/).
+Frontend tests are written in [Jest](https://facebook.github.io/jest/), with [snapshot tests](https://jestjs.io/docs/en/snapshot-testing) for ensuring components don't inadvertently change. API tests use [Go's `testing` package](https://golang.org/pkg/testing/).
 
 ### Adding/updating NPM packages
 

--- a/src/components/Form/BranchCollection/BranchCollection.jsx
+++ b/src/components/Form/BranchCollection/BranchCollection.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Branch } from '../../Form'
-import { newGuid } from '../ValidationElement/ValidationElement'
+import { newGuid } from '../ValidationElement'
 import { scrollToBottom } from '../Accordion/Accordion'
 
 export default class BranchCollection extends React.Component {

--- a/src/components/Form/ValidationElement/ValidationElement.jsx
+++ b/src/components/Form/ValidationElement/ValidationElement.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { newGuid, flattenObject, mergeError, triageErrors } from './helpers'
 
 export default class ValidationElement extends React.Component {
   constructor (props) {
@@ -88,89 +89,4 @@ export default class ValidationElement extends React.Component {
   guid () {
     return newGuid()
   }
-}
-
-export const newGuid = () => {
-  const s4 = () => {
-    return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1)
-  }
-
-  return `${s4()}${s4()}-${s4()}-${s4()}-${s4()}-${s4()}${s4()}${s4()}`
-}
-
-export const flattenObject = (obj) => {
-  let s = ''
-  let what = Object.prototype.toString.call(obj)
-  switch (what) {
-    case '[object Object]':
-      for (let p in obj) {
-        if (!obj.hasOwnProperty(p)) {
-          continue
-        }
-        s += (s.length === 0 ? '' : '.') + p + '.' + flattenObject(obj[p])
-      }
-      break
-    case '[object String]':
-      s += (s.length === 0 ? '' : '.') + obj
-      break
-    case '[object Array]':
-      obj.forEach((x) => {
-        s += (s.length === 0 ? '' : '.') + flattenObject(x)
-      })
-      break
-  }
-
-  return s
-}
-
-export const mergeError = (previous, error) => {
-  let codes = []
-  let errorString = flattenObject(error)
-
-  // Clean up any errors which are no longer valid
-  previous.forEach((c) => {
-    if (errorString && errorString.endsWith('.') && c.indexOf(errorString) > -1) {
-      return
-    }
-
-    codes.push(c)
-  })
-
-  // Add the error if it does not already exist
-  if (errorString && errorString.length && !errorString.endsWith('.') && !codes.includes(errorString)) {
-    codes.push(errorString)
-  }
-  return codes
-}
-
-export const triageErrors = (section, previous, codes) => {
-  let arr = []
-
-  // First we need to persist any error messages stored in the same section
-  // but not necessarily within the same scope
-  previous.forEach((e) => {
-    for (let subsection in codes) {
-      if (!codes.hasOwnProperty(subsection)) continue
-      if (e.indexOf(`${subsection}.`) === -1) {
-        arr.push(e.replace(`${section}.`, ''))
-      }
-    }
-  })
-
-  for (let subsection in codes) {
-    // skip loop if the property is from prototype
-    if (!codes.hasOwnProperty(subsection)) continue
-
-    if (codes[subsection]) {
-      for (let prop in codes[subsection]) {
-        if (!codes[subsection].hasOwnProperty(prop)) continue
-
-        let e = `${subsection}.` + flattenObject(codes[subsection][prop])
-        if (!arr.includes(e)) {
-          arr.push(e)
-        }
-      }
-    }
-  }
-  return arr
 }

--- a/src/components/Form/ValidationElement/helpers.js
+++ b/src/components/Form/ValidationElement/helpers.js
@@ -1,0 +1,95 @@
+export const newGuid = () => {
+  const s4 = () => {
+    return Math.floor((1 + Math.random()) * 0x10000)
+      .toString(16)
+      .substring(1)
+  }
+
+  return `${s4()}${s4()}-${s4()}-${s4()}-${s4()}-${s4()}${s4()}${s4()}`
+}
+
+export const flattenObject = obj => {
+  let s = ''
+  let what = Object.prototype.toString.call(obj)
+  switch (what) {
+    case '[object Object]':
+      for (let p in obj) {
+        if (!obj.hasOwnProperty(p)) {
+          continue
+        }
+        s += (s.length === 0 ? '' : '.') + p + '.' + flattenObject(obj[p])
+      }
+      break
+    case '[object String]':
+      s += (s.length === 0 ? '' : '.') + obj
+      break
+    case '[object Array]':
+      obj.forEach(x => {
+        s += (s.length === 0 ? '' : '.') + flattenObject(x)
+      })
+      break
+  }
+
+  return s
+}
+
+export const mergeError = (previous, error) => {
+  let codes = []
+  let errorString = flattenObject(error)
+
+  // Clean up any errors which are no longer valid
+  previous.forEach(c => {
+    if (
+      errorString &&
+      errorString.endsWith('.') &&
+      c.indexOf(errorString) > -1
+    ) {
+      return
+    }
+
+    codes.push(c)
+  })
+
+  // Add the error if it does not already exist
+  if (
+    errorString &&
+    errorString.length &&
+    !errorString.endsWith('.') &&
+    !codes.includes(errorString)
+  ) {
+    codes.push(errorString)
+  }
+  return codes
+}
+
+export const triageErrors = (section, previous, codes) => {
+  let arr = []
+
+  // First we need to persist any error messages stored in the same section
+  // but not necessarily within the same scope
+  previous.forEach(e => {
+    for (let subsection in codes) {
+      if (!codes.hasOwnProperty(subsection)) continue
+      if (e.indexOf(`${subsection}.`) === -1) {
+        arr.push(e.replace(`${section}.`, ''))
+      }
+    }
+  })
+
+  for (let subsection in codes) {
+    // skip loop if the property is from prototype
+    if (!codes.hasOwnProperty(subsection)) continue
+
+    if (codes[subsection]) {
+      for (let prop in codes[subsection]) {
+        if (!codes[subsection].hasOwnProperty(prop)) continue
+
+        let e = `${subsection}.` + flattenObject(codes[subsection][prop])
+        if (!arr.includes(e)) {
+          arr.push(e)
+        }
+      }
+    }
+  }
+  return arr
+}

--- a/src/components/Form/ValidationElement/helpers.test.js
+++ b/src/components/Form/ValidationElement/helpers.test.js
@@ -1,6 +1,6 @@
-import { flattenObject, mergeError, triageErrors } from './ValidationElement'
+import { flattenObject, mergeError, triageErrors } from './helpers'
 
-describe('The ValidationElement component', () => {
+describe('The ValidationElement helpers', () => {
   it('can flatten an object', () => {
     const tests = [
       {

--- a/src/components/Form/ValidationElement/index.js
+++ b/src/components/Form/ValidationElement/index.js
@@ -1,3 +1,4 @@
-import ValidationElement, { newGuid, flattenObject, mergeError, triageErrors } from './ValidationElement'
+import { newGuid } from './helpers'
+import ValidationElement from './ValidationElement'
 export default ValidationElement
-export { newGuid, flattenObject, mergeError, triageErrors }
+export { newGuid }

--- a/src/components/Main/__snapshots__/App.test.jsx.snap
+++ b/src/components/Main/__snapshots__/App.test.jsx.snap
@@ -1,0 +1,191 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Renders homepage 1`] = `
+<div
+  className=""
+>
+  <div
+    id="scrollTo"
+  />
+  <a
+    className="usa-skipnav"
+    href="#main-content"
+  >
+    Skip to form questions
+  </a>
+  <div
+    className="sticky-header "
+  >
+    <div
+      className="header-container"
+    >
+      <div
+        className="header"
+      >
+        <header
+          className="usa-header usa-header-basic"
+          role="banner"
+        >
+          <div
+            className="usa-banner mobile-hidden"
+          >
+            <div
+              className="usa-accordion"
+            >
+              <div
+                className="usa-banner-header"
+              >
+                <div
+                  className="usa-grid usa-banner-inner"
+                >
+                  <img
+                    alt="U.S. flag"
+                    src="/img/favicons/favicon-57.png"
+                  />
+                  <p>
+                    An official website of the United States government
+                  </p>
+                  <button
+                    aria-controls="gov-banner"
+                    aria-expanded="false"
+                    className="usa-accordion-button usa-banner-button"
+                  >
+                    <span
+                      className="usa-banner-button-text"
+                    >
+                      Here's how you know
+                    </span>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="usa-banner-content usa-grid usa-accordion-content"
+                id="gov-banner"
+              >
+                <div
+                  className="usa-banner-guidance-gov usa-width-one-half"
+                >
+                  <img
+                    alt="Dot gov"
+                    className="usa-banner-icon usa-media_block-img"
+                    src="/img/icon-dot-gov.svg"
+                  />
+                  <div
+                    className="usa-media_block-body"
+                  >
+                    <p>
+                      <strong>
+                        The .gov means it's official.
+                      </strong>
+                      <br />
+                      Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you're on a .gov or .mil site by inspecting your browser's address (or "location") bar.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  className="usa-banner-guidance-ssl usa-width-one-half"
+                >
+                  <img
+                    alt="SSL"
+                    className="usa-banner-icon usa-media_block-img"
+                    src="/img/icon-https.svg"
+                  />
+                  <div
+                    className="usa-media_block-body"
+                  >
+                    <p>
+                      This site is also protected by an SSL (Secure Sockets Layer) certificate that's been signed by the U.S. government. The &lt;strong&gt;https://&lt;/strong&gt; means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="eapp-structure-wrap eapp-header"
+          >
+            <div
+              className="eapp-structure-row"
+            >
+              <div
+                className="eapp-structure-left eapp-logo"
+                id="logo"
+              >
+                <div
+                  className="text-center"
+                >
+                  <img
+                    alt="Office of Personnet Management"
+                    className="eapp-logo-icon"
+                    src="/img/US-OfficeOfPersonnelManagement-Seal.svg"
+                  />
+                  <span
+                    className="eapp-logo-text"
+                  >
+                    SF86
+                  </span>
+                </div>
+              </div>
+              <div
+                className="eapp-structure-right eapp-title"
+              >
+                <div
+                  className="eapp-logout"
+                >
+                  <button
+                    className="instructions mobile-hidden"
+                    onClick={[Function]}
+                  >
+                    Instructions
+                  </button>
+                </div>
+                <h1
+                  className="title"
+                />
+              </div>
+            </div>
+          </div>
+        </header>
+        <div
+          id="scrollToProgress"
+        />
+        <div
+          className="usa-overlay"
+        />
+      </div>
+    </div>
+  </div>
+  <main
+    className="eapp-structure-wrap eapp-main"
+  >
+    <div
+      className="eapp-structure-row"
+    >
+      <div
+        className="eapp-structure-left eapp-navigation mobile-hidden"
+      >
+        <button
+          className="instructions mobile-visible"
+          onClick={[Function]}
+        >
+          <span>
+            Instructions
+          </span>
+        </button>
+         
+      </div>
+      <a
+        className="eapp-section-focus"
+        href="javascript:;;;"
+        title="Main content. Please press TAB to go to the next question"
+      />
+      <div
+        className="eapp-structure-right eapp-core visible"
+        id="main-content"
+      >
+         
+      </div>
+    </div>
+  </main>
+</div>
+`;

--- a/src/components/Section/Identification/Identification.test.jsx
+++ b/src/components/Section/Identification/Identification.test.jsx
@@ -15,6 +15,14 @@ const applicationState = {
   }
 }
 
+// give a fake GUID so the field IDs don't differ between snapshots
+// https://github.com/facebook/jest/issues/936#issuecomment-404246102
+jest.mock('../../Form/ValidationElement/helpers', () =>
+  Object.assign(require.requireActual('../../Form/ValidationElement/helpers'), {
+    newGuid: jest.fn().mockReturnValue('MOCK-GUID')
+  })
+)
+
 describe('The identification section', () => {
   // Setup
   window.token = 'fake-token'

--- a/src/components/Section/Identification/Identification.test.jsx
+++ b/src/components/Section/Identification/Identification.test.jsx
@@ -1,8 +1,9 @@
 import React from 'react'
+import renderer from 'react-test-renderer'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import { Provider } from 'react-redux'
-import Identification from './Identification'
+import Identification, { IdentificationSections } from './Identification'
 import { mount } from 'enzyme'
 
 const applicationState = {
@@ -48,5 +49,25 @@ describe('The identification section', () => {
       const component = mount(<Provider store={store}><Identification subsection={section} /></Provider>)
       expect(component.find('div').length).toBeGreaterThan(0)
     })
+  })
+
+  it('renders the Identification component', () => {
+    const store = mockStore({
+      authentication: { authenticated: true },
+      application: applicationState
+    })
+    const component = renderer.create(
+      <Provider store={store}>
+        <Identification />
+      </Provider>
+    )
+    let tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders the IdentificationSections component', () => {
+    const component = renderer.create(<IdentificationSections />)
+    let tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
   })
 })

--- a/src/components/Section/Identification/__snapshots__/Identification.test.jsx.snap
+++ b/src/components/Section/Identification/__snapshots__/Identification.test.jsx.snap
@@ -1,0 +1,3893 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The identification section renders the Identification component 1`] = `
+<div>
+  <div />
+</div>
+`;
+
+exports[`The identification section renders the IdentificationSections component 1`] = `
+<div>
+  <div
+    className="section-content applicant-name"
+    data-section="identification"
+    data-subsection="name"
+  >
+    <div
+      aria-label="Provide your full name"
+      className="field"
+      data-uuid="field-3c2f40b3-3652-cac4-1b79-0d1941378221"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-3c2f40b3-3652-cac4-1b79-0d1941378221"
+        name="field-3c2f40b3-3652-cac4-1b79-0d1941378221"
+      />
+      <h2
+        className="title h2"
+      >
+        Provide your full name
+      </h2>
+      <span
+        className="icon"
+      />
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component"
+          >
+            <div
+              className="name "
+            >
+              <div
+                aria-label="First name"
+                className="field required"
+                data-uuid="field-8a84c6dd-5d3b-501e-d107-77c5da349824"
+              >
+                <a
+                  aria-hidden="true"
+                  className="anchor"
+                  id="field-8a84c6dd-5d3b-501e-d107-77c5da349824"
+                  name="field-8a84c6dd-5d3b-501e-d107-77c5da349824"
+                />
+                <label
+                  className="title label"
+                >
+                  First name
+                </label>
+                <span
+                  className="icon"
+                >
+                  <a
+                    aria-label="Show help for First name"
+                    className="toggle label  adjust-for-labels"
+                    href="javascript:;"
+                    onClick={[Function]}
+                    title="Show help for First name"
+                  >
+                    <svg
+                      alt="Scalable vector graphic"
+                      focusable="false"
+                      height="14.57px"
+                      tabIndex="-1"
+                      viewBox="0 0 14.57 14.57"
+                      width="14.57px"
+                    >
+                      <g>
+                        <path
+                          className="eapp-help-icon"
+                          d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                        />
+                      </g>
+                    </svg>
+                  </a>
+                </span>
+                <div
+                  className="table expand"
+                >
+                  <span
+                    aria-live="polite"
+                    className="messages help-messages"
+                  />
+                </div>
+                <div
+                  className="table"
+                >
+                  <span
+                    className="content"
+                  >
+                    <span
+                      className="component"
+                    >
+                      <div
+                        className="first usa-input-error"
+                      >
+                        <input
+                          aria-describedby="first-error"
+                          aria-label={null}
+                          autoCapitalize={true}
+                          autoComplete={true}
+                          autoCorrect={true}
+                          className=""
+                          id="first-cca0deef-588c-1782-d54d-e8c385166578"
+                          maxLength="100"
+                          name="first"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          pattern="^[a-zA-Z\\\\-\\\\.' ]*$"
+                          spellCheck={true}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                      <div
+                        className="flags"
+                      >
+                        <div
+                          className="first-initial-only block"
+                        >
+                          <input
+                            aria-label="Initial only for null"
+                            checked={false}
+                            className="usa-input-success"
+                            id="firstInitialOnly-d3858e08-e211-da3a-324c-db0bbfa060ac"
+                            name="firstInitialOnly"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="checkbox"
+                            value={false}
+                          />
+                          <label
+                            className="checkbox no-toggle"
+                            htmlFor="firstInitialOnly-d3858e08-e211-da3a-324c-db0bbfa060ac"
+                          >
+                            <span>
+                              Initial only
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </span>
+                  </span>
+                </div>
+                <div
+                  className="table expand"
+                >
+                  <span
+                    aria-live="polite"
+                    className="messages error-messages"
+                    role="alert"
+                  />
+                </div>
+              </div>
+              <div
+                aria-label="Middle name"
+                className="field required"
+                data-uuid="field-2af17d9e-7432-e03a-646e-438bd9e27eeb"
+              >
+                <a
+                  aria-hidden="true"
+                  className="anchor"
+                  id="field-2af17d9e-7432-e03a-646e-438bd9e27eeb"
+                  name="field-2af17d9e-7432-e03a-646e-438bd9e27eeb"
+                />
+                <label
+                  className="title label"
+                >
+                  Middle name
+                </label>
+                <span
+                  className="icon"
+                >
+                  <a
+                    aria-label="Show help for Middle name"
+                    className="toggle label  adjust-for-labels"
+                    href="javascript:;"
+                    onClick={[Function]}
+                    title="Show help for Middle name"
+                  >
+                    <svg
+                      alt="Scalable vector graphic"
+                      focusable="false"
+                      height="14.57px"
+                      tabIndex="-1"
+                      viewBox="0 0 14.57 14.57"
+                      width="14.57px"
+                    >
+                      <g>
+                        <path
+                          className="eapp-help-icon"
+                          d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                        />
+                      </g>
+                    </svg>
+                  </a>
+                </span>
+                <div
+                  className="table expand"
+                >
+                  <span
+                    aria-live="polite"
+                    className="messages help-messages"
+                  />
+                </div>
+                <div
+                  className="table"
+                >
+                  <span
+                    className="content"
+                  >
+                    <span
+                      className="component"
+                    >
+                      <div
+                        className="middle usa-input-error"
+                      >
+                        <input
+                          aria-describedby="middle-error"
+                          aria-label={null}
+                          autoCapitalize={true}
+                          autoComplete={true}
+                          autoCorrect={true}
+                          className=""
+                          id="middle-e6e2273b-963e-6508-7e58-02b8f63f241f"
+                          maxLength="100"
+                          name="middle"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          pattern="^[a-zA-Z\\\\-\\\\.' ]*$"
+                          spellCheck={true}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                      <div
+                        className="middle-options flags"
+                      >
+                        <div
+                          className="middle-none block"
+                        >
+                          <input
+                            aria-label="No middle name for null"
+                            checked={false}
+                            className="usa-input-success"
+                            id="noMiddleName-a337cc34-13aa-e78f-d00d-dd8f7ec23139"
+                            name="noMiddleName"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="checkbox"
+                            value={false}
+                          />
+                          <label
+                            className="checkbox no-toggle"
+                            htmlFor="noMiddleName-a337cc34-13aa-e78f-d00d-dd8f7ec23139"
+                          >
+                            <span>
+                              No middle name
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="middle-initial-only block"
+                        >
+                          <input
+                            aria-label="Initial only for null"
+                            checked={false}
+                            className="usa-input-success"
+                            id="middleInitialOnly-32ebcfc4-e3c7-052e-6cae-d9e9d528550c"
+                            name="middleInitialOnly"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="checkbox"
+                            value={false}
+                          />
+                          <label
+                            className="checkbox no-toggle"
+                            htmlFor="middleInitialOnly-32ebcfc4-e3c7-052e-6cae-d9e9d528550c"
+                          >
+                            <span>
+                              Initial only
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </span>
+                  </span>
+                </div>
+                <div
+                  className="table expand"
+                >
+                  <span
+                    aria-live="polite"
+                    className="messages error-messages"
+                    role="alert"
+                  />
+                </div>
+              </div>
+              <div
+                aria-label="Last name"
+                className="field required"
+                data-uuid="field-2a95422d-bc27-4229-59f7-baa85a1ec415"
+              >
+                <a
+                  aria-hidden="true"
+                  className="anchor"
+                  id="field-2a95422d-bc27-4229-59f7-baa85a1ec415"
+                  name="field-2a95422d-bc27-4229-59f7-baa85a1ec415"
+                />
+                <label
+                  className="title label"
+                >
+                  Last name
+                </label>
+                <span
+                  className="icon"
+                >
+                  <a
+                    aria-label="Show help for Last name"
+                    className="toggle label  adjust-for-labels"
+                    href="javascript:;"
+                    onClick={[Function]}
+                    title="Show help for Last name"
+                  >
+                    <svg
+                      alt="Scalable vector graphic"
+                      focusable="false"
+                      height="14.57px"
+                      tabIndex="-1"
+                      viewBox="0 0 14.57 14.57"
+                      width="14.57px"
+                    >
+                      <g>
+                        <path
+                          className="eapp-help-icon"
+                          d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                        />
+                      </g>
+                    </svg>
+                  </a>
+                </span>
+                <div
+                  className="table expand"
+                >
+                  <span
+                    aria-live="polite"
+                    className="messages help-messages"
+                  />
+                </div>
+                <div
+                  className="table"
+                >
+                  <span
+                    className="content"
+                  >
+                    <span
+                      className="component"
+                    >
+                      <div
+                        className="last usa-input-error"
+                      >
+                        <input
+                          aria-describedby="last-error"
+                          aria-label={null}
+                          autoCapitalize={true}
+                          autoComplete={true}
+                          autoCorrect={true}
+                          className=""
+                          id="last-23c6a252-c90d-0e93-548d-d61df4bf4cc7"
+                          maxLength="100"
+                          name="last"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          pattern="^[a-zA-Z\\\\-\\\\.' ]*$"
+                          spellCheck={true}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                      <div
+                        className="flags"
+                      >
+                        <div
+                          className="last-initial-only block"
+                        >
+                          <input
+                            aria-label="Initial only for null"
+                            checked={false}
+                            className="usa-input-success"
+                            id="lastInitialOnly-b3a1c262-83a8-c19d-e2be-80f373020bfa"
+                            name="lastInitialOnly"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="checkbox"
+                            value={false}
+                          />
+                          <label
+                            className="checkbox no-toggle"
+                            htmlFor="lastInitialOnly-b3a1c262-83a8-c19d-e2be-80f373020bfa"
+                          >
+                            <span>
+                              Initial only
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </span>
+                  </span>
+                </div>
+                <div
+                  className="table expand"
+                >
+                  <span
+                    aria-live="polite"
+                    className="messages error-messages"
+                    role="alert"
+                  />
+                </div>
+              </div>
+              <div
+                aria-label="Suffix"
+                className="field"
+                data-uuid="field-5d40596a-b25b-772b-1b16-eafc7ae87078"
+              >
+                <a
+                  aria-hidden="true"
+                  className="anchor"
+                  id="field-5d40596a-b25b-772b-1b16-eafc7ae87078"
+                  name="field-5d40596a-b25b-772b-1b16-eafc7ae87078"
+                />
+                <label
+                  className="title label"
+                >
+                  Suffix
+                  <span
+                    className="optional"
+                  >
+                    (Optional)
+                  </span>
+                </label>
+                <span
+                  className="icon"
+                >
+                  <a
+                    aria-label="Show help for Suffix"
+                    className="toggle label"
+                    href="javascript:;"
+                    onClick={[Function]}
+                    title="Show help for Suffix"
+                  >
+                    <svg
+                      alt="Scalable vector graphic"
+                      focusable="false"
+                      height="14.57px"
+                      tabIndex="-1"
+                      viewBox="0 0 14.57 14.57"
+                      width="14.57px"
+                    >
+                      <g>
+                        <path
+                          className="eapp-help-icon"
+                          d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                        />
+                      </g>
+                    </svg>
+                  </a>
+                </span>
+                <div
+                  className="table expand"
+                >
+                  <span
+                    aria-live="polite"
+                    className="messages help-messages"
+                  />
+                </div>
+                <div
+                  className="table"
+                >
+                  <span
+                    className="content"
+                  >
+                    <span
+                      className="component"
+                    >
+                      <div
+                        className="blocks option-list suffix"
+                      >
+                        <div
+                          className="suffix-jr block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="suffix-02bbe7a3-7915-5121-6381-64931c6d64af"
+                          >
+                            <input
+                              aria-label="Jr for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="suffix-02bbe7a3-7915-5121-6381-64931c6d64af"
+                              name="suffix-02bbe7a3-7915-5121-6381-64931c6d64af"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="Jr"
+                            />
+                            <span>
+                              Jr
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="suffix-sr block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="suffix-273adbdd-a85c-6401-fbed-669d246f82e2"
+                          >
+                            <input
+                              aria-label="Sr for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="suffix-273adbdd-a85c-6401-fbed-669d246f82e2"
+                              name="suffix-273adbdd-a85c-6401-fbed-669d246f82e2"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="Sr"
+                            />
+                            <span>
+                              Sr
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="suffix-i block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="suffix-d4e2417b-0bf8-dffe-92b1-4c3ff71bbaf5"
+                          >
+                            <input
+                              aria-label="I for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="suffix-d4e2417b-0bf8-dffe-92b1-4c3ff71bbaf5"
+                              name="suffix-d4e2417b-0bf8-dffe-92b1-4c3ff71bbaf5"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="I"
+                            />
+                            <span>
+                              I
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="suffix-ii block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="suffix-7ef2b979-e762-6331-bcc3-bdec8e6af7ad"
+                          >
+                            <input
+                              aria-label="II for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="suffix-7ef2b979-e762-6331-bcc3-bdec8e6af7ad"
+                              name="suffix-7ef2b979-e762-6331-bcc3-bdec8e6af7ad"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="II"
+                            />
+                            <span>
+                              II
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="suffix-iii block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="suffix-d7065c6b-f9b1-c6de-a45e-0545a82dda0c"
+                          >
+                            <input
+                              aria-label="III for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="suffix-d7065c6b-f9b1-c6de-a45e-0545a82dda0c"
+                              name="suffix-d7065c6b-f9b1-c6de-a45e-0545a82dda0c"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="III"
+                            />
+                            <span>
+                              III
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="suffix-iv block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="suffix-34709925-79df-22d3-2fdd-5a6be886d293"
+                          >
+                            <input
+                              aria-label="IV for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="suffix-34709925-79df-22d3-2fdd-5a6be886d293"
+                              name="suffix-34709925-79df-22d3-2fdd-5a6be886d293"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="IV"
+                            />
+                            <span>
+                              IV
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="suffix-v block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="suffix-4f459903-0ace-9b3c-aa1d-0c5c34d2adc7"
+                          >
+                            <input
+                              aria-label="V for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="suffix-4f459903-0ace-9b3c-aa1d-0c5c34d2adc7"
+                              name="suffix-4f459903-0ace-9b3c-aa1d-0c5c34d2adc7"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="V"
+                            />
+                            <span>
+                              V
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="suffix-vi block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="suffix-29de6bb3-587d-9cbd-1d28-23b2e86717f2"
+                          >
+                            <input
+                              aria-label="VI for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="suffix-29de6bb3-587d-9cbd-1d28-23b2e86717f2"
+                              name="suffix-29de6bb3-587d-9cbd-1d28-23b2e86717f2"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="VI"
+                            />
+                            <span>
+                              VI
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="suffix-vii block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="suffix-a15b83d6-5bac-3e90-fab7-0b8bfe518494"
+                          >
+                            <input
+                              aria-label="VII for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="suffix-a15b83d6-5bac-3e90-fab7-0b8bfe518494"
+                              name="suffix-a15b83d6-5bac-3e90-fab7-0b8bfe518494"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="VII"
+                            />
+                            <span>
+                              VII
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="suffix-viii block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="suffix-a03b3670-bee8-87c4-9e7e-167a7e88b9f2"
+                          >
+                            <input
+                              aria-label="VIII for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="suffix-a03b3670-bee8-87c4-9e7e-167a7e88b9f2"
+                              name="suffix-a03b3670-bee8-87c4-9e7e-167a7e88b9f2"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="VIII"
+                            />
+                            <span>
+                              VIII
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="suffix-ix block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="suffix-b522afbb-4412-8e31-aed3-9fe4851ddf7d"
+                          >
+                            <input
+                              aria-label="IX for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="suffix-b522afbb-4412-8e31-aed3-9fe4851ddf7d"
+                              name="suffix-b522afbb-4412-8e31-aed3-9fe4851ddf7d"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="IX"
+                            />
+                            <span>
+                              IX
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="suffix-x block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="suffix-25aa9ad1-9521-bcee-81f5-b24c52e75fc3"
+                          >
+                            <input
+                              aria-label="X for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="suffix-25aa9ad1-9521-bcee-81f5-b24c52e75fc3"
+                              name="suffix-25aa9ad1-9521-bcee-81f5-b24c52e75fc3"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="X"
+                            />
+                            <span>
+                              X
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="suffix-more block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="suffix-ae2adaa3-41bf-74ec-6afc-6cf79bd20b2c"
+                          >
+                            <input
+                              aria-label="Other for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="suffix-ae2adaa3-41bf-74ec-6afc-6cf79bd20b2c"
+                              name="suffix-ae2adaa3-41bf-74ec-6afc-6cf79bd20b2c"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="Other"
+                            />
+                            <span>
+                              Other
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </span>
+                  </span>
+                </div>
+                <div
+                  className="table expand"
+                >
+                  <span
+                    aria-live="polite"
+                    className="messages error-messages"
+                    role="alert"
+                  />
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error"
+            role="alert"
+          >
+            <i
+              aria-hidden="true"
+              className="fa fa-exclamation"
+            />
+            <div
+              data-i18n="error.name.first.required"
+            >
+              <h5>
+                Oops, there’s a problem.
+              </h5>
+              <span>
+                <div>
+                  <p>
+                    If your first name is a single letter, please select the "Initial only" checkbox and type the letter. 100 character limit.
+                  </p>
+                </div>
+              </span>
+              
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="section-divider"
+  />
+  <div
+    className="section-content other-names"
+    data-section="identification"
+    data-subsection="othernames"
+  >
+    <div
+      aria-label="Provide your other names used and the period of time you used them"
+      className="field   no-margin-bottom"
+      data-uuid="field-686477be-609c-4562-b2df-b191d36cd20c"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-686477be-609c-4562-b2df-b191d36cd20c"
+        name="field-686477be-609c-4562-b2df-b191d36cd20c"
+      />
+      <h2
+        className="title h2"
+      >
+        Provide your other names used and the period of time you used them
+      </h2>
+      <span
+        className="icon"
+      >
+        <a
+          aria-label="Show help for Provide your other names used and the period of time you used them"
+          className="toggle h2"
+          href="javascript:;"
+          onClick={[Function]}
+          title="Show help for Provide your other names used and the period of time you used them"
+        >
+          <svg
+            alt="Scalable vector graphic"
+            focusable="false"
+            height="14.57px"
+            tabIndex="-1"
+            viewBox="0 0 14.57 14.57"
+            width="14.57px"
+          >
+            <g>
+              <path
+                className="eapp-help-icon"
+                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+              />
+            </g>
+          </svg>
+        </a>
+      </span>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component"
+          >
+            <div>
+              <p>
+                For example: your maiden name, name(s) by a former marriage, former name(s), alias(es), or nickname(s).
+              </p>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        />
+      </div>
+    </div>
+    <div
+      aria-label="Have you used any other names?"
+      className="field required  branch"
+      data-uuid="field-ac3f2a46-eb1e-6320-d1ec-2389b3ce6162"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-ac3f2a46-eb1e-6320-d1ec-2389b3ce6162"
+        name="field-ac3f2a46-eb1e-6320-d1ec-2389b3ce6162"
+      />
+      <h3
+        className="title h3"
+      >
+        Have you used any other names?
+      </h3>
+      <span
+        className="icon"
+      />
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component shrink"
+          >
+            <div
+              className="content"
+            />
+            <div
+              className="blocks option-list branch usa-input-error"
+            >
+              <div
+                className="yes block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_othernames-ccd9d479-7c07-fe8a-f836-afb0cf699a87"
+                >
+                  <input
+                    aria-label="Yes for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_othernames-ccd9d479-7c07-fe8a-f836-afb0cf699a87"
+                    name="has_othernames-ccd9d479-7c07-fe8a-f836-afb0cf699a87"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="Yes"
+                  />
+                  <span>
+                    Yes
+                  </span>
+                </label>
+              </div>
+              <div
+                className="no block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_othernames-38f0ff7d-2157-790d-e7c5-6c4d181c9ca0"
+                >
+                  <input
+                    aria-label="No for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_othernames-38f0ff7d-2157-790d-e7c5-6c4d181c9ca0"
+                    name="has_othernames-38f0ff7d-2157-790d-e7c5-6c4d181c9ca0"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="No"
+                  />
+                  <span>
+                    No
+                  </span>
+                </label>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error"
+            role="alert"
+          >
+            <i
+              aria-hidden="true"
+              className="fa fa-exclamation"
+            />
+            <div
+              data-i18n="error.required"
+            >
+              <h5>
+                Your response is required
+              </h5>
+              
+              
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="section-divider"
+  />
+  <div
+    className="section-content contact"
+    data-section="identification"
+    data-subsection="contacts"
+  >
+    <div
+      aria-label="Provide your contact information"
+      className="field   no-margin-bottom"
+      data-uuid="field-56d66d23-3de8-33eb-e165-2c8d5cb8f76c"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-56d66d23-3de8-33eb-e165-2c8d5cb8f76c"
+        name="field-56d66d23-3de8-33eb-e165-2c8d5cb8f76c"
+      />
+      <h2
+        className="title h2"
+      >
+        Provide your contact information
+      </h2>
+      <span
+        className="icon"
+      />
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component"
+          />
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        />
+      </div>
+    </div>
+    <div
+      aria-label="Your email addresses"
+      className="field   no-margin-bottom"
+      data-uuid="field-33e49949-bdfe-2474-04eb-800fc9c47987"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-33e49949-bdfe-2474-04eb-800fc9c47987"
+        name="field-33e49949-bdfe-2474-04eb-800fc9c47987"
+      />
+      <h3
+        className="title h3"
+      >
+        Your email addresses
+      </h3>
+      <span
+        className="icon"
+      >
+        <a
+          aria-label="Show help for Your email addresses"
+          className="toggle h3"
+          href="javascript:;"
+          onClick={[Function]}
+          title="Show help for Your email addresses"
+        >
+          <svg
+            alt="Scalable vector graphic"
+            focusable="false"
+            height="14.57px"
+            tabIndex="-1"
+            viewBox="0 0 14.57 14.57"
+            width="14.57px"
+          >
+            <g>
+              <path
+                className="eapp-help-icon"
+                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+              />
+            </g>
+          </svg>
+        </a>
+      </span>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component"
+          >
+            <div>
+              <p>
+                Providing email addresses may assist in the completion of your background investigation. Email addresses may be used as contact method, and identify subject in records.
+              </p>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        />
+      </div>
+    </div>
+    <div
+      className=" email-collection"
+    >
+      <div>
+        <div
+          className="accordion"
+        >
+          <strong
+            className="aria-description"
+          >
+            Summary of email addresses
+          </strong>
+          <div
+            className="items"
+          />
+          <div
+            className="append-button"
+          >
+            <button
+              className="add usa-button-outline"
+              onClick={[Function]}
+            >
+              Add another email
+              <i
+                className="fa fa-plus-circle"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      aria-label="Your phone numbers"
+      className="field   no-margin-bottom"
+      data-uuid="field-e3f0acb9-94ba-da49-4c32-26c4337c16ec"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-e3f0acb9-94ba-da49-4c32-26c4337c16ec"
+        name="field-e3f0acb9-94ba-da49-4c32-26c4337c16ec"
+      />
+      <h3
+        className="title h3"
+      >
+        Your phone numbers
+      </h3>
+      <span
+        className="icon"
+      >
+        <a
+          aria-label="Show help for Your phone numbers"
+          className="toggle h3"
+          href="javascript:;"
+          onClick={[Function]}
+          title="Show help for Your phone numbers"
+        >
+          <svg
+            alt="Scalable vector graphic"
+            focusable="false"
+            height="14.57px"
+            tabIndex="-1"
+            viewBox="0 0 14.57 14.57"
+            width="14.57px"
+          >
+            <g>
+              <path
+                className="eapp-help-icon"
+                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+              />
+            </g>
+          </svg>
+        </a>
+      </span>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component"
+          >
+            <div>
+              <p>
+                Provide three contact numbers. 
+                <strong>
+                  At least one number is required
+                </strong>
+                . Additional numbers may assist in the completion of your background investigation.
+              </p>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        />
+      </div>
+    </div>
+    <div
+      className=" telephone-collection"
+    >
+      <div>
+        <div
+          className="accordion"
+        >
+          <strong
+            className="aria-description"
+          >
+            Summary of phone numbers
+          </strong>
+          <div
+            className="items"
+          />
+          <div
+            className="append-button"
+          >
+            <button
+              className="add usa-button-outline"
+              onClick={[Function]}
+            >
+              Add another phone number
+              <i
+                className="fa fa-plus-circle"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="section-divider"
+  />
+  <div
+    className="section-content birthdate"
+    data-section="identification"
+    data-subsection="birthdate"
+  >
+    <div
+      aria-label="Provide your date of birth"
+      className="field required"
+      data-uuid="field-17322a69-b023-2667-66d6-96ab5fba21ec"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-17322a69-b023-2667-66d6-96ab5fba21ec"
+        name="field-17322a69-b023-2667-66d6-96ab5fba21ec"
+      />
+      <h2
+        className="title h2"
+      >
+        Provide your date of birth
+      </h2>
+      <span
+        className="icon"
+      >
+        <a
+          aria-label="Show help for Provide your date of birth"
+          className="toggle h2"
+          href="javascript:;"
+          onClick={[Function]}
+          title="Show help for Provide your date of birth"
+        >
+          <svg
+            alt="Scalable vector graphic"
+            focusable="false"
+            height="14.57px"
+            tabIndex="-1"
+            viewBox="0 0 14.57 14.57"
+            width="14.57px"
+          >
+            <g>
+              <path
+                className="eapp-help-icon"
+                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+              />
+            </g>
+          </svg>
+        </a>
+      </span>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component"
+          >
+            <div
+              className="datecontrol"
+            >
+              <div>
+                <div
+                  className="usa-form-group month"
+                >
+                  <div
+                    className="usa-input-error"
+                  >
+                    <label
+                      className="usa-input-error-label"
+                      htmlFor="month-ca35d542-6fac-6fa2-c7e4-3649193ae4eb"
+                    >
+                      Month
+                    </label>
+                    <input
+                      aria-describedby="month-error"
+                      aria-label="Month"
+                      autoCapitalize={true}
+                      autoComplete={true}
+                      autoCorrect={true}
+                      className=""
+                      disabled={false}
+                      id="month-ca35d542-6fac-6fa2-c7e4-3649193ae4eb"
+                      maxLength="2"
+                      name="month"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      pattern="^(\\\\s*|\\\\d+)$"
+                      placeholder="##"
+                      spellCheck={true}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  className="usa-form-group day "
+                >
+                  <div
+                    className="usa-input-error"
+                  >
+                    <label
+                      className="usa-input-error-label"
+                      htmlFor="day-98d38d86-f8bd-6af7-d2c6-9f7cc14cf465"
+                    >
+                      Day
+                    </label>
+                    <input
+                      aria-describedby="day-error"
+                      aria-label="Day"
+                      autoCapitalize={true}
+                      autoComplete={true}
+                      autoCorrect={true}
+                      className=""
+                      disabled={false}
+                      id="day-98d38d86-f8bd-6af7-d2c6-9f7cc14cf465"
+                      maxLength="2"
+                      name="day"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      pattern="^(\\\\s*|\\\\d+)$"
+                      placeholder="##"
+                      spellCheck={true}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  className="usa-form-group year"
+                >
+                  <div
+                    className="usa-input-error"
+                  >
+                    <label
+                      className="usa-input-error-label"
+                      htmlFor="year-69d31213-beae-4010-c686-66682f240de2"
+                    >
+                      Year
+                    </label>
+                    <input
+                      aria-describedby="year-error"
+                      aria-label="Year"
+                      autoCapitalize={true}
+                      autoComplete={true}
+                      autoCorrect={true}
+                      className=""
+                      disabled={false}
+                      id="year-69d31213-beae-4010-c686-66682f240de2"
+                      maxLength="4"
+                      name="year"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      pattern="^(\\\\s*|\\\\d+)$"
+                      placeholder="####"
+                      spellCheck={true}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                className="flags"
+              >
+                <div
+                  className="estimated block"
+                >
+                  <input
+                    aria-label="Estimated for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="estimated-aef1e7a8-e6a4-d973-127b-94cee9ed835c"
+                    name="estimated"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="checkbox"
+                    value={false}
+                  />
+                  <label
+                    className="checkbox no-toggle"
+                    htmlFor="estimated-aef1e7a8-e6a4-d973-127b-94cee9ed835c"
+                  >
+                    <span>
+                      Estimated
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error"
+            role="alert"
+          >
+            <i
+              aria-hidden="true"
+              className="fa fa-exclamation"
+            />
+            <div
+              data-i18n="error.date.required"
+            >
+              <h5>
+                Your response is required
+              </h5>
+              <span>
+                <div>
+                  <p>
+                    All parts of the date are required even if it is 
+                    <strong>
+                      estimated
+                    </strong>
+                    .
+                  </p>
+                </div>
+              </span>
+              
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="section-divider"
+  />
+  <div
+    className="section-content applicant-birthplace"
+    data-section="identification"
+    data-subsection="birthplace"
+  >
+    <div
+      aria-label="Provide your place of birth"
+      className="field required"
+      data-uuid="field-0dee195b-9024-1543-d179-c1d03c92f2ba"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-0dee195b-9024-1543-d179-c1d03c92f2ba"
+        name="field-0dee195b-9024-1543-d179-c1d03c92f2ba"
+      />
+      <h2
+        className="title h2"
+      >
+        Provide your place of birth
+      </h2>
+      <span
+        className="icon"
+      />
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component"
+          >
+            <div
+              className="location"
+            >
+              <div
+                className="fields"
+              >
+                <div
+                  className="toggleable-location"
+                >
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <label>
+                      Were you born in the United States?
+                    </label>
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="birthplace-620932e0-0374-f2ce-5d5d-766f5f5673b7"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="birthplace-620932e0-0374-f2ce-5d5d-766f5f5673b7"
+                          name="birthplace-620932e0-0374-f2ce-5d5d-766f5f5673b7"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="birthplace-2aa4688b-44b1-4051-171b-e4a9eb2fd840"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="birthplace-2aa4688b-44b1-4051-171b-e4a9eb2fd840"
+                          name="birthplace-2aa4688b-44b1-4051-171b-e4a9eb2fd840"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error"
+            role="alert"
+          >
+            <i
+              aria-hidden="true"
+              className="fa fa-exclamation"
+            />
+            <div
+              data-i18n="error.location.required"
+            >
+              <h5>
+                Your response is required
+              </h5>
+              
+              
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="section-divider"
+  />
+  <div
+    className="section-content applicant-ssn"
+    data-section="identification"
+    data-subsection="ssn"
+  >
+    <div
+      aria-label="Provide your U.S. Social Security Number"
+      className="field required"
+      data-uuid="field-f311f590-283b-8833-2a53-37eae29aeb13"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-f311f590-283b-8833-2a53-37eae29aeb13"
+        name="field-f311f590-283b-8833-2a53-37eae29aeb13"
+      />
+      <h2
+        className="title h2"
+      >
+        Provide your U.S. Social Security Number
+      </h2>
+      <span
+        className="icon"
+      >
+        <a
+          aria-label="Show help for Provide your U.S. Social Security Number"
+          className="toggle h2"
+          href="javascript:;"
+          onClick={[Function]}
+          title="Show help for Provide your U.S. Social Security Number"
+        >
+          <svg
+            alt="Scalable vector graphic"
+            focusable="false"
+            height="14.57px"
+            tabIndex="-1"
+            viewBox="0 0 14.57 14.57"
+            width="14.57px"
+          >
+            <g>
+              <path
+                className="eapp-help-icon"
+                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+              />
+            </g>
+          </svg>
+        </a>
+      </span>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component"
+          >
+            <div
+              className="ssn applicant-ssn-initial"
+            >
+              <div
+                className="first eapp-short-input usa-input-error"
+              >
+                <input
+                  aria-describedby="first-error"
+                  aria-label={null}
+                  autoCapitalize={true}
+                  autoComplete={true}
+                  autoCorrect={true}
+                  className=""
+                  disabled={false}
+                  id="first-522086b6-9ae4-6216-75af-26668c297a3d"
+                  maxLength="3"
+                  name="first"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onCopy={[Function]}
+                  onCut={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onPaste={[Function]}
+                  pattern="^[0-9]{3}$"
+                  placeholder="###"
+                  spellCheck={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="middle eapp-short-input usa-input-error"
+              >
+                <input
+                  aria-describedby="middle-error"
+                  aria-label={null}
+                  autoCapitalize={true}
+                  autoComplete={true}
+                  autoCorrect={true}
+                  className=""
+                  disabled={false}
+                  id="middle-8be7bafd-508a-9f68-fd3b-70c3890d1207"
+                  maxLength="2"
+                  name="middle"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onCopy={[Function]}
+                  onCut={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onPaste={[Function]}
+                  pattern="^[0-9]{2}$"
+                  placeholder="##"
+                  spellCheck={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="last eapp-short-input usa-input-error"
+              >
+                <input
+                  aria-describedby="last-error"
+                  aria-label={null}
+                  autoCapitalize={true}
+                  autoComplete={true}
+                  autoCorrect={true}
+                  className=""
+                  disabled={false}
+                  id="last-d34507e7-c366-c3dc-8d94-dac3ece55cd2"
+                  maxLength="4"
+                  name="last"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onCopy={[Function]}
+                  onCut={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onPaste={[Function]}
+                  pattern="^[0-9]{4}$"
+                  placeholder="####"
+                  spellCheck={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="flags"
+              >
+                <div
+                  className="not-applicable block"
+                >
+                  <input
+                    aria-label="Not applicable for null"
+                    checked={false}
+                    className="usa-input-success"
+                    id="notApplicable-ac19fdc2-4489-1890-0a62-cf4d1234e07f"
+                    name="notApplicable"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="checkbox"
+                    value={false}
+                  />
+                  <label
+                    className="checkbox no-toggle"
+                    htmlFor="notApplicable-ac19fdc2-4489-1890-0a62-cf4d1234e07f"
+                  >
+                    <span>
+                      Not applicable
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error"
+            role="alert"
+          >
+            <i
+              aria-hidden="true"
+              className="fa fa-exclamation"
+            />
+            <div
+              data-i18n="error.ssn.required"
+            >
+              <h5>
+                Your response is required
+              </h5>
+              
+              
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="section-divider"
+  />
+  <div
+    className="section-content physical"
+    data-section="identification"
+    data-subsection="physical"
+  >
+    <div
+      aria-label="Provide your identifying information"
+      className="field   no-margin-bottom"
+      data-uuid="field-e392d3b0-fa75-b219-7ea9-c08822b1bbc7"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-e392d3b0-fa75-b219-7ea9-c08822b1bbc7"
+        name="field-e392d3b0-fa75-b219-7ea9-c08822b1bbc7"
+      />
+      <h2
+        className="title h2"
+      >
+        Provide your identifying information
+      </h2>
+      <span
+        className="icon"
+      />
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component"
+          />
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        />
+      </div>
+    </div>
+    <div
+      aria-label="Height"
+      className="field required"
+      data-uuid="field-3bcda601-1d10-5809-d5bc-1f829d7fa490"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-3bcda601-1d10-5809-d5bc-1f829d7fa490"
+        name="field-3bcda601-1d10-5809-d5bc-1f829d7fa490"
+      />
+      <h3
+        className="title h3"
+      >
+        Height
+      </h3>
+      <span
+        className="icon"
+      >
+        <a
+          aria-label="Show help for Height"
+          className="toggle h3  adjust-for-labels"
+          href="javascript:;"
+          onClick={[Function]}
+          title="Show help for Height"
+        >
+          <svg
+            alt="Scalable vector graphic"
+            focusable="false"
+            height="14.57px"
+            tabIndex="-1"
+            viewBox="0 0 14.57 14.57"
+            width="14.57px"
+          >
+            <g>
+              <path
+                className="eapp-help-icon"
+                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+              />
+            </g>
+          </svg>
+        </a>
+      </span>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component shrink"
+          >
+            <div
+              className="height"
+            >
+              <div
+                className="feet"
+              >
+                <div
+                  className="usa-input-error"
+                >
+                  <label
+                    className="usa-input-error-label"
+                    htmlFor="feet-3e633e2d-4583-ed68-183a-43c239870d80"
+                  >
+                    Feet
+                  </label>
+                  <input
+                    aria-describedby="feet-error"
+                    aria-label="Feet"
+                    autoCapitalize={true}
+                    autoComplete={true}
+                    autoCorrect={true}
+                    className=""
+                    disabled={false}
+                    id="feet-3e633e2d-4583-ed68-183a-43c239870d80"
+                    maxLength="1"
+                    name="feet"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    pattern="^(\\\\s*|\\\\d+)$"
+                    placeholder="#"
+                    spellCheck={true}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+              <div
+                className="inches"
+              >
+                <div
+                  className="usa-input-error"
+                >
+                  <label
+                    className="usa-input-error-label"
+                    htmlFor="inches-8d4d5ec7-3659-a42d-d1ff-1bbec0a36b12"
+                  >
+                    Inches
+                  </label>
+                  <input
+                    aria-describedby="inches-error"
+                    aria-label="Inches"
+                    autoCapitalize={true}
+                    autoComplete={true}
+                    autoCorrect={true}
+                    className=""
+                    disabled={false}
+                    id="inches-8d4d5ec7-3659-a42d-d1ff-1bbec0a36b12"
+                    maxLength="2"
+                    name="inches"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    pattern="^(\\\\s*|\\\\d+)$"
+                    placeholder="##"
+                    spellCheck={true}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error"
+            role="alert"
+          >
+            <i
+              aria-hidden="true"
+              className="fa fa-exclamation"
+            />
+            <div
+              data-i18n="error.height.required"
+            >
+              <h5>
+                Your response is required
+              </h5>
+              
+              
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+    <div
+      aria-label="Weight"
+      className="field required"
+      data-uuid="field-0fe2e5ef-cacf-987d-bc61-1f2d878ce509"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-0fe2e5ef-cacf-987d-bc61-1f2d878ce509"
+        name="field-0fe2e5ef-cacf-987d-bc61-1f2d878ce509"
+      />
+      <h3
+        className="title h3"
+      >
+        Weight
+      </h3>
+      <span
+        className="icon"
+      >
+        <a
+          aria-label="Show help for Weight"
+          className="toggle h3  adjust-for-labels"
+          href="javascript:;"
+          onClick={[Function]}
+          title="Show help for Weight"
+        >
+          <svg
+            alt="Scalable vector graphic"
+            focusable="false"
+            height="14.57px"
+            tabIndex="-1"
+            viewBox="0 0 14.57 14.57"
+            width="14.57px"
+          >
+            <g>
+              <path
+                className="eapp-help-icon"
+                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+              />
+            </g>
+          </svg>
+        </a>
+      </span>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component shrink"
+          >
+            <div
+              className="weight"
+            >
+              <div
+                className="pounds"
+              >
+                <div
+                  className="usa-input-error"
+                >
+                  <label
+                    className="usa-input-error-label"
+                    htmlFor="pounds-04461680-21db-98a1-3403-ddd579cf0676"
+                  >
+                    Pounds
+                  </label>
+                  <input
+                    aria-describedby="pounds-error"
+                    aria-label="Pounds"
+                    autoCapitalize={true}
+                    autoComplete={true}
+                    autoCorrect={true}
+                    className=""
+                    disabled={false}
+                    id="pounds-04461680-21db-98a1-3403-ddd579cf0676"
+                    maxLength="3"
+                    name="pounds"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    pattern="^(\\\\s*|\\\\d+)$"
+                    placeholder="###"
+                    spellCheck={true}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error"
+            role="alert"
+          >
+            <i
+              aria-hidden="true"
+              className="fa fa-exclamation"
+            />
+            <div
+              data-i18n="error.weight.required"
+            >
+              <h5>
+                Your response is required
+              </h5>
+              
+              
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+    <div
+      aria-label="Hair color"
+      className="field required"
+      data-uuid="field-98a063d9-0d1d-8516-7fa7-b7c04e7e7838"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-98a063d9-0d1d-8516-7fa7-b7c04e7e7838"
+        name="field-98a063d9-0d1d-8516-7fa7-b7c04e7e7838"
+      />
+      <h3
+        className="title h3"
+      >
+        Hair color
+      </h3>
+      <span
+        className="icon"
+      >
+        <a
+          aria-label="Show help for Hair color"
+          className="toggle h3  adjust-for-big-buttons"
+          href="javascript:;"
+          onClick={[Function]}
+          title="Show help for Hair color"
+        >
+          <svg
+            alt="Scalable vector graphic"
+            focusable="false"
+            height="14.57px"
+            tabIndex="-1"
+            viewBox="0 0 14.57 14.57"
+            width="14.57px"
+          >
+            <g>
+              <path
+                className="eapp-help-icon"
+                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+              />
+            </g>
+          </svg>
+        </a>
+      </span>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component"
+          >
+            <div
+              className=" hair-colors"
+            >
+              <label />
+              <div
+                className="blocks option-list eapp-extend-labels usa-input-error"
+              >
+                <div
+                  className="black block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="hair-black-14545dbf-8df8-5791-77dc-f77df54b500f"
+                  >
+                    <input
+                      aria-label="Black for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="hair-black-14545dbf-8df8-5791-77dc-f77df54b500f"
+                      name="hair-black-14545dbf-8df8-5791-77dc-f77df54b500f"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Black"
+                    />
+                    <div
+                      className="hair-icon black"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 18 32"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 18 32"
+                      >
+                        <path
+                          d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Black
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="brown block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="hair-brown-7e808598-da63-9740-524f-14cba5dd8dd0"
+                  >
+                    <input
+                      aria-label="Brown for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="hair-brown-7e808598-da63-9740-524f-14cba5dd8dd0"
+                      name="hair-brown-7e808598-da63-9740-524f-14cba5dd8dd0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Brown"
+                    />
+                    <div
+                      className="hair-icon brown"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 18 32"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 18 32"
+                      >
+                        <path
+                          d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Brown
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="red block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="hair-red-668901ba-cfe5-689c-86ae-800012020ecd"
+                  >
+                    <input
+                      aria-label="Red or auburn for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="hair-red-668901ba-cfe5-689c-86ae-800012020ecd"
+                      name="hair-red-668901ba-cfe5-689c-86ae-800012020ecd"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Red"
+                    />
+                    <div
+                      className="hair-icon red"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 18 32"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 18 32"
+                      >
+                        <path
+                          d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Red or auburn
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="blonde block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="hair-blonde-c0b244d9-ba2b-bbdf-1f62-e0de3c2be4a0"
+                  >
+                    <input
+                      aria-label="Blonde or strawberry for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="hair-blonde-c0b244d9-ba2b-bbdf-1f62-e0de3c2be4a0"
+                      name="hair-blonde-c0b244d9-ba2b-bbdf-1f62-e0de3c2be4a0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Blonde"
+                    />
+                    <div
+                      className="hair-icon blonde"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 18 32"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 18 32"
+                      >
+                        <path
+                          d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Blonde or strawberry
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="sandy block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="hair-sandy-abab06ef-c7d8-cc12-3a7c-61915b6c1166"
+                  >
+                    <input
+                      aria-label="Sandy for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="hair-sandy-abab06ef-c7d8-cc12-3a7c-61915b6c1166"
+                      name="hair-sandy-abab06ef-c7d8-cc12-3a7c-61915b6c1166"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Sandy"
+                    />
+                    <div
+                      className="hair-icon sandy"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 18 32"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 18 32"
+                      >
+                        <path
+                          d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Sandy
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="gray block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="hair-gray-e42a72e4-8b60-8ab5-5034-7bf9e709f17e"
+                  >
+                    <input
+                      aria-label="Gray or partially gray for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="hair-gray-e42a72e4-8b60-8ab5-5034-7bf9e709f17e"
+                      name="hair-gray-e42a72e4-8b60-8ab5-5034-7bf9e709f17e"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Gray"
+                    />
+                    <div
+                      className="hair-icon gray"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 18 32"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 18 32"
+                      >
+                        <path
+                          d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Gray or partially gray
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="white block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="hair-white-a30c47c7-7b4f-8e1c-392d-a8f0b95f3e33"
+                  >
+                    <input
+                      aria-label="White for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="hair-white-a30c47c7-7b4f-8e1c-392d-a8f0b95f3e33"
+                      name="hair-white-a30c47c7-7b4f-8e1c-392d-a8f0b95f3e33"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="White"
+                    />
+                    <div
+                      className="hair-icon white"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 18 32"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 18 32"
+                      >
+                        <path
+                          d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      White
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="bald block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="hair-bald-23a49db7-9356-1fe1-ee48-bc7541774056"
+                  >
+                    <input
+                      aria-label="Bald for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="hair-bald-23a49db7-9356-1fe1-ee48-bc7541774056"
+                      name="hair-bald-23a49db7-9356-1fe1-ee48-bc7541774056"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Bald"
+                    />
+                    <div
+                      className="hair-icon bald"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 18.01 30.87"
+                      >
+                        <path
+                          d="M11.571,30.953h-1.328L10.04,30.9c-0.377-0.188-0.754-0.378-1.226-0.566l0.371-0.928 c0.018,0.007,0.035,0.014,0.051,0.021c-0.007-0.018-0.014-0.034-0.021-0.052l0.928-0.371c0.173,0.431,0.351,0.877,0.569,1.095 L11.571,30.953z"
+                        />
+                        <path
+                          d="M6.4,28.932c-0.853-0.538-1.63-1.108-2.31-1.696l0.653-0.756c0.643,0.555,1.379,1.095,2.189,1.606L6.4,28.932 z M2.102,25.136c-0.599-0.789-1.088-1.638-1.456-2.521L1.57,22.23c0.334,0.806,0.782,1.58,1.329,2.302L2.102,25.136z M-0.118,19.807c-0.086-0.607-0.13-1.244-0.13-1.893c0-0.352,0.018-0.688,0.053-1.013l0.994,0.107 c-0.031,0.289-0.047,0.591-0.047,0.905c0,0.602,0.041,1.19,0.121,1.752L-0.118,19.807z M1.53,14.525l-0.891-0.454 c0.418-0.819,0.987-1.591,1.739-2.36l0.715,0.699C2.413,13.105,1.901,13.797,1.53,14.525z M5.152,10.626L4.537,9.838l0.451-0.35 c0.61-0.472,1.186-0.918,1.697-1.38L7.355,8.85c-0.54,0.488-1.13,0.946-1.756,1.43L5.152,10.626z M9.168,6.477L8.243,6.095 C8.416,5.677,8.5,5.25,8.5,4.791c0-0.332-0.05-0.744-0.138-1.13l0.975-0.222C9.44,3.895,9.5,4.388,9.5,4.791 C9.5,5.375,9.388,5.943,9.168,6.477z"
+                        />
+                        <path
+                          d="M7.855,1.963C7.666,1.491,7.478,1.018,7.289,0.64L6.928-0.083h0.927l0.203,0.053 c0.381,0.19,0.757,0.379,1.226,0.566L8.912,1.464C8.838,1.435,8.767,1.405,8.697,1.376C8.726,1.448,8.755,1.52,8.784,1.592 L7.855,1.963z"
+                        />
+                        <path
+                          d="M8.667,27.461C8.556,27.004,8.5,26.539,8.5,26.079c0-0.576,0.104-1.134,0.31-1.656l0.931,0.365 C9.579,25.2,9.5,25.622,9.5,26.079c0,0.381,0.046,0.767,0.138,1.147L8.667,27.461z M11.267,22.762l-0.676-0.738 c0.563-0.516,1.186-0.994,1.845-1.501l0.361-0.278l0.611,0.791l-0.363,0.28C12.404,21.809,11.798,22.274,11.267,22.762z M15.579,19.179l-0.709-0.705c0.687-0.688,1.203-1.375,1.581-2.1l0.887,0.463C16.913,17.652,16.337,18.418,15.579,19.179z M18.191,14.012l-0.994-0.112c0.034-0.301,0.052-0.615,0.052-0.943c0-0.585-0.038-1.162-0.111-1.714l0.99-0.133 c0.08,0.596,0.121,1.217,0.121,1.847C18.249,13.323,18.229,13.675,18.191,14.012z M16.469,8.668 c-0.326-0.812-0.763-1.59-1.299-2.315l0.803-0.595c0.588,0.793,1.066,1.646,1.424,2.538L16.469,8.668z M13.345,4.394 c-0.638-0.558-1.372-1.099-2.182-1.61l0.533-0.846c0.854,0.539,1.63,1.112,2.307,1.703L13.345,4.394z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Bald
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="blue block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="hair-blue-410d7595-0d37-f63b-d051-aeae458ac3ce"
+                  >
+                    <input
+                      aria-label="Blue for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="hair-blue-410d7595-0d37-f63b-d051-aeae458ac3ce"
+                      name="hair-blue-410d7595-0d37-f63b-d051-aeae458ac3ce"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Blue"
+                    />
+                    <div
+                      className="hair-icon blue"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 18 32"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 18 32"
+                      >
+                        <path
+                          d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Blue
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="green block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="hair-green-4f299c2f-0ef1-4c68-e5d8-c0e9a8d8110f"
+                  >
+                    <input
+                      aria-label="Green for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="hair-green-4f299c2f-0ef1-4c68-e5d8-c0e9a8d8110f"
+                      name="hair-green-4f299c2f-0ef1-4c68-e5d8-c0e9a8d8110f"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Green"
+                    />
+                    <div
+                      className="hair-icon green"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 18 32"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 18 32"
+                      >
+                        <path
+                          d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Green
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="orange block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="hair-orange-33154e4c-24bb-bd3f-2659-c9ce425463e0"
+                  >
+                    <input
+                      aria-label="Orange for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="hair-orange-33154e4c-24bb-bd3f-2659-c9ce425463e0"
+                      name="hair-orange-33154e4c-24bb-bd3f-2659-c9ce425463e0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Orange"
+                    />
+                    <div
+                      className="hair-icon orange"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 18 32"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 18 32"
+                      >
+                        <path
+                          d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Orange
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="pink block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="hair-pink-ded662a9-a406-2593-b3d7-551dc1db9dcc"
+                  >
+                    <input
+                      aria-label="Pink for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="hair-pink-ded662a9-a406-2593-b3d7-551dc1db9dcc"
+                      name="hair-pink-ded662a9-a406-2593-b3d7-551dc1db9dcc"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Pink"
+                    />
+                    <div
+                      className="hair-icon pink"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 18 32"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 18 32"
+                      >
+                        <path
+                          d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Pink
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="purple block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="hair-purple-81184543-eeb3-2131-e3a1-6dfec555f9c3"
+                  >
+                    <input
+                      aria-label="Purple for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="hair-purple-81184543-eeb3-2131-e3a1-6dfec555f9c3"
+                      name="hair-purple-81184543-eeb3-2131-e3a1-6dfec555f9c3"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Purple"
+                    />
+                    <div
+                      className="hair-icon purple"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 18 32"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 18 32"
+                      >
+                        <path
+                          d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Purple
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="unknown block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="hair-unknown-d4e1d88e-4e42-a050-88e5-2994b404c6af"
+                  >
+                    <input
+                      aria-label="Unspecified or unknown for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="hair-unknown-d4e1d88e-4e42-a050-88e5-2994b404c6af"
+                      name="hair-unknown-d4e1d88e-4e42-a050-88e5-2994b404c6af"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Unknown"
+                    />
+                    <div
+                      className="hair-icon unknown"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 30.86 36.84"
+                      >
+                        <path
+                          d="M15.43,34.25C6.91,34.25,0,27.34,0,18.82C0,10.3,6.91,3.39,15.43,3.39s15.43,6.91,15.43,15.43 C30.87,27.34,23.95,34.25,15.43,34.25z M15.84,8.53c-3.28,0-5.73,1.41-7.46,4.28c-0.18,0.28-0.1,0.64,0.16,0.84l2.65,2.01 c0.1,0.08,0.24,0.12,0.38,0.12c0.18,0,0.38-0.08,0.5-0.24c0.94-1.21,1.35-1.57,1.73-1.85c0.34-0.24,1-0.48,1.73-0.48 c1.29,0,2.47,0.82,2.47,1.71c0,1.04-0.54,1.57-1.77,2.13c-1.43,0.64-3.38,2.31-3.38,4.26v0.72c0,0.36,0.28,0.64,0.64,0.64h3.86 c0.36,0,0.64-0.28,0.64-0.64c0-0.46,0.58-1.45,1.53-1.99c1.53-0.87,3.62-2.03,3.62-5.08C23.15,11.28,19.29,8.53,15.84,8.53z M18.01,24.61c0-0.36-0.28-0.64-0.64-0.64H13.5c-0.36,0-0.64,0.28-0.64,0.64v3.86c0,0.36,0.28,0.64,0.64,0.64h3.86 c0.36,0,0.64-0.28,0.64-0.64V24.61z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Unspecified or unknown
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error"
+            role="alert"
+          >
+            <i
+              aria-hidden="true"
+              className="fa fa-exclamation"
+            />
+            <div
+              data-i18n="error.required"
+            >
+              <h5>
+                Your response is required
+              </h5>
+              
+              
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+    <div
+      aria-label="Eye color"
+      className="field required"
+      data-uuid="field-7c21c9e0-2513-52eb-3ded-066b9c3b3a09"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-7c21c9e0-2513-52eb-3ded-066b9c3b3a09"
+        name="field-7c21c9e0-2513-52eb-3ded-066b9c3b3a09"
+      />
+      <h3
+        className="title h3"
+      >
+        Eye color
+      </h3>
+      <span
+        className="icon"
+      >
+        <a
+          aria-label="Show help for Eye color"
+          className="toggle h3  adjust-for-big-buttons"
+          href="javascript:;"
+          onClick={[Function]}
+          title="Show help for Eye color"
+        >
+          <svg
+            alt="Scalable vector graphic"
+            focusable="false"
+            height="14.57px"
+            tabIndex="-1"
+            viewBox="0 0 14.57 14.57"
+            width="14.57px"
+          >
+            <g>
+              <path
+                className="eapp-help-icon"
+                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+              />
+            </g>
+          </svg>
+        </a>
+      </span>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component"
+          >
+            <div
+              className=" eye-colors"
+            >
+              <label />
+              <div
+                className="blocks option-list eapp-extend-labels usa-input-error"
+              >
+                <div
+                  className="brown block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="eye-brown-b5740c30-eea1-3b9d-7822-9b31de1040a4"
+                  >
+                    <input
+                      aria-label="Brown for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="eye-brown-b5740c30-eea1-3b9d-7822-9b31de1040a4"
+                      name="eye-brown-b5740c30-eea1-3b9d-7822-9b31de1040a4"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Brown"
+                    />
+                    <div
+                      className="eye-icon brown"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 36 36.84"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 36 36.84"
+                      >
+                        <path
+                          d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Brown
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="hazel block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="eye-hazel-92b5d3d0-488d-b0dd-4af9-f2bb8f0e0f5f"
+                  >
+                    <input
+                      aria-label="Hazel for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="eye-hazel-92b5d3d0-488d-b0dd-4af9-f2bb8f0e0f5f"
+                      name="eye-hazel-92b5d3d0-488d-b0dd-4af9-f2bb8f0e0f5f"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Hazel"
+                    />
+                    <div
+                      className="eye-icon hazel"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 36 36.84"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 36 36.84"
+                      >
+                        <path
+                          d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Hazel
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="blue block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="eye-blue-22d3b2a1-665c-64e3-e0d0-5919a59d9f86"
+                  >
+                    <input
+                      aria-label="Blue for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="eye-blue-22d3b2a1-665c-64e3-e0d0-5919a59d9f86"
+                      name="eye-blue-22d3b2a1-665c-64e3-e0d0-5919a59d9f86"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Blue"
+                    />
+                    <div
+                      className="eye-icon blue"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 36 36.84"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 36 36.84"
+                      >
+                        <path
+                          d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Blue
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="green block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="eye-green-21ca03ea-a91c-490b-6b61-d35cd639613f"
+                  >
+                    <input
+                      aria-label="Green for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="eye-green-21ca03ea-a91c-490b-6b61-d35cd639613f"
+                      name="eye-green-21ca03ea-a91c-490b-6b61-d35cd639613f"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Green"
+                    />
+                    <div
+                      className="eye-icon green"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 36 36.84"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 36 36.84"
+                      >
+                        <path
+                          d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Green
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="gray block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="eye-gray-1764ef80-4398-0283-84bb-8fcf802fd357"
+                  >
+                    <input
+                      aria-label="Gray for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="eye-gray-1764ef80-4398-0283-84bb-8fcf802fd357"
+                      name="eye-gray-1764ef80-4398-0283-84bb-8fcf802fd357"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Gray"
+                    />
+                    <div
+                      className="eye-icon gray"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 36 36.84"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 36 36.84"
+                      >
+                        <path
+                          d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Gray
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="maroon block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="eye-maroon-a1ee3100-f2dd-46a3-bfb8-4ccb95dce801"
+                  >
+                    <input
+                      aria-label="Maroon for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="eye-maroon-a1ee3100-f2dd-46a3-bfb8-4ccb95dce801"
+                      name="eye-maroon-a1ee3100-f2dd-46a3-bfb8-4ccb95dce801"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Maroon"
+                    />
+                    <div
+                      className="eye-icon maroon"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 36 36.84"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 36 36.84"
+                      >
+                        <path
+                          d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Maroon
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="black block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="eye-black-9095c0ca-b173-78da-9400-3438dead244f"
+                  >
+                    <input
+                      aria-label="Black for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="eye-black-9095c0ca-b173-78da-9400-3438dead244f"
+                      name="eye-black-9095c0ca-b173-78da-9400-3438dead244f"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Black"
+                    />
+                    <div
+                      className="eye-icon black"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 36 36.84"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 36 36.84"
+                      >
+                        <path
+                          d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Black
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="multi block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="eye-multi-fdbd4de1-c125-5905-1cbc-b6c3113dc045"
+                  >
+                    <input
+                      aria-label="Multicolored for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="eye-multi-fdbd4de1-c125-5905-1cbc-b6c3113dc045"
+                      name="eye-multi-fdbd4de1-c125-5905-1cbc-b6c3113dc045"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Multicolored"
+                    />
+                    <div
+                      className="eye-icon multi"
+                    >
+                      <img
+                        alt="Scalable vector graphic"
+                        className="svg"
+                        src="/img/eye-multicolor.svg"
+                      />
+                    </div>
+                    <span>
+                      Multicolored
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="pink block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="eye-pink-f13e46eb-7c6e-34a8-0239-1ab292b5c451"
+                  >
+                    <input
+                      aria-label="Pink for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="eye-pink-f13e46eb-7c6e-34a8-0239-1ab292b5c451"
+                      name="eye-pink-f13e46eb-7c6e-34a8-0239-1ab292b5c451"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Pink"
+                    />
+                    <div
+                      className="eye-icon pink"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        enableBackground="new 0 0 36 36.84"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 36 36.84"
+                      >
+                        <path
+                          d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Pink
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="unknown block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="eye-unknown-70fdd296-0bc4-56ee-34e4-762fadd5c453"
+                  >
+                    <input
+                      aria-label="Unknown for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="eye-unknown-70fdd296-0bc4-56ee-34e4-762fadd5c453"
+                      name="eye-unknown-70fdd296-0bc4-56ee-34e4-762fadd5c453"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Unknown"
+                    />
+                    <div
+                      className="eye-icon unknown"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 30.86 36.84"
+                      >
+                        <path
+                          d="M15.43,34.25C6.91,34.25,0,27.34,0,18.82C0,10.3,6.91,3.39,15.43,3.39s15.43,6.91,15.43,15.43 C30.87,27.34,23.95,34.25,15.43,34.25z M15.84,8.53c-3.28,0-5.73,1.41-7.46,4.28c-0.18,0.28-0.1,0.64,0.16,0.84l2.65,2.01 c0.1,0.08,0.24,0.12,0.38,0.12c0.18,0,0.38-0.08,0.5-0.24c0.94-1.21,1.35-1.57,1.73-1.85c0.34-0.24,1-0.48,1.73-0.48 c1.29,0,2.47,0.82,2.47,1.71c0,1.04-0.54,1.57-1.77,2.13c-1.43,0.64-3.38,2.31-3.38,4.26v0.72c0,0.36,0.28,0.64,0.64,0.64h3.86 c0.36,0,0.64-0.28,0.64-0.64c0-0.46,0.58-1.45,1.53-1.99c1.53-0.87,3.62-2.03,3.62-5.08C23.15,11.28,19.29,8.53,15.84,8.53z M18.01,24.61c0-0.36-0.28-0.64-0.64-0.64H13.5c-0.36,0-0.64,0.28-0.64,0.64v3.86c0,0.36,0.28,0.64,0.64,0.64h3.86 c0.36,0,0.64-0.28,0.64-0.64V24.61z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Unknown
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error"
+            role="alert"
+          >
+            <i
+              aria-hidden="true"
+              className="fa fa-exclamation"
+            />
+            <div
+              data-i18n="error.required"
+            >
+              <h5>
+                Your response is required
+              </h5>
+              
+              
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+    <div
+      aria-label="Select your sex"
+      className="field required"
+      data-uuid="field-69439bbc-b5cc-ed91-65bc-cd685736c325"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-69439bbc-b5cc-ed91-65bc-cd685736c325"
+        name="field-69439bbc-b5cc-ed91-65bc-cd685736c325"
+      />
+      <h3
+        className="title h3"
+      >
+        Select your sex
+      </h3>
+      <span
+        className="icon"
+      >
+        <a
+          aria-label="Show help for Select your sex"
+          className="toggle h3  adjust-for-big-buttons"
+          href="javascript:;"
+          onClick={[Function]}
+          title="Show help for Select your sex"
+        >
+          <svg
+            alt="Scalable vector graphic"
+            focusable="false"
+            height="14.57px"
+            tabIndex="-1"
+            viewBox="0 0 14.57 14.57"
+            width="14.57px"
+          >
+            <g>
+              <path
+                className="eapp-help-icon"
+                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+              />
+            </g>
+          </svg>
+        </a>
+      </span>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component shrink"
+          >
+            <div
+              className=" sex"
+            >
+              <label />
+              <div
+                className="blocks  usa-input-error"
+              >
+                <div
+                  className="female block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="sex-7c209c18-6504-9c0f-8c3b-a7ccc19acbcd"
+                  >
+                    <input
+                      aria-label="Female for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="sex-7c209c18-6504-9c0f-8c3b-a7ccc19acbcd"
+                      name="sex-7c209c18-6504-9c0f-8c3b-a7ccc19acbcd"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Female"
+                    />
+                    <div
+                      className="sex-icon"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="0 0 50.81 79.19"
+                      >
+                        <path
+                          d="M50.81,25.4C50.81,11.37,39.43,0,25.4,0S0,11.37,0,25.4c0,12.32,8.77,22.59,20.4,24.91v9.09h-9.79v10h9.79v9.79 h10V69.4h9.79v-10H30.4v-9.09C42.04,47.99,50.81,37.72,50.81,25.4z M10,25.4C10,16.91,16.91,10,25.4,10s15.4,6.91,15.4,15.4 s-6.91,15.4-15.4,15.4S10,33.9,10,25.4z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Female
+                    </span>
+                  </label>
+                </div>
+                <div
+                  className="male block extended"
+                >
+                  <label
+                    className=""
+                    htmlFor="sex-e6b1e02e-961d-b892-17ba-84cb6eb4a341"
+                  >
+                    <input
+                      aria-label="Male for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="sex-e6b1e02e-961d-b892-17ba-84cb6eb4a341"
+                      name="sex-e6b1e02e-961d-b892-17ba-84cb6eb4a341"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Male"
+                    />
+                    <div
+                      className="sex-icon"
+                    >
+                      <svg
+                        alt="Scalable vector graphic"
+                        focusable="false"
+                        tabIndex="-1"
+                        viewBox="-10 -10 80 80"
+                      >
+                        <path
+                          d="M62.77,0.12V0H37.69v10h8.64l-6.4,6.4c-4.35-3.04-9.43-4.56-14.52-4.56c-6.5,0-13,2.48-17.96,7.44 c-9.92,9.92-9.92,26.01,0,35.93c4.96,4.96,11.46,7.44,17.96,7.44c6.5,0,13-2.48,17.96-7.44c8.58-8.58,9.73-21.76,3.48-31.58 l6.05-6.05v7.64h10V0.12H62.77z M36.3,48.14c-2.91,2.91-6.78,4.51-10.89,4.51c-4.11,0-7.98-1.6-10.89-4.51 C11.6,45.23,10,41.36,10,37.24c0-4.11,1.6-7.98,4.51-10.89s6.78-4.51,10.89-4.51c4.11,0,7.98,1.6,10.89,4.51s4.51,6.78,4.51,10.89 C40.81,41.36,39.21,45.23,36.3,48.14z"
+                        />
+                      </svg>
+                    </div>
+                    <span>
+                      Male
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+            <a
+              className="comments-button add"
+              href="javascript:;;"
+              onClick={[Function]}
+            >
+              <span>
+                Add a comment
+              </span>
+              <i
+                className="fa fa-plus-circle"
+              />
+            </a>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error"
+            role="alert"
+          >
+            <i
+              aria-hidden="true"
+              className="fa fa-exclamation"
+            />
+            <div
+              data-i18n="error.required"
+            >
+              <h5>
+                Your response is required
+              </h5>
+              
+              
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="section-divider"
+  />
+  <div
+    aria-label="Add a comment to clarify any of your responses in the information about you section"
+    className="field   section-comment"
+    data-uuid="field-502615de-d385-f400-9894-b69987d5ea01"
+  >
+    <a
+      aria-hidden="true"
+      className="anchor"
+      id="field-502615de-d385-f400-9894-b69987d5ea01"
+      name="field-502615de-d385-f400-9894-b69987d5ea01"
+    />
+    <h4
+      className="title h4"
+    >
+      Add a comment to clarify any of your responses in the information about you section
+      <span
+        className="optional"
+      >
+        (Optional)
+      </span>
+    </h4>
+    <span
+      className="icon"
+    />
+    <div
+      className="table expand"
+    >
+      <span
+        aria-live="polite"
+        className="messages help-messages"
+      />
+    </div>
+    <div
+      className="table"
+    >
+      <span
+        className="content"
+      >
+        <span
+          className="component"
+        >
+          <div
+            className=""
+          >
+            <input
+              aria-describedby="Comments-error"
+              aria-label={null}
+              autoCapitalize={true}
+              autoComplete={true}
+              autoCorrect={true}
+              className=""
+              id="Comments-567dae66-fcfe-3a38-2f49-f9e979ebe380"
+              maxLength={255}
+              name="Comments"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              pattern=".*"
+              spellCheck={true}
+              type="text"
+              value=""
+            />
+          </div>
+        </span>
+      </span>
+    </div>
+    <div
+      className="table expand"
+    >
+      <span
+        aria-live="polite"
+        className="messages error-messages"
+        role="alert"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Section/Identification/__snapshots__/Identification.test.jsx.snap
+++ b/src/components/Section/Identification/__snapshots__/Identification.test.jsx.snap
@@ -16,13 +16,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Provide your full name"
       className="field"
-      data-uuid="field-3c2f40b3-3652-cac4-1b79-0d1941378221"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-3c2f40b3-3652-cac4-1b79-0d1941378221"
-        name="field-3c2f40b3-3652-cac4-1b79-0d1941378221"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h2
         className="title h2"
@@ -55,13 +55,13 @@ exports[`The identification section renders the IdentificationSections component
               <div
                 aria-label="First name"
                 className="field required"
-                data-uuid="field-8a84c6dd-5d3b-501e-d107-77c5da349824"
+                data-uuid="field-MOCK-GUID"
               >
                 <a
                   aria-hidden="true"
                   className="anchor"
-                  id="field-8a84c6dd-5d3b-501e-d107-77c5da349824"
-                  name="field-8a84c6dd-5d3b-501e-d107-77c5da349824"
+                  id="field-MOCK-GUID"
+                  name="field-MOCK-GUID"
                 />
                 <label
                   className="title label"
@@ -122,7 +122,7 @@ exports[`The identification section renders the IdentificationSections component
                           autoComplete={true}
                           autoCorrect={true}
                           className=""
-                          id="first-cca0deef-588c-1782-d54d-e8c385166578"
+                          id="first-MOCK-GUID"
                           maxLength="100"
                           name="first"
                           onBlur={[Function]}
@@ -145,7 +145,7 @@ exports[`The identification section renders the IdentificationSections component
                             aria-label="Initial only for null"
                             checked={false}
                             className="usa-input-success"
-                            id="firstInitialOnly-d3858e08-e211-da3a-324c-db0bbfa060ac"
+                            id="firstInitialOnly-MOCK-GUID"
                             name="firstInitialOnly"
                             onBlur={[Function]}
                             onChange={[Function]}
@@ -156,7 +156,7 @@ exports[`The identification section renders the IdentificationSections component
                           />
                           <label
                             className="checkbox no-toggle"
-                            htmlFor="firstInitialOnly-d3858e08-e211-da3a-324c-db0bbfa060ac"
+                            htmlFor="firstInitialOnly-MOCK-GUID"
                           >
                             <span>
                               Initial only
@@ -180,13 +180,13 @@ exports[`The identification section renders the IdentificationSections component
               <div
                 aria-label="Middle name"
                 className="field required"
-                data-uuid="field-2af17d9e-7432-e03a-646e-438bd9e27eeb"
+                data-uuid="field-MOCK-GUID"
               >
                 <a
                   aria-hidden="true"
                   className="anchor"
-                  id="field-2af17d9e-7432-e03a-646e-438bd9e27eeb"
-                  name="field-2af17d9e-7432-e03a-646e-438bd9e27eeb"
+                  id="field-MOCK-GUID"
+                  name="field-MOCK-GUID"
                 />
                 <label
                   className="title label"
@@ -247,7 +247,7 @@ exports[`The identification section renders the IdentificationSections component
                           autoComplete={true}
                           autoCorrect={true}
                           className=""
-                          id="middle-e6e2273b-963e-6508-7e58-02b8f63f241f"
+                          id="middle-MOCK-GUID"
                           maxLength="100"
                           name="middle"
                           onBlur={[Function]}
@@ -270,7 +270,7 @@ exports[`The identification section renders the IdentificationSections component
                             aria-label="No middle name for null"
                             checked={false}
                             className="usa-input-success"
-                            id="noMiddleName-a337cc34-13aa-e78f-d00d-dd8f7ec23139"
+                            id="noMiddleName-MOCK-GUID"
                             name="noMiddleName"
                             onBlur={[Function]}
                             onChange={[Function]}
@@ -281,7 +281,7 @@ exports[`The identification section renders the IdentificationSections component
                           />
                           <label
                             className="checkbox no-toggle"
-                            htmlFor="noMiddleName-a337cc34-13aa-e78f-d00d-dd8f7ec23139"
+                            htmlFor="noMiddleName-MOCK-GUID"
                           >
                             <span>
                               No middle name
@@ -295,7 +295,7 @@ exports[`The identification section renders the IdentificationSections component
                             aria-label="Initial only for null"
                             checked={false}
                             className="usa-input-success"
-                            id="middleInitialOnly-32ebcfc4-e3c7-052e-6cae-d9e9d528550c"
+                            id="middleInitialOnly-MOCK-GUID"
                             name="middleInitialOnly"
                             onBlur={[Function]}
                             onChange={[Function]}
@@ -306,7 +306,7 @@ exports[`The identification section renders the IdentificationSections component
                           />
                           <label
                             className="checkbox no-toggle"
-                            htmlFor="middleInitialOnly-32ebcfc4-e3c7-052e-6cae-d9e9d528550c"
+                            htmlFor="middleInitialOnly-MOCK-GUID"
                           >
                             <span>
                               Initial only
@@ -330,13 +330,13 @@ exports[`The identification section renders the IdentificationSections component
               <div
                 aria-label="Last name"
                 className="field required"
-                data-uuid="field-2a95422d-bc27-4229-59f7-baa85a1ec415"
+                data-uuid="field-MOCK-GUID"
               >
                 <a
                   aria-hidden="true"
                   className="anchor"
-                  id="field-2a95422d-bc27-4229-59f7-baa85a1ec415"
-                  name="field-2a95422d-bc27-4229-59f7-baa85a1ec415"
+                  id="field-MOCK-GUID"
+                  name="field-MOCK-GUID"
                 />
                 <label
                   className="title label"
@@ -397,7 +397,7 @@ exports[`The identification section renders the IdentificationSections component
                           autoComplete={true}
                           autoCorrect={true}
                           className=""
-                          id="last-23c6a252-c90d-0e93-548d-d61df4bf4cc7"
+                          id="last-MOCK-GUID"
                           maxLength="100"
                           name="last"
                           onBlur={[Function]}
@@ -420,7 +420,7 @@ exports[`The identification section renders the IdentificationSections component
                             aria-label="Initial only for null"
                             checked={false}
                             className="usa-input-success"
-                            id="lastInitialOnly-b3a1c262-83a8-c19d-e2be-80f373020bfa"
+                            id="lastInitialOnly-MOCK-GUID"
                             name="lastInitialOnly"
                             onBlur={[Function]}
                             onChange={[Function]}
@@ -431,7 +431,7 @@ exports[`The identification section renders the IdentificationSections component
                           />
                           <label
                             className="checkbox no-toggle"
-                            htmlFor="lastInitialOnly-b3a1c262-83a8-c19d-e2be-80f373020bfa"
+                            htmlFor="lastInitialOnly-MOCK-GUID"
                           >
                             <span>
                               Initial only
@@ -455,13 +455,13 @@ exports[`The identification section renders the IdentificationSections component
               <div
                 aria-label="Suffix"
                 className="field"
-                data-uuid="field-5d40596a-b25b-772b-1b16-eafc7ae87078"
+                data-uuid="field-MOCK-GUID"
               >
                 <a
                   aria-hidden="true"
                   className="anchor"
-                  id="field-5d40596a-b25b-772b-1b16-eafc7ae87078"
-                  name="field-5d40596a-b25b-772b-1b16-eafc7ae87078"
+                  id="field-MOCK-GUID"
+                  name="field-MOCK-GUID"
                 />
                 <label
                   className="title label"
@@ -525,15 +525,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-02bbe7a3-7915-5121-6381-64931c6d64af"
+                            htmlFor="suffix-MOCK-GUID"
                           >
                             <input
                               aria-label="Jr for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-02bbe7a3-7915-5121-6381-64931c6d64af"
-                              name="suffix-02bbe7a3-7915-5121-6381-64931c6d64af"
+                              id="suffix-MOCK-GUID"
+                              name="suffix-MOCK-GUID"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -552,15 +552,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-273adbdd-a85c-6401-fbed-669d246f82e2"
+                            htmlFor="suffix-MOCK-GUID"
                           >
                             <input
                               aria-label="Sr for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-273adbdd-a85c-6401-fbed-669d246f82e2"
-                              name="suffix-273adbdd-a85c-6401-fbed-669d246f82e2"
+                              id="suffix-MOCK-GUID"
+                              name="suffix-MOCK-GUID"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -579,15 +579,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-d4e2417b-0bf8-dffe-92b1-4c3ff71bbaf5"
+                            htmlFor="suffix-MOCK-GUID"
                           >
                             <input
                               aria-label="I for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-d4e2417b-0bf8-dffe-92b1-4c3ff71bbaf5"
-                              name="suffix-d4e2417b-0bf8-dffe-92b1-4c3ff71bbaf5"
+                              id="suffix-MOCK-GUID"
+                              name="suffix-MOCK-GUID"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -606,15 +606,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-7ef2b979-e762-6331-bcc3-bdec8e6af7ad"
+                            htmlFor="suffix-MOCK-GUID"
                           >
                             <input
                               aria-label="II for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-7ef2b979-e762-6331-bcc3-bdec8e6af7ad"
-                              name="suffix-7ef2b979-e762-6331-bcc3-bdec8e6af7ad"
+                              id="suffix-MOCK-GUID"
+                              name="suffix-MOCK-GUID"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -633,15 +633,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-d7065c6b-f9b1-c6de-a45e-0545a82dda0c"
+                            htmlFor="suffix-MOCK-GUID"
                           >
                             <input
                               aria-label="III for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-d7065c6b-f9b1-c6de-a45e-0545a82dda0c"
-                              name="suffix-d7065c6b-f9b1-c6de-a45e-0545a82dda0c"
+                              id="suffix-MOCK-GUID"
+                              name="suffix-MOCK-GUID"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -660,15 +660,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-34709925-79df-22d3-2fdd-5a6be886d293"
+                            htmlFor="suffix-MOCK-GUID"
                           >
                             <input
                               aria-label="IV for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-34709925-79df-22d3-2fdd-5a6be886d293"
-                              name="suffix-34709925-79df-22d3-2fdd-5a6be886d293"
+                              id="suffix-MOCK-GUID"
+                              name="suffix-MOCK-GUID"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -687,15 +687,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-4f459903-0ace-9b3c-aa1d-0c5c34d2adc7"
+                            htmlFor="suffix-MOCK-GUID"
                           >
                             <input
                               aria-label="V for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-4f459903-0ace-9b3c-aa1d-0c5c34d2adc7"
-                              name="suffix-4f459903-0ace-9b3c-aa1d-0c5c34d2adc7"
+                              id="suffix-MOCK-GUID"
+                              name="suffix-MOCK-GUID"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -714,15 +714,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-29de6bb3-587d-9cbd-1d28-23b2e86717f2"
+                            htmlFor="suffix-MOCK-GUID"
                           >
                             <input
                               aria-label="VI for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-29de6bb3-587d-9cbd-1d28-23b2e86717f2"
-                              name="suffix-29de6bb3-587d-9cbd-1d28-23b2e86717f2"
+                              id="suffix-MOCK-GUID"
+                              name="suffix-MOCK-GUID"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -741,15 +741,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-a15b83d6-5bac-3e90-fab7-0b8bfe518494"
+                            htmlFor="suffix-MOCK-GUID"
                           >
                             <input
                               aria-label="VII for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-a15b83d6-5bac-3e90-fab7-0b8bfe518494"
-                              name="suffix-a15b83d6-5bac-3e90-fab7-0b8bfe518494"
+                              id="suffix-MOCK-GUID"
+                              name="suffix-MOCK-GUID"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -768,15 +768,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-a03b3670-bee8-87c4-9e7e-167a7e88b9f2"
+                            htmlFor="suffix-MOCK-GUID"
                           >
                             <input
                               aria-label="VIII for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-a03b3670-bee8-87c4-9e7e-167a7e88b9f2"
-                              name="suffix-a03b3670-bee8-87c4-9e7e-167a7e88b9f2"
+                              id="suffix-MOCK-GUID"
+                              name="suffix-MOCK-GUID"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -795,15 +795,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-b522afbb-4412-8e31-aed3-9fe4851ddf7d"
+                            htmlFor="suffix-MOCK-GUID"
                           >
                             <input
                               aria-label="IX for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-b522afbb-4412-8e31-aed3-9fe4851ddf7d"
-                              name="suffix-b522afbb-4412-8e31-aed3-9fe4851ddf7d"
+                              id="suffix-MOCK-GUID"
+                              name="suffix-MOCK-GUID"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -822,15 +822,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-25aa9ad1-9521-bcee-81f5-b24c52e75fc3"
+                            htmlFor="suffix-MOCK-GUID"
                           >
                             <input
                               aria-label="X for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-25aa9ad1-9521-bcee-81f5-b24c52e75fc3"
-                              name="suffix-25aa9ad1-9521-bcee-81f5-b24c52e75fc3"
+                              id="suffix-MOCK-GUID"
+                              name="suffix-MOCK-GUID"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -849,15 +849,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-ae2adaa3-41bf-74ec-6afc-6cf79bd20b2c"
+                            htmlFor="suffix-MOCK-GUID"
                           >
                             <input
                               aria-label="Other for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-ae2adaa3-41bf-74ec-6afc-6cf79bd20b2c"
-                              name="suffix-ae2adaa3-41bf-74ec-6afc-6cf79bd20b2c"
+                              id="suffix-MOCK-GUID"
+                              name="suffix-MOCK-GUID"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -937,13 +937,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Provide your other names used and the period of time you used them"
       className="field   no-margin-bottom"
-      data-uuid="field-686477be-609c-4562-b2df-b191d36cd20c"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-686477be-609c-4562-b2df-b191d36cd20c"
-        name="field-686477be-609c-4562-b2df-b191d36cd20c"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h2
         className="title h2"
@@ -1015,13 +1015,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Have you used any other names?"
       className="field required  branch"
-      data-uuid="field-ac3f2a46-eb1e-6320-d1ec-2389b3ce6162"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-ac3f2a46-eb1e-6320-d1ec-2389b3ce6162"
-        name="field-ac3f2a46-eb1e-6320-d1ec-2389b3ce6162"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h3
         className="title h3"
@@ -1059,15 +1059,15 @@ exports[`The identification section renders the IdentificationSections component
               >
                 <label
                   className=""
-                  htmlFor="has_othernames-ccd9d479-7c07-fe8a-f836-afb0cf699a87"
+                  htmlFor="has_othernames-MOCK-GUID"
                 >
                   <input
                     aria-label="Yes for null"
                     checked={false}
                     className="usa-input-success"
                     disabled={false}
-                    id="has_othernames-ccd9d479-7c07-fe8a-f836-afb0cf699a87"
-                    name="has_othernames-ccd9d479-7c07-fe8a-f836-afb0cf699a87"
+                    id="has_othernames-MOCK-GUID"
+                    name="has_othernames-MOCK-GUID"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onClick={[Function]}
@@ -1086,15 +1086,15 @@ exports[`The identification section renders the IdentificationSections component
               >
                 <label
                   className=""
-                  htmlFor="has_othernames-38f0ff7d-2157-790d-e7c5-6c4d181c9ca0"
+                  htmlFor="has_othernames-MOCK-GUID"
                 >
                   <input
                     aria-label="No for null"
                     checked={false}
                     className="usa-input-success"
                     disabled={false}
-                    id="has_othernames-38f0ff7d-2157-790d-e7c5-6c4d181c9ca0"
-                    name="has_othernames-38f0ff7d-2157-790d-e7c5-6c4d181c9ca0"
+                    id="has_othernames-MOCK-GUID"
+                    name="has_othernames-MOCK-GUID"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onClick={[Function]}
@@ -1154,13 +1154,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Provide your contact information"
       className="field   no-margin-bottom"
-      data-uuid="field-56d66d23-3de8-33eb-e165-2c8d5cb8f76c"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-56d66d23-3de8-33eb-e165-2c8d5cb8f76c"
-        name="field-56d66d23-3de8-33eb-e165-2c8d5cb8f76c"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h2
         className="title h2"
@@ -1202,13 +1202,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Your email addresses"
       className="field   no-margin-bottom"
-      data-uuid="field-33e49949-bdfe-2474-04eb-800fc9c47987"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-33e49949-bdfe-2474-04eb-800fc9c47987"
-        name="field-33e49949-bdfe-2474-04eb-800fc9c47987"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h3
         className="title h3"
@@ -1311,13 +1311,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Your phone numbers"
       className="field   no-margin-bottom"
-      data-uuid="field-e3f0acb9-94ba-da49-4c32-26c4337c16ec"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-e3f0acb9-94ba-da49-4c32-26c4337c16ec"
-        name="field-e3f0acb9-94ba-da49-4c32-26c4337c16ec"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h3
         className="title h3"
@@ -1433,13 +1433,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Provide your date of birth"
       className="field required"
-      data-uuid="field-17322a69-b023-2667-66d6-96ab5fba21ec"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-17322a69-b023-2667-66d6-96ab5fba21ec"
-        name="field-17322a69-b023-2667-66d6-96ab5fba21ec"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h2
         className="title h2"
@@ -1502,7 +1502,7 @@ exports[`The identification section renders the IdentificationSections component
                   >
                     <label
                       className="usa-input-error-label"
-                      htmlFor="month-ca35d542-6fac-6fa2-c7e4-3649193ae4eb"
+                      htmlFor="month-MOCK-GUID"
                     >
                       Month
                     </label>
@@ -1514,7 +1514,7 @@ exports[`The identification section renders the IdentificationSections component
                       autoCorrect={true}
                       className=""
                       disabled={false}
-                      id="month-ca35d542-6fac-6fa2-c7e4-3649193ae4eb"
+                      id="month-MOCK-GUID"
                       maxLength="2"
                       name="month"
                       onBlur={[Function]}
@@ -1537,7 +1537,7 @@ exports[`The identification section renders the IdentificationSections component
                   >
                     <label
                       className="usa-input-error-label"
-                      htmlFor="day-98d38d86-f8bd-6af7-d2c6-9f7cc14cf465"
+                      htmlFor="day-MOCK-GUID"
                     >
                       Day
                     </label>
@@ -1549,7 +1549,7 @@ exports[`The identification section renders the IdentificationSections component
                       autoCorrect={true}
                       className=""
                       disabled={false}
-                      id="day-98d38d86-f8bd-6af7-d2c6-9f7cc14cf465"
+                      id="day-MOCK-GUID"
                       maxLength="2"
                       name="day"
                       onBlur={[Function]}
@@ -1572,7 +1572,7 @@ exports[`The identification section renders the IdentificationSections component
                   >
                     <label
                       className="usa-input-error-label"
-                      htmlFor="year-69d31213-beae-4010-c686-66682f240de2"
+                      htmlFor="year-MOCK-GUID"
                     >
                       Year
                     </label>
@@ -1584,7 +1584,7 @@ exports[`The identification section renders the IdentificationSections component
                       autoCorrect={true}
                       className=""
                       disabled={false}
-                      id="year-69d31213-beae-4010-c686-66682f240de2"
+                      id="year-MOCK-GUID"
                       maxLength="4"
                       name="year"
                       onBlur={[Function]}
@@ -1611,7 +1611,7 @@ exports[`The identification section renders the IdentificationSections component
                     checked={false}
                     className="usa-input-success"
                     disabled={false}
-                    id="estimated-aef1e7a8-e6a4-d973-127b-94cee9ed835c"
+                    id="estimated-MOCK-GUID"
                     name="estimated"
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -1622,7 +1622,7 @@ exports[`The identification section renders the IdentificationSections component
                   />
                   <label
                     className="checkbox no-toggle"
-                    htmlFor="estimated-aef1e7a8-e6a4-d973-127b-94cee9ed835c"
+                    htmlFor="estimated-MOCK-GUID"
                   >
                     <span>
                       Estimated
@@ -1686,13 +1686,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Provide your place of birth"
       className="field required"
-      data-uuid="field-0dee195b-9024-1543-d179-c1d03c92f2ba"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-0dee195b-9024-1543-d179-c1d03c92f2ba"
-        name="field-0dee195b-9024-1543-d179-c1d03c92f2ba"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h2
         className="title h2"
@@ -1739,15 +1739,15 @@ exports[`The identification section renders the IdentificationSections component
                     >
                       <label
                         className=""
-                        htmlFor="birthplace-620932e0-0374-f2ce-5d5d-766f5f5673b7"
+                        htmlFor="birthplace-MOCK-GUID"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="birthplace-620932e0-0374-f2ce-5d5d-766f5f5673b7"
-                          name="birthplace-620932e0-0374-f2ce-5d5d-766f5f5673b7"
+                          id="birthplace-MOCK-GUID"
+                          name="birthplace-MOCK-GUID"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -1766,15 +1766,15 @@ exports[`The identification section renders the IdentificationSections component
                     >
                       <label
                         className=""
-                        htmlFor="birthplace-2aa4688b-44b1-4051-171b-e4a9eb2fd840"
+                        htmlFor="birthplace-MOCK-GUID"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="birthplace-2aa4688b-44b1-4051-171b-e4a9eb2fd840"
-                          name="birthplace-2aa4688b-44b1-4051-171b-e4a9eb2fd840"
+                          id="birthplace-MOCK-GUID"
+                          name="birthplace-MOCK-GUID"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -1837,13 +1837,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Provide your U.S. Social Security Number"
       className="field required"
-      data-uuid="field-f311f590-283b-8833-2a53-37eae29aeb13"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-f311f590-283b-8833-2a53-37eae29aeb13"
-        name="field-f311f590-283b-8833-2a53-37eae29aeb13"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h2
         className="title h2"
@@ -1908,7 +1908,7 @@ exports[`The identification section renders the IdentificationSections component
                   autoCorrect={true}
                   className=""
                   disabled={false}
-                  id="first-522086b6-9ae4-6216-75af-26668c297a3d"
+                  id="first-MOCK-GUID"
                   maxLength="3"
                   name="first"
                   onBlur={[Function]}
@@ -1936,7 +1936,7 @@ exports[`The identification section renders the IdentificationSections component
                   autoCorrect={true}
                   className=""
                   disabled={false}
-                  id="middle-8be7bafd-508a-9f68-fd3b-70c3890d1207"
+                  id="middle-MOCK-GUID"
                   maxLength="2"
                   name="middle"
                   onBlur={[Function]}
@@ -1964,7 +1964,7 @@ exports[`The identification section renders the IdentificationSections component
                   autoCorrect={true}
                   className=""
                   disabled={false}
-                  id="last-d34507e7-c366-c3dc-8d94-dac3ece55cd2"
+                  id="last-MOCK-GUID"
                   maxLength="4"
                   name="last"
                   onBlur={[Function]}
@@ -1991,7 +1991,7 @@ exports[`The identification section renders the IdentificationSections component
                     aria-label="Not applicable for null"
                     checked={false}
                     className="usa-input-success"
-                    id="notApplicable-ac19fdc2-4489-1890-0a62-cf4d1234e07f"
+                    id="notApplicable-MOCK-GUID"
                     name="notApplicable"
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -2002,7 +2002,7 @@ exports[`The identification section renders the IdentificationSections component
                   />
                   <label
                     className="checkbox no-toggle"
-                    htmlFor="notApplicable-ac19fdc2-4489-1890-0a62-cf4d1234e07f"
+                    htmlFor="notApplicable-MOCK-GUID"
                   >
                     <span>
                       Not applicable
@@ -2056,13 +2056,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Provide your identifying information"
       className="field   no-margin-bottom"
-      data-uuid="field-e392d3b0-fa75-b219-7ea9-c08822b1bbc7"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-e392d3b0-fa75-b219-7ea9-c08822b1bbc7"
-        name="field-e392d3b0-fa75-b219-7ea9-c08822b1bbc7"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h2
         className="title h2"
@@ -2104,13 +2104,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Height"
       className="field required"
-      data-uuid="field-3bcda601-1d10-5809-d5bc-1f829d7fa490"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-3bcda601-1d10-5809-d5bc-1f829d7fa490"
-        name="field-3bcda601-1d10-5809-d5bc-1f829d7fa490"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h3
         className="title h3"
@@ -2172,7 +2172,7 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className="usa-input-error-label"
-                    htmlFor="feet-3e633e2d-4583-ed68-183a-43c239870d80"
+                    htmlFor="feet-MOCK-GUID"
                   >
                     Feet
                   </label>
@@ -2184,7 +2184,7 @@ exports[`The identification section renders the IdentificationSections component
                     autoCorrect={true}
                     className=""
                     disabled={false}
-                    id="feet-3e633e2d-4583-ed68-183a-43c239870d80"
+                    id="feet-MOCK-GUID"
                     maxLength="1"
                     name="feet"
                     onBlur={[Function]}
@@ -2207,7 +2207,7 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className="usa-input-error-label"
-                    htmlFor="inches-8d4d5ec7-3659-a42d-d1ff-1bbec0a36b12"
+                    htmlFor="inches-MOCK-GUID"
                   >
                     Inches
                   </label>
@@ -2219,7 +2219,7 @@ exports[`The identification section renders the IdentificationSections component
                     autoCorrect={true}
                     className=""
                     disabled={false}
-                    id="inches-8d4d5ec7-3659-a42d-d1ff-1bbec0a36b12"
+                    id="inches-MOCK-GUID"
                     maxLength="2"
                     name="inches"
                     onBlur={[Function]}
@@ -2271,13 +2271,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Weight"
       className="field required"
-      data-uuid="field-0fe2e5ef-cacf-987d-bc61-1f2d878ce509"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-0fe2e5ef-cacf-987d-bc61-1f2d878ce509"
-        name="field-0fe2e5ef-cacf-987d-bc61-1f2d878ce509"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h3
         className="title h3"
@@ -2339,7 +2339,7 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className="usa-input-error-label"
-                    htmlFor="pounds-04461680-21db-98a1-3403-ddd579cf0676"
+                    htmlFor="pounds-MOCK-GUID"
                   >
                     Pounds
                   </label>
@@ -2351,7 +2351,7 @@ exports[`The identification section renders the IdentificationSections component
                     autoCorrect={true}
                     className=""
                     disabled={false}
-                    id="pounds-04461680-21db-98a1-3403-ddd579cf0676"
+                    id="pounds-MOCK-GUID"
                     maxLength="3"
                     name="pounds"
                     onBlur={[Function]}
@@ -2403,13 +2403,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Hair color"
       className="field required"
-      data-uuid="field-98a063d9-0d1d-8516-7fa7-b7c04e7e7838"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-98a063d9-0d1d-8516-7fa7-b7c04e7e7838"
-        name="field-98a063d9-0d1d-8516-7fa7-b7c04e7e7838"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h3
         className="title h3"
@@ -2472,15 +2472,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-black-14545dbf-8df8-5791-77dc-f77df54b500f"
+                    htmlFor="hair-black-MOCK-GUID"
                   >
                     <input
                       aria-label="Black for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-black-14545dbf-8df8-5791-77dc-f77df54b500f"
-                      name="hair-black-14545dbf-8df8-5791-77dc-f77df54b500f"
+                      id="hair-black-MOCK-GUID"
+                      name="hair-black-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -2514,15 +2514,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-brown-7e808598-da63-9740-524f-14cba5dd8dd0"
+                    htmlFor="hair-brown-MOCK-GUID"
                   >
                     <input
                       aria-label="Brown for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-brown-7e808598-da63-9740-524f-14cba5dd8dd0"
-                      name="hair-brown-7e808598-da63-9740-524f-14cba5dd8dd0"
+                      id="hair-brown-MOCK-GUID"
+                      name="hair-brown-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -2556,15 +2556,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-red-668901ba-cfe5-689c-86ae-800012020ecd"
+                    htmlFor="hair-red-MOCK-GUID"
                   >
                     <input
                       aria-label="Red or auburn for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-red-668901ba-cfe5-689c-86ae-800012020ecd"
-                      name="hair-red-668901ba-cfe5-689c-86ae-800012020ecd"
+                      id="hair-red-MOCK-GUID"
+                      name="hair-red-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -2598,15 +2598,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-blonde-c0b244d9-ba2b-bbdf-1f62-e0de3c2be4a0"
+                    htmlFor="hair-blonde-MOCK-GUID"
                   >
                     <input
                       aria-label="Blonde or strawberry for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-blonde-c0b244d9-ba2b-bbdf-1f62-e0de3c2be4a0"
-                      name="hair-blonde-c0b244d9-ba2b-bbdf-1f62-e0de3c2be4a0"
+                      id="hair-blonde-MOCK-GUID"
+                      name="hair-blonde-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -2640,15 +2640,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-sandy-abab06ef-c7d8-cc12-3a7c-61915b6c1166"
+                    htmlFor="hair-sandy-MOCK-GUID"
                   >
                     <input
                       aria-label="Sandy for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-sandy-abab06ef-c7d8-cc12-3a7c-61915b6c1166"
-                      name="hair-sandy-abab06ef-c7d8-cc12-3a7c-61915b6c1166"
+                      id="hair-sandy-MOCK-GUID"
+                      name="hair-sandy-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -2682,15 +2682,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-gray-e42a72e4-8b60-8ab5-5034-7bf9e709f17e"
+                    htmlFor="hair-gray-MOCK-GUID"
                   >
                     <input
                       aria-label="Gray or partially gray for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-gray-e42a72e4-8b60-8ab5-5034-7bf9e709f17e"
-                      name="hair-gray-e42a72e4-8b60-8ab5-5034-7bf9e709f17e"
+                      id="hair-gray-MOCK-GUID"
+                      name="hair-gray-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -2724,15 +2724,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-white-a30c47c7-7b4f-8e1c-392d-a8f0b95f3e33"
+                    htmlFor="hair-white-MOCK-GUID"
                   >
                     <input
                       aria-label="White for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-white-a30c47c7-7b4f-8e1c-392d-a8f0b95f3e33"
-                      name="hair-white-a30c47c7-7b4f-8e1c-392d-a8f0b95f3e33"
+                      id="hair-white-MOCK-GUID"
+                      name="hair-white-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -2766,15 +2766,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-bald-23a49db7-9356-1fe1-ee48-bc7541774056"
+                    htmlFor="hair-bald-MOCK-GUID"
                   >
                     <input
                       aria-label="Bald for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-bald-23a49db7-9356-1fe1-ee48-bc7541774056"
-                      name="hair-bald-23a49db7-9356-1fe1-ee48-bc7541774056"
+                      id="hair-bald-MOCK-GUID"
+                      name="hair-bald-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -2816,15 +2816,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-blue-410d7595-0d37-f63b-d051-aeae458ac3ce"
+                    htmlFor="hair-blue-MOCK-GUID"
                   >
                     <input
                       aria-label="Blue for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-blue-410d7595-0d37-f63b-d051-aeae458ac3ce"
-                      name="hair-blue-410d7595-0d37-f63b-d051-aeae458ac3ce"
+                      id="hair-blue-MOCK-GUID"
+                      name="hair-blue-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -2858,15 +2858,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-green-4f299c2f-0ef1-4c68-e5d8-c0e9a8d8110f"
+                    htmlFor="hair-green-MOCK-GUID"
                   >
                     <input
                       aria-label="Green for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-green-4f299c2f-0ef1-4c68-e5d8-c0e9a8d8110f"
-                      name="hair-green-4f299c2f-0ef1-4c68-e5d8-c0e9a8d8110f"
+                      id="hair-green-MOCK-GUID"
+                      name="hair-green-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -2900,15 +2900,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-orange-33154e4c-24bb-bd3f-2659-c9ce425463e0"
+                    htmlFor="hair-orange-MOCK-GUID"
                   >
                     <input
                       aria-label="Orange for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-orange-33154e4c-24bb-bd3f-2659-c9ce425463e0"
-                      name="hair-orange-33154e4c-24bb-bd3f-2659-c9ce425463e0"
+                      id="hair-orange-MOCK-GUID"
+                      name="hair-orange-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -2942,15 +2942,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-pink-ded662a9-a406-2593-b3d7-551dc1db9dcc"
+                    htmlFor="hair-pink-MOCK-GUID"
                   >
                     <input
                       aria-label="Pink for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-pink-ded662a9-a406-2593-b3d7-551dc1db9dcc"
-                      name="hair-pink-ded662a9-a406-2593-b3d7-551dc1db9dcc"
+                      id="hair-pink-MOCK-GUID"
+                      name="hair-pink-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -2984,15 +2984,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-purple-81184543-eeb3-2131-e3a1-6dfec555f9c3"
+                    htmlFor="hair-purple-MOCK-GUID"
                   >
                     <input
                       aria-label="Purple for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-purple-81184543-eeb3-2131-e3a1-6dfec555f9c3"
-                      name="hair-purple-81184543-eeb3-2131-e3a1-6dfec555f9c3"
+                      id="hair-purple-MOCK-GUID"
+                      name="hair-purple-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -3026,15 +3026,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-unknown-d4e1d88e-4e42-a050-88e5-2994b404c6af"
+                    htmlFor="hair-unknown-MOCK-GUID"
                   >
                     <input
                       aria-label="Unspecified or unknown for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-unknown-d4e1d88e-4e42-a050-88e5-2994b404c6af"
-                      name="hair-unknown-d4e1d88e-4e42-a050-88e5-2994b404c6af"
+                      id="hair-unknown-MOCK-GUID"
+                      name="hair-unknown-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -3100,13 +3100,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Eye color"
       className="field required"
-      data-uuid="field-7c21c9e0-2513-52eb-3ded-066b9c3b3a09"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-7c21c9e0-2513-52eb-3ded-066b9c3b3a09"
-        name="field-7c21c9e0-2513-52eb-3ded-066b9c3b3a09"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h3
         className="title h3"
@@ -3169,15 +3169,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-brown-b5740c30-eea1-3b9d-7822-9b31de1040a4"
+                    htmlFor="eye-brown-MOCK-GUID"
                   >
                     <input
                       aria-label="Brown for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-brown-b5740c30-eea1-3b9d-7822-9b31de1040a4"
-                      name="eye-brown-b5740c30-eea1-3b9d-7822-9b31de1040a4"
+                      id="eye-brown-MOCK-GUID"
+                      name="eye-brown-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -3211,15 +3211,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-hazel-92b5d3d0-488d-b0dd-4af9-f2bb8f0e0f5f"
+                    htmlFor="eye-hazel-MOCK-GUID"
                   >
                     <input
                       aria-label="Hazel for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-hazel-92b5d3d0-488d-b0dd-4af9-f2bb8f0e0f5f"
-                      name="eye-hazel-92b5d3d0-488d-b0dd-4af9-f2bb8f0e0f5f"
+                      id="eye-hazel-MOCK-GUID"
+                      name="eye-hazel-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -3253,15 +3253,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-blue-22d3b2a1-665c-64e3-e0d0-5919a59d9f86"
+                    htmlFor="eye-blue-MOCK-GUID"
                   >
                     <input
                       aria-label="Blue for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-blue-22d3b2a1-665c-64e3-e0d0-5919a59d9f86"
-                      name="eye-blue-22d3b2a1-665c-64e3-e0d0-5919a59d9f86"
+                      id="eye-blue-MOCK-GUID"
+                      name="eye-blue-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -3295,15 +3295,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-green-21ca03ea-a91c-490b-6b61-d35cd639613f"
+                    htmlFor="eye-green-MOCK-GUID"
                   >
                     <input
                       aria-label="Green for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-green-21ca03ea-a91c-490b-6b61-d35cd639613f"
-                      name="eye-green-21ca03ea-a91c-490b-6b61-d35cd639613f"
+                      id="eye-green-MOCK-GUID"
+                      name="eye-green-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -3337,15 +3337,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-gray-1764ef80-4398-0283-84bb-8fcf802fd357"
+                    htmlFor="eye-gray-MOCK-GUID"
                   >
                     <input
                       aria-label="Gray for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-gray-1764ef80-4398-0283-84bb-8fcf802fd357"
-                      name="eye-gray-1764ef80-4398-0283-84bb-8fcf802fd357"
+                      id="eye-gray-MOCK-GUID"
+                      name="eye-gray-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -3379,15 +3379,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-maroon-a1ee3100-f2dd-46a3-bfb8-4ccb95dce801"
+                    htmlFor="eye-maroon-MOCK-GUID"
                   >
                     <input
                       aria-label="Maroon for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-maroon-a1ee3100-f2dd-46a3-bfb8-4ccb95dce801"
-                      name="eye-maroon-a1ee3100-f2dd-46a3-bfb8-4ccb95dce801"
+                      id="eye-maroon-MOCK-GUID"
+                      name="eye-maroon-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -3421,15 +3421,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-black-9095c0ca-b173-78da-9400-3438dead244f"
+                    htmlFor="eye-black-MOCK-GUID"
                   >
                     <input
                       aria-label="Black for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-black-9095c0ca-b173-78da-9400-3438dead244f"
-                      name="eye-black-9095c0ca-b173-78da-9400-3438dead244f"
+                      id="eye-black-MOCK-GUID"
+                      name="eye-black-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -3463,15 +3463,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-multi-fdbd4de1-c125-5905-1cbc-b6c3113dc045"
+                    htmlFor="eye-multi-MOCK-GUID"
                   >
                     <input
                       aria-label="Multicolored for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-multi-fdbd4de1-c125-5905-1cbc-b6c3113dc045"
-                      name="eye-multi-fdbd4de1-c125-5905-1cbc-b6c3113dc045"
+                      id="eye-multi-MOCK-GUID"
+                      name="eye-multi-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -3499,15 +3499,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-pink-f13e46eb-7c6e-34a8-0239-1ab292b5c451"
+                    htmlFor="eye-pink-MOCK-GUID"
                   >
                     <input
                       aria-label="Pink for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-pink-f13e46eb-7c6e-34a8-0239-1ab292b5c451"
-                      name="eye-pink-f13e46eb-7c6e-34a8-0239-1ab292b5c451"
+                      id="eye-pink-MOCK-GUID"
+                      name="eye-pink-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -3541,15 +3541,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-unknown-70fdd296-0bc4-56ee-34e4-762fadd5c453"
+                    htmlFor="eye-unknown-MOCK-GUID"
                   >
                     <input
                       aria-label="Unknown for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-unknown-70fdd296-0bc4-56ee-34e4-762fadd5c453"
-                      name="eye-unknown-70fdd296-0bc4-56ee-34e4-762fadd5c453"
+                      id="eye-unknown-MOCK-GUID"
+                      name="eye-unknown-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -3615,13 +3615,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Select your sex"
       className="field required"
-      data-uuid="field-69439bbc-b5cc-ed91-65bc-cd685736c325"
+      data-uuid="field-MOCK-GUID"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-69439bbc-b5cc-ed91-65bc-cd685736c325"
-        name="field-69439bbc-b5cc-ed91-65bc-cd685736c325"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
       />
       <h3
         className="title h3"
@@ -3684,15 +3684,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="sex-7c209c18-6504-9c0f-8c3b-a7ccc19acbcd"
+                    htmlFor="sex-MOCK-GUID"
                   >
                     <input
                       aria-label="Female for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="sex-7c209c18-6504-9c0f-8c3b-a7ccc19acbcd"
-                      name="sex-7c209c18-6504-9c0f-8c3b-a7ccc19acbcd"
+                      id="sex-MOCK-GUID"
+                      name="sex-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -3725,15 +3725,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="sex-e6b1e02e-961d-b892-17ba-84cb6eb4a341"
+                    htmlFor="sex-MOCK-GUID"
                   >
                     <input
                       aria-label="Male for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="sex-e6b1e02e-961d-b892-17ba-84cb6eb4a341"
-                      name="sex-e6b1e02e-961d-b892-17ba-84cb6eb4a341"
+                      id="sex-MOCK-GUID"
+                      name="sex-MOCK-GUID"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -3815,13 +3815,13 @@ exports[`The identification section renders the IdentificationSections component
   <div
     aria-label="Add a comment to clarify any of your responses in the information about you section"
     className="field   section-comment"
-    data-uuid="field-502615de-d385-f400-9894-b69987d5ea01"
+    data-uuid="field-MOCK-GUID"
   >
     <a
       aria-hidden="true"
       className="anchor"
-      id="field-502615de-d385-f400-9894-b69987d5ea01"
-      name="field-502615de-d385-f400-9894-b69987d5ea01"
+      id="field-MOCK-GUID"
+      name="field-MOCK-GUID"
     />
     <h4
       className="title h4"
@@ -3863,7 +3863,7 @@ exports[`The identification section renders the IdentificationSections component
               autoComplete={true}
               autoCorrect={true}
               className=""
-              id="Comments-567dae66-fcfe-3a38-2f49-f9e979ebe380"
+              id="Comments-MOCK-GUID"
               maxLength={255}
               name="Comments"
               onBlur={[Function]}


### PR DESCRIPTION
While working on #614, I want to ensure the markup being generated matches what was there before. [Jest's snapshots](https://jestjs.io/docs/en/snapshot-testing) are useful for this. This pull request:

* Commits snapshots to the repository, as [recommended](https://jestjs.io/docs/en/snapshot-testing#should-snapshot-files-be-committed)
* Adds snapshot tests for the `Identification` and `IdentificationSections` components
* To ensure the field `id`s don't change every time (making the snapshots worthless), mocks the GUIDs in the tests
* Moves the `ValidationElement` helper functions to their own file to support the mocking