### PR TITLE
Improve eQIP API error handling

### DIFF
--- a/api/eqip/testdata/malformedResponse.xml
+++ b/api/eqip/testdata/malformedResponse.xml
@@ -1,0 +1,1 @@
+Malformed response is not a valid SOAP message


### PR DESCRIPTION
Add higher-level error messages and differentiate between protocol and application-level errors.