### PR TITLE
add section and subsection to errors where not otherwise specified

### DIFF
--- a/src/actions/ApplicationActions.js
+++ b/src/actions/ApplicationActions.js
@@ -116,6 +116,14 @@ export function clearErrors(property, subsection) {
  * section.
  */
 export function reportErrors(section, subsection, codes) {
+  // set the section and subsection, in case not otherwise set
+  codes = codes.map(err => {
+    return {
+      ...err,
+      section: err.section || section,
+      subsection: err.subsection || subsection
+    }
+  })
   return updateApplication('Errors', section, codes)
 }
 

--- a/src/actions/ApplicationActions.js
+++ b/src/actions/ApplicationActions.js
@@ -3,8 +3,8 @@ import { api } from '../services'
 import schema, { unschema } from '../schema'
 import validate from '../validators'
 
-export function getApplicationState (done) {
-  return function (dispatch, getState) {
+export function getApplicationState(done) {
+  return function(dispatch, getState) {
     let locked = false
     let formData = {}
     api
@@ -27,7 +27,13 @@ export function getApplicationState (done) {
           formData = r.data
           for (const section in formData) {
             for (const subsection in formData[section]) {
-              dispatch(updateApplication(section, subsection, unschema(formData[section][subsection])))
+              dispatch(
+                updateApplication(
+                  section,
+                  subsection,
+                  unschema(formData[section][subsection])
+                )
+              )
             }
           }
         })
@@ -50,7 +56,7 @@ export function getApplicationState (done) {
   }
 }
 
-export function updateApplication (section, property, values) {
+export function updateApplication(section, property, values) {
   return {
     type: `${section}.${property}`,
     section: section,
@@ -59,7 +65,7 @@ export function updateApplication (section, property, values) {
   }
 }
 
-export function validateApplication (dispatch, application = {}) {
+export function validateApplication(dispatch, application = {}) {
   navigationWalker((path, child) => {
     if (path.length && path[0].store && child.store && child.validator) {
       const sectionName = path[0].url
@@ -82,13 +88,19 @@ export function validateApplication (dispatch, application = {}) {
         valid = null
       }
 
-      dispatch(reportCompletion(sectionName.toLowerCase(), subsectionName.toLowerCase(), valid))
+      dispatch(
+        reportCompletion(
+          sectionName.toLowerCase(),
+          subsectionName.toLowerCase(),
+          valid
+        )
+      )
     }
   })
 }
 
 // Special action that provides a way to flush all errors for a section+subsection upon entry so it may be stored with the re-validated data.
-export function clearErrors (property, subsection) {
+export function clearErrors(property, subsection) {
   const section = 'Errors'
   return {
     type: `${section}.${property}`,
@@ -103,26 +115,33 @@ export function clearErrors (property, subsection) {
  * This is a generic function to report any errors for a particular
  * section.
  */
-export function reportErrors (section, subsection, codes) {
+export function reportErrors(section, subsection, codes) {
   return updateApplication('Errors', section, codes)
 }
 
-export function reportCompletion (section, subsection, status) {
-  return updateApplication('Completed', section, [{ code: `${section}/${subsection}`.trim(), section: section, subsection: subsection, valid: status }])
+export function reportCompletion(section, subsection, status) {
+  return updateApplication('Completed', section, [
+    {
+      code: `${section}/${subsection}`.trim(),
+      section: section,
+      subsection: subsection,
+      valid: status
+    }
+  ])
 }
 
-export function updateIdentificationApplicantName (values) {
+export function updateIdentificationApplicantName(values) {
   return updateApplication('Identification', 'ApplicantName', values)
 }
 
-export function updateIdentificationBirthPlace (values) {
+export function updateIdentificationBirthPlace(values) {
   return updateApplication('Identification', 'ApplicantBirthPlace', values)
 }
 
-export function updateIdentificationBirthDate (values) {
+export function updateIdentificationBirthDate(values) {
   return updateApplication('Identification', 'ApplicantBirthDate', values)
 }
 
-export function updateIdentificationSSN (values) {
+export function updateIdentificationSSN(values) {
   return updateApplication('Identification', 'ApplicantSSN', values)
 }

--- a/src/actions/ApplicationActions.test.js
+++ b/src/actions/ApplicationActions.test.js
@@ -60,15 +60,38 @@ describe('Application actions', function() {
       {
         name: 'ApplicantNameReportError',
         callback: function() {
-          return reportErrors('Identification', 'ApplicantName', [
-            { code: 'minlength', valid: false }
-          ])
+          const errors = [
+            {
+              code: 'minlength',
+              valid: false
+            },
+            {
+              code: 'empty',
+              section: 'Identification',
+              subsection: 'Elsewhere',
+              valid: false
+            }
+          ]
+          return reportErrors('Identification', 'ApplicantName', errors)
         },
         expected: {
           type: 'Errors.Identification',
           section: 'Errors',
           property: 'Identification',
-          values: [{ code: 'minlength', valid: false }]
+          values: [
+            {
+              code: 'minlength',
+              section: 'Identification',
+              subsection: 'ApplicantName',
+              valid: false
+            },
+            {
+              code: 'empty',
+              section: 'Identification',
+              subsection: 'Elsewhere',
+              valid: false
+            }
+          ]
         }
       }
     ]
@@ -77,6 +100,7 @@ describe('Application actions', function() {
       let actual = t.callback()
       expect(actual.type).toEqual(t.expected.type)
       expect(actual.section).toEqual(t.expected.section)
+      expect(actual.subsection).toEqual(t.expected.subsection)
       expect(actual.property).toEqual(t.expected.property)
       expect(actual.values).toEqual(t.expected.values)
     })

--- a/src/actions/ApplicationActions.test.js
+++ b/src/actions/ApplicationActions.test.js
@@ -1,11 +1,17 @@
-import { updateIdentificationApplicantName, updateIdentificationBirthPlace, updateIdentificationBirthDate, updateIdentificationSSN, reportErrors } from './ApplicationActions'
+import {
+  updateIdentificationApplicantName,
+  updateIdentificationBirthPlace,
+  updateIdentificationBirthDate,
+  updateIdentificationSSN,
+  reportErrors
+} from './ApplicationActions'
 
-describe('Application actions', function () {
-  it('should create an action for updating identification properties', function () {
+describe('Application actions', function() {
+  it('should create an action for updating identification properties', function() {
     const tests = [
       {
         name: 'ApplicantName',
-        callback: function () {
+        callback: function() {
           return updateIdentificationApplicantName('charles xavier')
         },
         expected: {
@@ -17,7 +23,7 @@ describe('Application actions', function () {
       },
       {
         name: 'ApplicantBirthPlace',
-        callback: function () {
+        callback: function() {
           return updateIdentificationBirthPlace('Earth')
         },
         expected: {
@@ -29,7 +35,7 @@ describe('Application actions', function () {
       },
       {
         name: 'ApplicantBirthDate',
-        callback: function () {
+        callback: function() {
           return updateIdentificationBirthDate('6/21/1982')
         },
         expected: {
@@ -41,7 +47,7 @@ describe('Application actions', function () {
       },
       {
         name: 'ApplicantSSN',
-        callback: function () {
+        callback: function() {
           return updateIdentificationSSN('123456789')
         },
         expected: {
@@ -53,8 +59,10 @@ describe('Application actions', function () {
       },
       {
         name: 'ApplicantNameReportError',
-        callback: function () {
-          return reportErrors('Identification', 'ApplicantName', [{ code: 'minlength', valid: false }])
+        callback: function() {
+          return reportErrors('Identification', 'ApplicantName', [
+            { code: 'minlength', valid: false }
+          ])
         },
         expected: {
           type: 'Errors.Identification',
@@ -65,7 +73,7 @@ describe('Application actions', function () {
       }
     ]
 
-    tests.forEach((t) => {
+    tests.forEach(t => {
       let actual = t.callback()
       expect(actual.type).toEqual(t.expected.type)
       expect(actual.section).toEqual(t.expected.section)

--- a/src/components/Section/SectionElement.jsx
+++ b/src/components/Section/SectionElement.jsx
@@ -13,7 +13,8 @@ export default class SectionElement extends React.Component {
   }
 
   handleError(value, arr) {
-    this.props.dispatch(reportErrors(this.props.section, '', arr))
+    const action = reportErrors(this.props.section, this.props.subsection, arr)
+    this.props.dispatch(action)
     return arr
   }
 


### PR DESCRIPTION
Fixes #648.

Turns out that some of the custom eApp error objects have `section` and `subsection` properties, while others don't, which is why the bug was only showing up in certain cases 😒 Another vote for #658.