### PR TITLE
Fixes bad XML generated when relative deceased

### DIFF
--- a/api/templates/relatives-and-associates.xml
+++ b/api/templates/relatives-and-associates.xml
@@ -76,9 +76,9 @@
       {{- $foreignPOB := ne $birthCountry "United States" }}
       {{- $usCitizen := citizenshipHas $Item.Citizenship "United States" }}
       {{- $deceased := eq (branch $Item.IsDeceased) "Yes" }}
-      {{- $usAddress := eq $Item.Address.props.country "United States" }}
+      {{- $usAddress := addressIn $Item.Address "United States" }}
 
-      {{- if or (and $usCitizen $foreignPOB $deceased) (and $usAddress $foreignPOB $usAddress) (and $foreignPOB $usCitizen) }}
+      {{- if or (and $usCitizen $foreignPOB $deceased) (and $usCitizen $foreignPOB $usAddress) }}
       <Citizenship>
         <ProofOfStatus>
           <Comment></Comment>

--- a/api/testdata/bad-address.json
+++ b/api/testdata/bad-address.json
@@ -1,0 +1,6 @@
+{
+  "type": "location",
+  "props": {
+    "layout": "Address"
+  }
+}

--- a/api/testdata/nonus-address.json
+++ b/api/testdata/nonus-address.json
@@ -1,0 +1,9 @@
+{
+  "type": "location",
+  "props": {
+    "layout": "Address",
+    "street": "10 Drury St.",
+    "city": "Stanley",
+    "country": "Falkland Islands Islas Malvinas"
+  }
+}

--- a/api/testdata/us-address.json
+++ b/api/testdata/us-address.json
@@ -1,0 +1,11 @@
+{
+  "type": "location",
+  "props": {
+    "layout": "Address",
+    "street": "110 Main ST.",
+    "city": "Monterey",
+    "state": "CA",
+    "zipcode": "93940",
+    "country": "United States"
+  }
+}

--- a/api/xml/xml.go
+++ b/api/xml/xml.go
@@ -22,6 +22,7 @@ func (service Service) DefaultTemplate(templateName string, data map[string]inte
 	// These can be helper functions for formatting or even to process complex structure
 	// types.
 	fmap := template.FuncMap{
+		"addressIn":            addressIn,
 		"branch":               branch,
 		"branchToBool":         branchToBool,
 		"branchcollectionHas":  branchcollectionHas,
@@ -366,6 +367,25 @@ func maritalStatus(status string) string {
 		"Widowed":      "Widowed",
 	}
 	return alias[status]
+}
+
+// addressIn returns true if Location entity (Address) is in the specified country
+func addressIn(location map[string]interface{}, country string) bool {
+	props, ok := location["props"]
+	if !ok {
+		return false
+	}
+
+	c, ok := (props.(map[string]interface{}))["country"]
+	if !ok {
+		return false
+	}
+
+	if c == country {
+		return true
+	}
+
+	return false
 }
 
 func citizenshipHas(data map[string]interface{}, country string) bool {

--- a/api/xml/xml_test.go
+++ b/api/xml/xml_test.go
@@ -119,6 +119,25 @@ func TestPackage(t *testing.T) {
 	}
 }
 
+func TestAddressIn(t *testing.T) {
+	country := "United States"
+
+	us := "testdata/us-address.json"
+	if !addressIn(readSectionData(us), country) {
+		t.Fatalf("%s should be in %s", us, country)
+	}
+
+	nonus := "testdata/nonus-address.json"
+	if addressIn(readSectionData(nonus), country) {
+		t.Fatalf("%s should not be in %s", nonus, country)
+	}
+
+	bad := "testdata/bad-address.json"
+	if addressIn(readSectionData(bad), country) {
+		t.Fatalf("%s should not be in %s", bad, country)
+	}
+}
+
 func applicationData() map[string]interface{} {
 	return map[string]interface{}{
 		"Identification": map[string]interface{}{


### PR DESCRIPTION
Fixes #625. XML template did not account for when relative did not have an addressed associated with them, e.g., when deceased, resulting in the entire relatives-and-associates.xml template being omitted.