### PR TITLE
fix navigation to "Review and submit"

### DIFF
--- a/src/components/Section/Package/Attachments.jsx
+++ b/src/components/Section/Package/Attachments.jsx
@@ -1,12 +1,10 @@
 import React from 'react'
 import FileSaver from 'file-saver'
-import { connect } from 'react-redux'
 import { i18n, env } from '../../../config'
 import { api } from '../../../services'
-import SectionElement from '../SectionElement'
 import { Show, Field, Text, RadioGroup, Radio, Svg } from '../../Form'
 
-export default class Attachments extends SectionElement {
+export default class Attachments extends React.Component {
   constructor(props) {
     super(props)
     this.state = {

--- a/src/components/Section/Package/Attachments.jsx
+++ b/src/components/Section/Package/Attachments.jsx
@@ -7,7 +7,7 @@ import SectionElement from '../SectionElement'
 import { Show, Field, Text, RadioGroup, Radio, Svg } from '../../Form'
 
 export default class Attachments extends SectionElement {
-  constructor (props) {
+  constructor(props) {
     super(props)
     this.state = {
       attachments: [],
@@ -16,7 +16,7 @@ export default class Attachments extends SectionElement {
 
     this.supportsBlobs = false
     try {
-      this.supportsBlobs = !!new window.Blob
+      this.supportsBlobs = !!new window.Blob()
     } catch (e) {
       this.supportsBlobs = false
     }
@@ -31,11 +31,11 @@ export default class Attachments extends SectionElement {
     this.displayAttachments = this.displayAttachments.bind(this)
   }
 
-  componentDidMount () {
+  componentDidMount() {
     this.getStoredAttachments()
   }
 
-  update (queue) {
+  update(queue) {
     this.props.onUpdate({
       AttachmentType: this.props.AttachmentType,
       UploadDescription: this.props.UploadDescription,
@@ -44,20 +44,20 @@ export default class Attachments extends SectionElement {
     })
   }
 
-  updateAttachmentType (values) {
+  updateAttachmentType(values) {
     this.update({ AttachmentType: values })
   }
 
-  updateUploadDescription (values) {
+  updateUploadDescription(values) {
     this.update({ UploadDescription: values })
   }
 
-  updateOtherMethod (values) {
+  updateOtherMethod(values) {
     this.update({ OtherMethod: values })
   }
 
-  uploadFile (event) {
-    const set = (attachment) => {
+  uploadFile(event) {
+    const set = attachment => {
       // reset the file input
       this.refs.form.reset()
 
@@ -75,84 +75,119 @@ export default class Attachments extends SectionElement {
     let formData = new window.FormData()
     formData.append('file', file)
 
-    api.saveAttachment(formData).then((response) => {
-      const attachmentID = response.data || 0
-      if (attachmentID === 0) {
-        return
-      }
-      if (!description) {
-        set({
-          id: attachmentID,
-          filename: file.name,
-          size: file.size,
-          description: description
-        })
-        return
-      }
-      api.updateAttachment(attachmentID, description).then(response => {
-        set({
-          id: attachmentID,
-          filename: file.name,
-          size: file.size,
-          description: description
-        })
-      }).catch(() => {
-        this.setState({ errorMessage: i18n.t('application.attachments.upload.error.update') })
+    api
+      .saveAttachment(formData)
+      .then(response => {
+        const attachmentID = response.data || 0
+        if (attachmentID === 0) {
+          return
+        }
+        if (!description) {
+          set({
+            id: attachmentID,
+            filename: file.name,
+            size: file.size,
+            description: description
+          })
+          return
+        }
+        api
+          .updateAttachment(attachmentID, description)
+          .then(response => {
+            set({
+              id: attachmentID,
+              filename: file.name,
+              size: file.size,
+              description: description
+            })
+          })
+          .catch(() => {
+            this.setState({
+              errorMessage: i18n.t(
+                'application.attachments.upload.error.update'
+              )
+            })
+          })
       })
-    }).catch(() => {
-      this.setState({ errorMessage: i18n.t('application.attachments.upload.error.save') })
-    })
+      .catch(() => {
+        this.setState({
+          errorMessage: i18n.t('application.attachments.upload.error.save')
+        })
+      })
     event.preventDefault()
   }
 
-  download (id) {
+  download(id) {
     if (!this.supportsBlobs) {
       return
     }
 
     const attachment = this.state.attachments.find(x => x.id === id)
-    api.getAttachment(id).then((response) => {
-      const blob = blobFromBase64(response.data, 'application/octet-stream')
-      FileSaver.saveAs(blob, attachment.filename)
-    }).catch(() => {
-      this.setState({ errorMessage: i18n.t('application.attachments.upload.error.download') })
-    })
+    api
+      .getAttachment(id)
+      .then(response => {
+        const blob = blobFromBase64(response.data, 'application/octet-stream')
+        FileSaver.saveAs(blob, attachment.filename)
+      })
+      .catch(() => {
+        this.setState({
+          errorMessage: i18n.t('application.attachments.upload.error.download')
+        })
+      })
   }
 
-  delete (id) {
-    api.deleteAttachment(id).then((response) => {
-      let attachments = this.state.attachments
-      attachments = attachments.filter(x => x.id !== id)
-      this.setState({ attachments: attachments, errorMessage: '' })
-    }).catch(() => {
-      this.setState({ errorMessage: i18n.t('application.attachments.upload.error.delete') })
-    })
+  delete(id) {
+    api
+      .deleteAttachment(id)
+      .then(response => {
+        let attachments = this.state.attachments
+        attachments = attachments.filter(x => x.id !== id)
+        this.setState({ attachments: attachments, errorMessage: '' })
+      })
+      .catch(() => {
+        this.setState({
+          errorMessage: i18n.t('application.attachments.upload.error.delete')
+        })
+      })
   }
 
-  getStoredAttachments () {
-    api.listAttachments().then((response) => {
+  getStoredAttachments() {
+    api.listAttachments().then(response => {
       this.setState({ attachments: response.data || [], errorMessage: '' })
     })
   }
 
-  displayAttachments (items) {
+  displayAttachments(items) {
     return items.map((x, i) => {
       return (
         <tr key={`attachment-${x.id}`}>
           <td>
             <Show when={this.supportsBlobs}>
-              <a href="javascript:;;" aria-label={`Download ${x.filename}`} onClick={this.download.bind(this, x.id)}>
-                <strong>{`${i+1}. `}{x.description ? `${x.description} - ` : ''}</strong>{x.filename}
+              <a
+                href="javascript:;;"
+                aria-label={`Download ${x.filename}`}
+                onClick={this.download.bind(this, x.id)}>
+                <strong>
+                  {`${i + 1}. `}
+                  {x.description ? `${x.description} - ` : ''}
+                </strong>
+                {x.filename}
               </a>
             </Show>
             <Show when={!this.supportsBlobs}>
-              <strong>{`${i+1}. `}{x.description ? `${x.description} - ` : ''}</strong>{x.filename}
+              <strong>
+                {`${i + 1}. `}
+                {x.description ? `${x.description} - ` : ''}
+              </strong>
+              {x.filename}
             </Show>
           </td>
           <td>
             <button onClick={this.delete.bind(this, x.id)}>
-              <i className="fa fa-trash" aria-hidden="true"></i>
-              <span>{i18n.t('application.attachments.upload.files.remove')}</span>
+              <i className="fa fa-trash" aria-hidden="true" />
+              <span>
+                {i18n.t('application.attachments.upload.files.remove')}
+              </span>
             </button>
           </td>
         </tr>
@@ -160,15 +195,16 @@ export default class Attachments extends SectionElement {
     })
   }
 
-  limits () {
+  limits() {
     const fileMax = env.FileMaximumSize()
 
     const fileTypes = env.FileTypes()
     fileTypes[fileTypes.length - 1] = `or ${fileTypes[fileTypes.length - 1]}`
 
-    const message = i18n.t('application.attachments.upload.limits')
-          .replace('{types}', fileTypes.join(', '))
-          .replace('{max_size}', humanReadableFileSize(fileMax))
+    const message = i18n
+      .t('application.attachments.upload.limits')
+      .replace('{types}', fileTypes.join(', '))
+      .replace('{max_size}', humanReadableFileSize(fileMax))
 
     return (
       <p>
@@ -177,40 +213,45 @@ export default class Attachments extends SectionElement {
     )
   }
 
-  render () {
+  render() {
     return (
       <div className="attachments">
-        <Field title={i18n.t('application.attachments.method.title')}
-               help="application.attachments.help"
-               className="attachment-type"
-               optional={true}>
+        <Field
+          title={i18n.t('application.attachments.method.title')}
+          help="application.attachments.help"
+          className="attachment-type"
+          optional={true}>
           {i18n.m('application.attachments.method.para')}
-          <RadioGroup className="attachment-type option-list eapp-extend-labels"
-                      onError={this.props.onError}
-                      selectedValue={(this.props.AttachmentType || {}).value}>
-            <Radio name="attachment-type-upload"
-                   label={i18n.m('application.attachments.type.upload')}
-                   value="Upload"
-                   onUpdate={this.updateAttachmentType}
-                   onError={this.props.onError}>
+          <RadioGroup
+            className="attachment-type option-list eapp-extend-labels"
+            onError={this.props.onError}
+            selectedValue={(this.props.AttachmentType || {}).value}>
+            <Radio
+              name="attachment-type-upload"
+              label={i18n.m('application.attachments.type.upload')}
+              value="Upload"
+              onUpdate={this.updateAttachmentType}
+              onError={this.props.onError}>
               <div className="attachment-icon upload">
                 <Svg src="/img/attach-upload.svg" />
               </div>
             </Radio>
-            <Radio name="attachment-type-fax"
-                   label={i18n.m('application.attachments.type.fax')}
-                   value="Fax"
-                   onUpdate={this.updateAttachmentType}
-                   onError={this.props.onError}>
+            <Radio
+              name="attachment-type-fax"
+              label={i18n.m('application.attachments.type.fax')}
+              value="Fax"
+              onUpdate={this.updateAttachmentType}
+              onError={this.props.onError}>
               <div className="attachment-icon fax">
                 <Svg src="/img/attach-fax.svg" />
               </div>
             </Radio>
-            <Radio name="attachment-type-other"
-                   label={i18n.m('application.attachments.type.other')}
-                   value="Other"
-                   onUpdate={this.updateAttachmentType}
-                   onError={this.props.onError}>
+            <Radio
+              name="attachment-type-other"
+              label={i18n.m('application.attachments.type.other')}
+              value="Other"
+              onUpdate={this.updateAttachmentType}
+              onError={this.props.onError}>
               <div className="attachment-icon mail">
                 <Svg src="/img/attach-mail.svg" />
               </div>
@@ -219,20 +260,26 @@ export default class Attachments extends SectionElement {
         </Field>
 
         <Show when={(this.props.AttachmentType || {}).value === 'Upload'}>
-          <Field title={i18n.t('application.attachments.upload.title')}
-                 optional={true}
-                 className={this.state.errorMessage ? 'no-margin-bottom upload-area' : 'upload-area'}>
+          <Field
+            title={i18n.t('application.attachments.upload.title')}
+            optional={true}
+            className={
+              this.state.errorMessage
+                ? 'no-margin-bottom upload-area'
+                : 'upload-area'
+            }>
             {i18n.m('application.attachments.upload.para')}
             {this.limits()}
             <form ref="form">
               <input id="file-upload" ref="file" type="file" />
             </form>
-            <Text {...this.props.UploadDescription}
-                  name="UploadDescription"
-                  label={i18n.t('application.attachments.upload.description')}
-                  onUpdate={this.updateUploadDescription}
-                  onError={this.props.onError}
-                  />
+            <Text
+              {...this.props.UploadDescription}
+              name="UploadDescription"
+              label={i18n.t('application.attachments.upload.description')}
+              onUpdate={this.updateUploadDescription}
+              onError={this.props.onError}
+            />
             <button onClick={this.uploadFile}>
               {i18n.t('application.attachments.upload.send')}
             </button>
@@ -243,8 +290,10 @@ export default class Attachments extends SectionElement {
               <div className="table expand">
                 <span className="messages error-messages">
                   <div className="message error">
-                    <i className="fa fa-exclamation"></i>
-                    <h3>{i18n.t('application.attachments.upload.error.title')}</h3>
+                    <i className="fa fa-exclamation" />
+                    <h3>
+                      {i18n.t('application.attachments.upload.error.title')}
+                    </h3>
                     <p>{this.state.errorMessage}</p>
                   </div>
                 </span>
@@ -253,40 +302,40 @@ export default class Attachments extends SectionElement {
           </Show>
 
           <Show when={this.state.attachments.length > 0}>
-            <Field title={i18n.t('application.attachments.upload.files.title')}
-                   optional={true}>
+            <Field
+              title={i18n.t('application.attachments.upload.files.title')}
+              optional={true}>
               {i18n.m('application.attachments.upload.files.para')}
               <table>
-                <tbody>
-                  {this.displayAttachments(this.state.attachments)}
-                </tbody>
+                <tbody>{this.displayAttachments(this.state.attachments)}</tbody>
               </table>
             </Field>
           </Show>
         </Show>
 
         <Show when={(this.props.AttachmentType || {}).value === 'Fax'}>
-          <Field title={i18n.t('application.attachments.fax.title')}
-                 optional={true}
-                 className="fax-area">
+          <Field
+            title={i18n.t('application.attachments.fax.title')}
+            optional={true}
+            className="fax-area">
             {i18n.m('application.attachments.fax.para')}
-            <button>
-              {i18n.t('application.attachments.fax.print')}
-            </button>
+            <button>{i18n.t('application.attachments.fax.print')}</button>
           </Field>
         </Show>
 
         <Show when={(this.props.AttachmentType || {}).value === 'Other'}>
-          <Field title={i18n.t('application.attachments.other.title')}
-                 optional={true}
-                 className="other-area">
+          <Field
+            title={i18n.t('application.attachments.other.title')}
+            optional={true}
+            className="other-area">
             {i18n.m('application.attachments.other.para')}
-            <Text {...this.props.OtherMethod}
-                  name="OtherMethod"
-                  label={i18n.t('application.attachments.other.method')}
-                  onUpdate={this.updateOtherMethod}
-                  onError={this.props.onError}
-                  />
+            <Text
+              {...this.props.OtherMethod}
+              name="OtherMethod"
+              label={i18n.t('application.attachments.other.method')}
+              onUpdate={this.updateOtherMethod}
+              onError={this.props.onError}
+            />
           </Field>
         </Show>
       </div>
@@ -301,8 +350,10 @@ Attachments.defaultProps = {
   OtherMethod: {},
   section: 'releases',
   subsection: 'attachments',
-  onUpdate: (queue) => {},
-  onError: (value, arr) => { return arr }
+  onUpdate: queue => {},
+  onError: (value, arr) => {
+    return arr
+  }
 }
 
 const humanReadableFileSize = (bytes, si = true) => {
@@ -312,9 +363,9 @@ const humanReadableFileSize = (bytes, si = true) => {
   }
 
   const units = si
-        ? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-        : ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
-  let u = -1;
+    ? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+    : ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+  let u = -1
   do {
     bytes /= threshold
     u++
@@ -328,7 +379,7 @@ const blobFromBase64 = (base64, contentType = '', size = 512) => {
   const buffer = []
   for (let offset = 0; offset < binary.length; offset += size) {
     let slice = binary.slice(offset, offset + size)
-    let numbers =  new Array(slice.length)
+    let numbers = new Array(slice.length)
     for (let i = 0; i < slice.length; i++) {
       numbers[i] = slice.charCodeAt(i)
     }

--- a/src/components/Section/Package/Attachments.test.jsx
+++ b/src/components/Section/Package/Attachments.test.jsx
@@ -1,8 +1,17 @@
 import React from 'react'
+import renderer from 'react-test-renderer'
 import MockAdapter from 'axios-mock-adapter'
 import { mount } from 'enzyme'
 import { api } from '../../../services'
 import Attachments from './Attachments'
+
+// give a fake GUID so the field IDs don't differ between snapshots
+// https://github.com/facebook/jest/issues/936#issuecomment-404246102
+jest.mock('../../Form/ValidationElement/helpers', () =>
+  Object.assign(require.requireActual('../../Form/ValidationElement/helpers'), {
+    newGuid: jest.fn().mockReturnValue('MOCK-GUID')
+  })
+)
 
 describe('The attachments component', () => {
   beforeEach(() => {
@@ -56,5 +65,12 @@ describe('The attachments component', () => {
     expect(component.find('.upload-area').length).toBe(1)
     component.find('input[type="radio"][value="Upload"]').simulate('click')
     expect(updates).toBe(1)
+  })
+
+  it('renders properly', () => {
+    const props = { AttachmentType: { value: 'Upload' } }
+    const component = renderer.create(<Attachments {...props} />)
+    let tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
   })
 })

--- a/src/components/Section/Package/Attachments.test.jsx
+++ b/src/components/Section/Package/Attachments.test.jsx
@@ -24,7 +24,8 @@ describe('The attachments component', () => {
       errorMessage: 'This is a test'
     }
     const component = mount(<Attachments {...props} />)
-    expect(component.find('.upload-error .message.error p').text()).toBe(props.errorMessage)
+    const msg = component.find('.upload-error .message.error p').text()
+    expect(msg).toBe(props.errorMessage)
   })
 
   it('displays for fax', () => {
@@ -47,7 +48,9 @@ describe('The attachments component', () => {
     let updates = 0
     const props = {
       AttachmentType: { value: 'Upload' },
-      onUpdate: () => { updates++ }
+      onUpdate: () => {
+        updates++
+      }
     }
     const component = mount(<Attachments {...props} />)
     expect(component.find('.upload-area').length).toBe(1)

--- a/src/components/Section/Package/Print.jsx
+++ b/src/components/Section/Package/Print.jsx
@@ -20,7 +20,7 @@ import { PsychologicalSections } from '../Psychological'
 import AuthenticatedView from '../../../views/AuthenticatedView'
 
 class Print extends SectionElement {
-  constructor (props) {
+  constructor(props) {
     super(props)
     this.sections = this.sections.bind(this)
     this.handlePrint = this.handlePrint.bind(this)
@@ -31,48 +31,63 @@ class Print extends SectionElement {
 
     this.supportsBlobs = false
     try {
-      this.supportsBlobs = !!new window.Blob
+      this.supportsBlobs = !!new window.Blob()
     } catch (e) {
       this.supportsBlobs = false
     }
 
     this.getStoredAttachments = this.getStoredAttachments.bind(this)
     this.displayAttachments = this.displayAttachments.bind(this)
-
   }
 
-  download (id) {
+  download(id) {
     if (!this.supportsBlobs) {
       return
     }
 
     const attachment = this.state.attachments.find(x => x.id === id)
-    api.getAttachment(id).then((response) => {
-      const blob = blobFromBase64(response.data, 'application/octet-stream')
-      FileSaver.saveAs(blob, attachment.filename)
-    }).catch(() => {
-      this.setState({ errorMessage: i18n.t('application.attachments.upload.error.download') })
-    })
+    api
+      .getAttachment(id)
+      .then(response => {
+        const blob = blobFromBase64(response.data, 'application/octet-stream')
+        FileSaver.saveAs(blob, attachment.filename)
+      })
+      .catch(() => {
+        this.setState({
+          errorMessage: i18n.t('application.attachments.upload.error.download')
+        })
+      })
   }
 
-  getStoredAttachments () {
-    api.listAttachments().then((response) => {
+  getStoredAttachments() {
+    api.listAttachments().then(response => {
       this.setState({ attachments: response.data || [], errorMessage: '' })
     })
   }
 
-  displayAttachments (items) {
+  displayAttachments(items) {
     return items.map((x, i) => {
       return (
         <tr key={`attachment-${x.id}`}>
           <td>
             <Show when={this.supportsBlobs}>
-              <a href="javascript:;;" aria-label={`Download ${x.filename}`} onClick={this.download.bind(this, x.id)}>
-                <strong>{`${i+1}. `}{x.description ? `${x.description} - ` : ''}</strong>{x.filename}
+              <a
+                href="javascript:;;"
+                aria-label={`Download ${x.filename}`}
+                onClick={this.download.bind(this, x.id)}>
+                <strong>
+                  {`${i + 1}. `}
+                  {x.description ? `${x.description} - ` : ''}
+                </strong>
+                {x.filename}
               </a>
             </Show>
             <Show when={!this.supportsBlobs}>
-              <strong>{`${i+1}. `}{x.description ? `${x.description} - ` : ''}</strong>{x.filename}
+              <strong>
+                {`${i + 1}. `}
+                {x.description ? `${x.description} - ` : ''}
+              </strong>
+              {x.filename}
             </Show>
           </td>
         </tr>
@@ -80,14 +95,14 @@ class Print extends SectionElement {
     })
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     let nav = document.getElementsByClassName('form-navigation')[0]
     nav.removeEventListener('click', this.captureNavigationClick)
     let logout = document.getElementsByClassName('eapp-logout')[0]
     logout.removeEventListener('click', this.captureLogoutClick)
   }
 
-  componentDidMount () {
+  componentDidMount() {
     let nav = document.getElementsByClassName('form-navigation')[0]
     if (nav && nav.addEventListener) {
       nav.addEventListener('click', this.captureNavigationClick)
@@ -100,27 +115,31 @@ class Print extends SectionElement {
     this.getStoredAttachments()
   }
 
-  captureNavigationClick (e) {
+  captureNavigationClick(e) {
     if (!window.alert(i18n.t('application.alert.navigation'))) {
       e.stopPropagation()
     }
   }
 
-  captureLogoutClick (e) {
+  captureLogoutClick(e) {
     if (!window.confirm(i18n.t('application.alert.logout'))) {
       e.stopPropagation()
     }
   }
 
-  sections () {
+  sections() {
     return navigation.map((section, index, arr) => {
       let sectionComponent = null
       switch (section.url) {
         case 'identification':
-          sectionComponent = <IdentificationSections {...this.props.Identification} />
+          sectionComponent = (
+            <IdentificationSections {...this.props.Identification} />
+          )
           break
         case 'relationships':
-          sectionComponent = <RelationshipSections {...this.props.Relationships} />
+          sectionComponent = (
+            <RelationshipSections {...this.props.Relationships} />
+          )
           break
         case 'history':
           sectionComponent = <HistorySections {...this.props.History} />
@@ -129,7 +148,12 @@ class Print extends SectionElement {
           sectionComponent = <CitizenshipSections {...this.props.Citizenship} />
           break
         case 'military':
-          sectionComponent = <MilitarySections {...this.props.Military} application={this.props.Application} />
+          sectionComponent = (
+            <MilitarySections
+              {...this.props.Military}
+              application={this.props.Application}
+            />
+          )
           break
         case 'foreign':
           sectionComponent = <ForeignSections {...this.props.Foreign} />
@@ -138,13 +162,17 @@ class Print extends SectionElement {
           sectionComponent = <FinancialSections {...this.props.Financial} />
           break
         case 'substance':
-          sectionComponent = <SubstanceUseSections {...this.props.SubstanceUse} />
+          sectionComponent = (
+            <SubstanceUseSections {...this.props.SubstanceUse} />
+          )
           break
         case 'legal':
           sectionComponent = <LegalSections {...this.props.Legal} />
           break
         case 'psychological':
-          sectionComponent = <PsychologicalSections {...this.props.Psychological} />
+          sectionComponent = (
+            <PsychologicalSections {...this.props.Psychological} />
+          )
           break
         default:
           return null
@@ -153,13 +181,13 @@ class Print extends SectionElement {
       return (
         <div className="section-print-container" key={index}>
           <h3 className="section-print-header">{section.title}</h3>
-          { sectionComponent }
+          {sectionComponent}
         </div>
       )
     })
   }
 
-  handlePrint () {
+  handlePrint() {
     let interval = setInterval(() => {
       if (document.hasFocus()) {
         clearInterval(interval)
@@ -169,57 +197,58 @@ class Print extends SectionElement {
     window.print()
   }
 
-  done () {
+  done() {
     return (
       <div className="done">
         <span className="icon">
           <Svg src="/img/checkmark.svg" alt={i18n.t('review.completeSvg')} />
         </span>
-        { i18n.m('application.print.done') }
+        {i18n.m('application.print.done')}
       </div>
     )
   }
 
-  render () {
+  render() {
     return (
       <div className="pre-print-view">
         <div>
-          { i18n.m('application.print.title') }
+          {i18n.m('application.print.title')}
           <button className="print-btn" onClick={this.handlePrint}>
-            { i18n.t('application.print.button') }
+            {i18n.t('application.print.button')}
           </button>
-          <Show when={this.state.printed}>
-            { this.done() }
-          </Show>
+          <Show when={this.state.printed}>{this.done()}</Show>
           <h4 className="hash">{i18n.t('application.hashCode.title')}</h4>
           <p className="hash">{this.props.Settings.hash}</p>
         </div>
         <div>
-          <h4 className="attachments">{i18n.t('application.print.files.title')}</h4>
-          <p className="attachments">{i18n.m('application.print.files.para')}</p>
+          <h4 className="attachments">
+            {i18n.t('application.print.files.title')}
+          </h4>
+          <p className="attachments">
+            {i18n.m('application.print.files.para')}
+          </p>
           <table>
-            <tbody>
-              {this.displayAttachments(this.state.attachments)}
-            </tbody>
+            <tbody>{this.displayAttachments(this.state.attachments)}</tbody>
           </table>
         </div>
-        <div className="print-view">
-          { this.sections() }
-        </div>
-
+        <div className="print-view">{this.sections()}</div>
       </div>
     )
   }
 }
 
-function mapStateToProps (state) {
+function mapStateToProps(state) {
   const app = state.application || {}
   const identification = app.Identification || {}
   const relationships = app.Relationships || {}
   const history = app.History || {}
   const historyResidence = history.Residence || {}
   const historyEmployment = history.Employment || { List: {} }
-  const historyEducation = history.Education || { HasAttended: '', HasDegree10: '', List: {} }
+  const historyEducation = history.Education || {
+    HasAttended: '',
+    HasDegree10: '',
+    List: {}
+  }
   const citizenship = app.Citizenship || {}
   const military = app.Military || {}
   const foreign = app.Foreign || {}
@@ -257,7 +286,7 @@ function mapStateToProps (state) {
 Print.defaultProps = {
   section: 'print',
   subsection: 'intro',
-  store: 'Print',
+  store: 'Print'
 }
 
 const blobFromBase64 = (base64, contentType = '', size = 512) => {
@@ -265,7 +294,7 @@ const blobFromBase64 = (base64, contentType = '', size = 512) => {
   const buffer = []
   for (let offset = 0; offset < binary.length; offset += size) {
     let slice = binary.slice(offset, offset + size)
-    let numbers =  new Array(slice.length)
+    let numbers = new Array(slice.length)
     for (let i = 0; i < slice.length; i++) {
       numbers[i] = slice.charCodeAt(i)
     }
@@ -273,6 +302,5 @@ const blobFromBase64 = (base64, contentType = '', size = 512) => {
   }
   return new window.Blob(buffer, { type: contentType })
 }
-
 
 export default connect(mapStateToProps)(AuthenticatedView(Print))

--- a/src/components/Section/Package/Print.jsx
+++ b/src/components/Section/Package/Print.jsx
@@ -1,11 +1,9 @@
 import React from 'react'
 import FileSaver from 'file-saver'
 import { connect } from 'react-redux'
-import { i18n, env, navigation } from '../../../config'
+import { i18n, navigation } from '../../../config'
 import { api } from '../../../services'
-import { SectionViews, SectionView } from '../SectionView'
-import SectionElement from '../SectionElement'
-import { Show, Svg, Field, Text, RadioGroup, Radio } from '../../Form'
+import { Show, Svg } from '../../Form'
 
 import { IdentificationSections } from '../Identification'
 import { RelationshipSections } from '../Relationships'
@@ -19,7 +17,7 @@ import { LegalSections } from '../Legal'
 import { PsychologicalSections } from '../Psychological'
 import AuthenticatedView from '../../../views/AuthenticatedView'
 
-class Print extends SectionElement {
+class Print extends React.Component {
   constructor(props) {
     super(props)
     this.sections = this.sections.bind(this)

--- a/src/components/Section/Package/Print.test.jsx
+++ b/src/components/Section/Package/Print.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import renderer from 'react-test-renderer'
 import MockAdapter from 'axios-mock-adapter'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
@@ -10,6 +11,14 @@ import Print from './Print'
 const applicationState = {
   Application: {}
 }
+
+// give a fake GUID so the field IDs don't differ between snapshots
+// https://github.com/facebook/jest/issues/936#issuecomment-404246102
+jest.mock('../../Form/ValidationElement/helpers', () =>
+  Object.assign(require.requireActual('../../Form/ValidationElement/helpers'), {
+    newGuid: jest.fn().mockReturnValue('MOCK-GUID')
+  })
+)
 
 describe('The print section', () => {
   // Setup
@@ -51,5 +60,19 @@ describe('The print section', () => {
     )
     component.find('.print-btn').simulate('click')
     expect(printed).toBe(true)
+  })
+
+  it('renders properly', () => {
+    const store = mockStore({
+      authentication: { authenticated: true },
+      application: applicationState
+    })
+    const component = renderer.create(
+      <Provider store={store}>
+        <Print subsection="intro" />
+      </Provider>
+    )
+    let tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
   })
 })

--- a/src/components/Section/Package/Print.test.jsx
+++ b/src/components/Section/Package/Print.test.jsx
@@ -14,7 +14,7 @@ const applicationState = {
 describe('The print section', () => {
   // Setup
   window.token = 'fake-token'
-  const middlewares = [ thunk ]
+  const middlewares = [thunk]
   const mockStore = configureMockStore(middlewares)
 
   beforeEach(() => {
@@ -23,18 +23,32 @@ describe('The print section', () => {
   })
 
   it('visible when authenticated', () => {
-    const store = mockStore({ authentication: { authenticated: true }, application: applicationState })
-    const component = mount(<Provider store={store}><Print subsection="intro" /></Provider>)
+    const store = mockStore({
+      authentication: { authenticated: true },
+      application: applicationState
+    })
+    const component = mount(
+      <Provider store={store}>
+        <Print subsection="intro" />
+      </Provider>
+    )
     expect(component.find('.section-print-container').length).toBe(10)
   })
 
   it('launches print dialog', () => {
     let printed = false
-    window.print = function () {
+    window.print = function() {
       printed = true
     }
-    const store = mockStore({ authentication: { authenticated: true }, application: applicationState })
-    const component = mount(<Provider store={store}><Print subsection="intro" /></Provider>)
+    const store = mockStore({
+      authentication: { authenticated: true },
+      application: applicationState
+    })
+    const component = mount(
+      <Provider store={store}>
+        <Print subsection="intro" />
+      </Provider>
+    )
     component.find('.print-btn').simulate('click')
     expect(printed).toBe(true)
   })

--- a/src/components/Section/Package/__snapshots__/Attachments.test.jsx.snap
+++ b/src/components/Section/Package/__snapshots__/Attachments.test.jsx.snap
@@ -1,0 +1,311 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The attachments component renders properly 1`] = `
+<div
+  className="attachments"
+>
+  <div
+    aria-label="Specify your attachment method"
+    className="field   attachment-type"
+    data-uuid="field-MOCK-GUID"
+  >
+    <a
+      aria-hidden="true"
+      className="anchor"
+      id="field-MOCK-GUID"
+      name="field-MOCK-GUID"
+    />
+    <h3
+      className="title h3"
+    >
+      Specify your attachment method
+    </h3>
+    <span
+      className="icon"
+    >
+      <a
+        aria-label="Show help for Specify your attachment method"
+        className="toggle h3"
+        href="javascript:;"
+        onClick={[Function]}
+        title="Show help for Specify your attachment method"
+      >
+        <svg
+          alt="Scalable vector graphic"
+          focusable="false"
+          height="14.57px"
+          tabIndex="-1"
+          viewBox="0 0 14.57 14.57"
+          width="14.57px"
+        >
+          <g>
+            <path
+              className="eapp-help-icon"
+              d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+            />
+          </g>
+        </svg>
+      </a>
+    </span>
+    <div
+      className="table expand"
+    >
+      <span
+        aria-live="polite"
+        className="messages help-messages"
+      />
+    </div>
+    <div
+      className="table"
+    >
+      <span
+        className="content"
+      >
+        <span
+          className="component"
+        >
+          <div>
+            <p>
+              Choose the method you will use to provide attachments for your Investigation Request.
+            </p>
+          </div>
+          <div
+            className="blocks attachment-type option-list eapp-extend-labels"
+          >
+            <div
+              className="block extended"
+            >
+              <label
+                className="checked"
+                htmlFor="attachment-type-upload-MOCK-GUID"
+              >
+                <input
+                  aria-label="[object Object] for null"
+                  checked={true}
+                  className="usa-input-success selected"
+                  disabled={false}
+                  id="attachment-type-upload-MOCK-GUID"
+                  name="attachment-type-upload-MOCK-GUID"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  type="radio"
+                  value="Upload"
+                />
+                <div
+                  className="attachment-icon upload"
+                >
+                  <img
+                    alt="Scalable vector graphic"
+                    className="svg"
+                    src="/img/attach-upload.svg"
+                  />
+                </div>
+                <span>
+                  <div>
+                    <p>
+                      Upload file
+                    </p>
+                  </div>
+                </span>
+              </label>
+            </div>
+            <div
+              className="block extended"
+            >
+              <label
+                className=""
+                htmlFor="attachment-type-fax-MOCK-GUID"
+              >
+                <input
+                  aria-label="[object Object] for null"
+                  checked={false}
+                  className="usa-input-success"
+                  disabled={false}
+                  id="attachment-type-fax-MOCK-GUID"
+                  name="attachment-type-fax-MOCK-GUID"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  type="radio"
+                  value="Fax"
+                />
+                <div
+                  className="attachment-icon fax"
+                >
+                  <img
+                    alt="Scalable vector graphic"
+                    className="svg"
+                    src="/img/attach-fax.svg"
+                  />
+                </div>
+                <span>
+                  <div>
+                    <p>
+                      Direct fax
+                    </p>
+                  </div>
+                </span>
+              </label>
+            </div>
+            <div
+              className="block extended"
+            >
+              <label
+                className=""
+                htmlFor="attachment-type-other-MOCK-GUID"
+              >
+                <input
+                  aria-label="[object Object] for null"
+                  checked={false}
+                  className="usa-input-success"
+                  disabled={false}
+                  id="attachment-type-other-MOCK-GUID"
+                  name="attachment-type-other-MOCK-GUID"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  type="radio"
+                  value="Other"
+                />
+                <div
+                  className="attachment-icon mail"
+                >
+                  <img
+                    alt="Scalable vector graphic"
+                    className="svg"
+                    src="/img/attach-mail.svg"
+                  />
+                </div>
+                <span>
+                  <div>
+                    <p>
+                      Other
+                    </p>
+                  </div>
+                </span>
+              </label>
+            </div>
+          </div>
+        </span>
+      </span>
+    </div>
+    <div
+      className="table expand"
+    >
+      <span
+        aria-live="polite"
+        className="messages error-messages"
+        role="alert"
+      />
+    </div>
+  </div>
+  <span>
+    <div
+      aria-label="Upload file to e-QIP directly"
+      className="field   upload-area"
+      data-uuid="field-MOCK-GUID"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
+      />
+      <h3
+        className="title h3"
+      >
+        Upload file to e-QIP directly
+      </h3>
+      <span
+        className="icon"
+      />
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component"
+          >
+            <div>
+              <p>
+                Certification, General Release and Medical Release forms must be attached separately as single page documents. Items such as a resume or OF 612 can be uploaded as multi-page documents.
+              </p>
+            </div>
+            <p>
+              <strong>
+                TIFF, PNG, or PDF files only. Maximum file size allowed is 5.0 MB.
+              </strong>
+            </p>
+            <form>
+              <input
+                id="file-upload"
+                type="file"
+              />
+            </form>
+            <div
+              className=""
+            >
+              <label
+                className=""
+                htmlFor="UploadDescription-MOCK-GUID"
+              >
+                Description
+              </label>
+              <input
+                aria-describedby="UploadDescription-error"
+                aria-label="Description"
+                autoCapitalize={true}
+                autoComplete={true}
+                autoCorrect={true}
+                className=""
+                id="UploadDescription-MOCK-GUID"
+                maxLength={255}
+                name="UploadDescription"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                pattern=".*"
+                spellCheck={true}
+                type="text"
+                value=""
+              />
+            </div>
+            <button
+              onClick={[Function]}
+            >
+              Upload attachment
+            </button>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        />
+      </div>
+    </div>
+  </span>
+</div>
+`;

--- a/src/components/Section/Package/__snapshots__/Print.test.jsx.snap
+++ b/src/components/Section/Package/__snapshots__/Print.test.jsx.snap
@@ -1,0 +1,15829 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The print section renders properly 1`] = `
+<div
+  className="pre-print-view"
+>
+  <div>
+    <div>
+      <h2>
+        Please print and save your responses
+      </h2>
+    </div>
+    <div>
+      <p>
+        <strong>
+          This will be your only opportunity.
+        </strong>
+         Your form will be locked when you logout. Be sure to print and save your responses before leaving this screen. To save a PDF click the Save/Print button then change the printer "Destination" to "Save as PDF".
+      </p>
+    </div>
+    <button
+      className="print-btn"
+      onClick={[Function]}
+    >
+      Save/Print
+    </button>
+    <h4
+      className="hash"
+    >
+      Data hash code
+    </h4>
+    <p
+      className="hash"
+    >
+      
+    </p>
+  </div>
+  <div>
+    <h4
+      className="attachments"
+    >
+      Certification and Releases
+    </h4>
+    <p
+      className="attachments"
+    >
+      <div>
+        <p>
+          The following are archival documents corresponding to your digitally signed certification and releases.
+        </p>
+      </div>
+    </p>
+    <table>
+      <tbody />
+    </table>
+  </div>
+  <div
+    className="print-view"
+  >
+    <div
+      className="section-print-container"
+    >
+      <h3
+        className="section-print-header"
+      >
+        Information about you
+      </h3>
+      <div>
+        <div
+          className="section-content applicant-name"
+          data-section="identification"
+          data-subsection="name"
+        >
+          <div
+            aria-label="Provide your full name"
+            className="field"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Provide your full name
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div
+                    className="name "
+                  >
+                    <div
+                      aria-label="First name"
+                      className="field required"
+                      data-uuid="field-MOCK-GUID"
+                    >
+                      <a
+                        aria-hidden="true"
+                        className="anchor"
+                        id="field-MOCK-GUID"
+                        name="field-MOCK-GUID"
+                      />
+                      <label
+                        className="title label"
+                      >
+                        First name
+                      </label>
+                      <span
+                        className="icon"
+                      >
+                        <a
+                          aria-label="Show help for First name"
+                          className="toggle label  adjust-for-labels"
+                          href="javascript:;"
+                          onClick={[Function]}
+                          title="Show help for First name"
+                        >
+                          <svg
+                            alt="Scalable vector graphic"
+                            focusable="false"
+                            height="14.57px"
+                            tabIndex="-1"
+                            viewBox="0 0 14.57 14.57"
+                            width="14.57px"
+                          >
+                            <g>
+                              <path
+                                className="eapp-help-icon"
+                                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                              />
+                            </g>
+                          </svg>
+                        </a>
+                      </span>
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages help-messages"
+                        />
+                      </div>
+                      <div
+                        className="table"
+                      >
+                        <span
+                          className="content"
+                        >
+                          <span
+                            className="component"
+                          >
+                            <div
+                              className="first usa-input-error"
+                            >
+                              <input
+                                aria-describedby="first-error"
+                                aria-label={null}
+                                autoCapitalize={true}
+                                autoComplete={true}
+                                autoCorrect={true}
+                                className=""
+                                id="first-MOCK-GUID"
+                                maxLength="100"
+                                name="first"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                pattern="^[a-zA-Z\\\\-\\\\.' ]*$"
+                                spellCheck={true}
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                            <div
+                              className="flags"
+                            >
+                              <div
+                                className="first-initial-only block"
+                              >
+                                <input
+                                  aria-label="Initial only for null"
+                                  checked={false}
+                                  className="usa-input-success"
+                                  id="firstInitialOnly-MOCK-GUID"
+                                  name="firstInitialOnly"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  type="checkbox"
+                                  value={false}
+                                />
+                                <label
+                                  className="checkbox no-toggle"
+                                  htmlFor="firstInitialOnly-MOCK-GUID"
+                                >
+                                  <span>
+                                    Initial only
+                                  </span>
+                                </label>
+                              </div>
+                            </div>
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages error-messages"
+                          role="alert"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      aria-label="Middle name"
+                      className="field required"
+                      data-uuid="field-MOCK-GUID"
+                    >
+                      <a
+                        aria-hidden="true"
+                        className="anchor"
+                        id="field-MOCK-GUID"
+                        name="field-MOCK-GUID"
+                      />
+                      <label
+                        className="title label"
+                      >
+                        Middle name
+                      </label>
+                      <span
+                        className="icon"
+                      >
+                        <a
+                          aria-label="Show help for Middle name"
+                          className="toggle label  adjust-for-labels"
+                          href="javascript:;"
+                          onClick={[Function]}
+                          title="Show help for Middle name"
+                        >
+                          <svg
+                            alt="Scalable vector graphic"
+                            focusable="false"
+                            height="14.57px"
+                            tabIndex="-1"
+                            viewBox="0 0 14.57 14.57"
+                            width="14.57px"
+                          >
+                            <g>
+                              <path
+                                className="eapp-help-icon"
+                                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                              />
+                            </g>
+                          </svg>
+                        </a>
+                      </span>
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages help-messages"
+                        />
+                      </div>
+                      <div
+                        className="table"
+                      >
+                        <span
+                          className="content"
+                        >
+                          <span
+                            className="component"
+                          >
+                            <div
+                              className="middle usa-input-error"
+                            >
+                              <input
+                                aria-describedby="middle-error"
+                                aria-label={null}
+                                autoCapitalize={true}
+                                autoComplete={true}
+                                autoCorrect={true}
+                                className=""
+                                id="middle-MOCK-GUID"
+                                maxLength="100"
+                                name="middle"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                pattern="^[a-zA-Z\\\\-\\\\.' ]*$"
+                                spellCheck={true}
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                            <div
+                              className="middle-options flags"
+                            >
+                              <div
+                                className="middle-none block"
+                              >
+                                <input
+                                  aria-label="No middle name for null"
+                                  checked={false}
+                                  className="usa-input-success"
+                                  id="noMiddleName-MOCK-GUID"
+                                  name="noMiddleName"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  type="checkbox"
+                                  value={false}
+                                />
+                                <label
+                                  className="checkbox no-toggle"
+                                  htmlFor="noMiddleName-MOCK-GUID"
+                                >
+                                  <span>
+                                    No middle name
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                className="middle-initial-only block"
+                              >
+                                <input
+                                  aria-label="Initial only for null"
+                                  checked={false}
+                                  className="usa-input-success"
+                                  id="middleInitialOnly-MOCK-GUID"
+                                  name="middleInitialOnly"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  type="checkbox"
+                                  value={false}
+                                />
+                                <label
+                                  className="checkbox no-toggle"
+                                  htmlFor="middleInitialOnly-MOCK-GUID"
+                                >
+                                  <span>
+                                    Initial only
+                                  </span>
+                                </label>
+                              </div>
+                            </div>
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages error-messages"
+                          role="alert"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      aria-label="Last name"
+                      className="field required"
+                      data-uuid="field-MOCK-GUID"
+                    >
+                      <a
+                        aria-hidden="true"
+                        className="anchor"
+                        id="field-MOCK-GUID"
+                        name="field-MOCK-GUID"
+                      />
+                      <label
+                        className="title label"
+                      >
+                        Last name
+                      </label>
+                      <span
+                        className="icon"
+                      >
+                        <a
+                          aria-label="Show help for Last name"
+                          className="toggle label  adjust-for-labels"
+                          href="javascript:;"
+                          onClick={[Function]}
+                          title="Show help for Last name"
+                        >
+                          <svg
+                            alt="Scalable vector graphic"
+                            focusable="false"
+                            height="14.57px"
+                            tabIndex="-1"
+                            viewBox="0 0 14.57 14.57"
+                            width="14.57px"
+                          >
+                            <g>
+                              <path
+                                className="eapp-help-icon"
+                                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                              />
+                            </g>
+                          </svg>
+                        </a>
+                      </span>
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages help-messages"
+                        />
+                      </div>
+                      <div
+                        className="table"
+                      >
+                        <span
+                          className="content"
+                        >
+                          <span
+                            className="component"
+                          >
+                            <div
+                              className="last usa-input-error"
+                            >
+                              <input
+                                aria-describedby="last-error"
+                                aria-label={null}
+                                autoCapitalize={true}
+                                autoComplete={true}
+                                autoCorrect={true}
+                                className=""
+                                id="last-MOCK-GUID"
+                                maxLength="100"
+                                name="last"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                pattern="^[a-zA-Z\\\\-\\\\.' ]*$"
+                                spellCheck={true}
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                            <div
+                              className="flags"
+                            >
+                              <div
+                                className="last-initial-only block"
+                              >
+                                <input
+                                  aria-label="Initial only for null"
+                                  checked={false}
+                                  className="usa-input-success"
+                                  id="lastInitialOnly-MOCK-GUID"
+                                  name="lastInitialOnly"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  type="checkbox"
+                                  value={false}
+                                />
+                                <label
+                                  className="checkbox no-toggle"
+                                  htmlFor="lastInitialOnly-MOCK-GUID"
+                                >
+                                  <span>
+                                    Initial only
+                                  </span>
+                                </label>
+                              </div>
+                            </div>
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages error-messages"
+                          role="alert"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      aria-label="Suffix"
+                      className="field"
+                      data-uuid="field-MOCK-GUID"
+                    >
+                      <a
+                        aria-hidden="true"
+                        className="anchor"
+                        id="field-MOCK-GUID"
+                        name="field-MOCK-GUID"
+                      />
+                      <label
+                        className="title label"
+                      >
+                        Suffix
+                        <span
+                          className="optional"
+                        >
+                          (Optional)
+                        </span>
+                      </label>
+                      <span
+                        className="icon"
+                      >
+                        <a
+                          aria-label="Show help for Suffix"
+                          className="toggle label"
+                          href="javascript:;"
+                          onClick={[Function]}
+                          title="Show help for Suffix"
+                        >
+                          <svg
+                            alt="Scalable vector graphic"
+                            focusable="false"
+                            height="14.57px"
+                            tabIndex="-1"
+                            viewBox="0 0 14.57 14.57"
+                            width="14.57px"
+                          >
+                            <g>
+                              <path
+                                className="eapp-help-icon"
+                                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                              />
+                            </g>
+                          </svg>
+                        </a>
+                      </span>
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages help-messages"
+                        />
+                      </div>
+                      <div
+                        className="table"
+                      >
+                        <span
+                          className="content"
+                        >
+                          <span
+                            className="component"
+                          >
+                            <div
+                              className="blocks option-list suffix"
+                            >
+                              <div
+                                className="suffix-jr block"
+                              >
+                                <label
+                                  className=""
+                                  htmlFor="suffix-MOCK-GUID"
+                                >
+                                  <input
+                                    aria-label="Jr for null"
+                                    checked={false}
+                                    className="usa-input-success"
+                                    disabled={false}
+                                    id="suffix-MOCK-GUID"
+                                    name="suffix-MOCK-GUID"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    type="radio"
+                                    value="Jr"
+                                  />
+                                  <span>
+                                    Jr
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                className="suffix-sr block"
+                              >
+                                <label
+                                  className=""
+                                  htmlFor="suffix-MOCK-GUID"
+                                >
+                                  <input
+                                    aria-label="Sr for null"
+                                    checked={false}
+                                    className="usa-input-success"
+                                    disabled={false}
+                                    id="suffix-MOCK-GUID"
+                                    name="suffix-MOCK-GUID"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    type="radio"
+                                    value="Sr"
+                                  />
+                                  <span>
+                                    Sr
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                className="suffix-i block"
+                              >
+                                <label
+                                  className=""
+                                  htmlFor="suffix-MOCK-GUID"
+                                >
+                                  <input
+                                    aria-label="I for null"
+                                    checked={false}
+                                    className="usa-input-success"
+                                    disabled={false}
+                                    id="suffix-MOCK-GUID"
+                                    name="suffix-MOCK-GUID"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    type="radio"
+                                    value="I"
+                                  />
+                                  <span>
+                                    I
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                className="suffix-ii block"
+                              >
+                                <label
+                                  className=""
+                                  htmlFor="suffix-MOCK-GUID"
+                                >
+                                  <input
+                                    aria-label="II for null"
+                                    checked={false}
+                                    className="usa-input-success"
+                                    disabled={false}
+                                    id="suffix-MOCK-GUID"
+                                    name="suffix-MOCK-GUID"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    type="radio"
+                                    value="II"
+                                  />
+                                  <span>
+                                    II
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                className="suffix-iii block"
+                              >
+                                <label
+                                  className=""
+                                  htmlFor="suffix-MOCK-GUID"
+                                >
+                                  <input
+                                    aria-label="III for null"
+                                    checked={false}
+                                    className="usa-input-success"
+                                    disabled={false}
+                                    id="suffix-MOCK-GUID"
+                                    name="suffix-MOCK-GUID"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    type="radio"
+                                    value="III"
+                                  />
+                                  <span>
+                                    III
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                className="suffix-iv block"
+                              >
+                                <label
+                                  className=""
+                                  htmlFor="suffix-MOCK-GUID"
+                                >
+                                  <input
+                                    aria-label="IV for null"
+                                    checked={false}
+                                    className="usa-input-success"
+                                    disabled={false}
+                                    id="suffix-MOCK-GUID"
+                                    name="suffix-MOCK-GUID"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    type="radio"
+                                    value="IV"
+                                  />
+                                  <span>
+                                    IV
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                className="suffix-v block"
+                              >
+                                <label
+                                  className=""
+                                  htmlFor="suffix-MOCK-GUID"
+                                >
+                                  <input
+                                    aria-label="V for null"
+                                    checked={false}
+                                    className="usa-input-success"
+                                    disabled={false}
+                                    id="suffix-MOCK-GUID"
+                                    name="suffix-MOCK-GUID"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    type="radio"
+                                    value="V"
+                                  />
+                                  <span>
+                                    V
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                className="suffix-vi block"
+                              >
+                                <label
+                                  className=""
+                                  htmlFor="suffix-MOCK-GUID"
+                                >
+                                  <input
+                                    aria-label="VI for null"
+                                    checked={false}
+                                    className="usa-input-success"
+                                    disabled={false}
+                                    id="suffix-MOCK-GUID"
+                                    name="suffix-MOCK-GUID"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    type="radio"
+                                    value="VI"
+                                  />
+                                  <span>
+                                    VI
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                className="suffix-vii block"
+                              >
+                                <label
+                                  className=""
+                                  htmlFor="suffix-MOCK-GUID"
+                                >
+                                  <input
+                                    aria-label="VII for null"
+                                    checked={false}
+                                    className="usa-input-success"
+                                    disabled={false}
+                                    id="suffix-MOCK-GUID"
+                                    name="suffix-MOCK-GUID"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    type="radio"
+                                    value="VII"
+                                  />
+                                  <span>
+                                    VII
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                className="suffix-viii block"
+                              >
+                                <label
+                                  className=""
+                                  htmlFor="suffix-MOCK-GUID"
+                                >
+                                  <input
+                                    aria-label="VIII for null"
+                                    checked={false}
+                                    className="usa-input-success"
+                                    disabled={false}
+                                    id="suffix-MOCK-GUID"
+                                    name="suffix-MOCK-GUID"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    type="radio"
+                                    value="VIII"
+                                  />
+                                  <span>
+                                    VIII
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                className="suffix-ix block"
+                              >
+                                <label
+                                  className=""
+                                  htmlFor="suffix-MOCK-GUID"
+                                >
+                                  <input
+                                    aria-label="IX for null"
+                                    checked={false}
+                                    className="usa-input-success"
+                                    disabled={false}
+                                    id="suffix-MOCK-GUID"
+                                    name="suffix-MOCK-GUID"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    type="radio"
+                                    value="IX"
+                                  />
+                                  <span>
+                                    IX
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                className="suffix-x block"
+                              >
+                                <label
+                                  className=""
+                                  htmlFor="suffix-MOCK-GUID"
+                                >
+                                  <input
+                                    aria-label="X for null"
+                                    checked={false}
+                                    className="usa-input-success"
+                                    disabled={false}
+                                    id="suffix-MOCK-GUID"
+                                    name="suffix-MOCK-GUID"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    type="radio"
+                                    value="X"
+                                  />
+                                  <span>
+                                    X
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                className="suffix-more block"
+                              >
+                                <label
+                                  className=""
+                                  htmlFor="suffix-MOCK-GUID"
+                                >
+                                  <input
+                                    aria-label="Other for null"
+                                    checked={false}
+                                    className="usa-input-success"
+                                    disabled={false}
+                                    id="suffix-MOCK-GUID"
+                                    name="suffix-MOCK-GUID"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    type="radio"
+                                    value="Other"
+                                  />
+                                  <span>
+                                    Other
+                                  </span>
+                                </label>
+                              </div>
+                            </div>
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages error-messages"
+                          role="alert"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.name.first.required"
+                  >
+                    <h5>
+                      Oops, there’s a problem.
+                    </h5>
+                    <span>
+                      <div>
+                        <p>
+                          If your first name is a single letter, please select the "Initial only" checkbox and type the letter. 100 character limit.
+                        </p>
+                      </div>
+                    </span>
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content other-names"
+          data-section="identification"
+          data-subsection="othernames"
+        >
+          <div
+            aria-label="Provide your other names used and the period of time you used them"
+            className="field   no-margin-bottom"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Provide your other names used and the period of time you used them
+            </h2>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Provide your other names used and the period of time you used them"
+                className="toggle h2"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Provide your other names used and the period of time you used them"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div>
+                    <p>
+                      For example: your maiden name, name(s) by a former marriage, former name(s), alias(es), or nickname(s).
+                    </p>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+          </div>
+          <div
+            aria-label="Have you used any other names?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Have you used any other names?
+            </h3>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_othernames-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_othernames-MOCK-GUID"
+                          name="has_othernames-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_othernames-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_othernames-MOCK-GUID"
+                          name="has_othernames-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content contact"
+          data-section="identification"
+          data-subsection="contacts"
+        >
+          <div
+            aria-label="Provide your contact information"
+            className="field   no-margin-bottom"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Provide your contact information
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                />
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+          </div>
+          <div
+            aria-label="Your email addresses"
+            className="field   no-margin-bottom"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Your email addresses
+            </h3>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Your email addresses"
+                className="toggle h3"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Your email addresses"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div>
+                    <p>
+                      Providing email addresses may assist in the completion of your background investigation. Email addresses may be used as contact method, and identify subject in records.
+                    </p>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+          </div>
+          <div
+            className=" email-collection"
+          >
+            <div>
+              <div
+                className="accordion"
+              >
+                <strong
+                  className="aria-description"
+                >
+                  Summary of email addresses
+                </strong>
+                <div
+                  className="items"
+                />
+                <div
+                  className="append-button"
+                >
+                  <button
+                    className="add usa-button-outline"
+                    onClick={[Function]}
+                  >
+                    Add another email
+                    <i
+                      className="fa fa-plus-circle"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-label="Your phone numbers"
+            className="field   no-margin-bottom"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Your phone numbers
+            </h3>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Your phone numbers"
+                className="toggle h3"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Your phone numbers"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div>
+                    <p>
+                      Provide three contact numbers. 
+                      <strong>
+                        At least one number is required
+                      </strong>
+                      . Additional numbers may assist in the completion of your background investigation.
+                    </p>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+          </div>
+          <div
+            className=" telephone-collection"
+          >
+            <div>
+              <div
+                className="accordion"
+              >
+                <strong
+                  className="aria-description"
+                >
+                  Summary of phone numbers
+                </strong>
+                <div
+                  className="items"
+                />
+                <div
+                  className="append-button"
+                >
+                  <button
+                    className="add usa-button-outline"
+                    onClick={[Function]}
+                  >
+                    Add another phone number
+                    <i
+                      className="fa fa-plus-circle"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content birthdate"
+          data-section="identification"
+          data-subsection="birthdate"
+        >
+          <div
+            aria-label="Provide your date of birth"
+            className="field required"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Provide your date of birth
+            </h2>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Provide your date of birth"
+                className="toggle h2"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Provide your date of birth"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div
+                    className="datecontrol"
+                  >
+                    <div>
+                      <div
+                        className="usa-form-group month"
+                      >
+                        <div
+                          className="usa-input-error"
+                        >
+                          <label
+                            className="usa-input-error-label"
+                            htmlFor="month-MOCK-GUID"
+                          >
+                            Month
+                          </label>
+                          <input
+                            aria-describedby="month-error"
+                            aria-label="Month"
+                            autoCapitalize={true}
+                            autoComplete={true}
+                            autoCorrect={true}
+                            className=""
+                            disabled={false}
+                            id="month-MOCK-GUID"
+                            maxLength="2"
+                            name="month"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            pattern="^(\\\\s*|\\\\d+)$"
+                            placeholder="##"
+                            spellCheck={true}
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        className="usa-form-group day "
+                      >
+                        <div
+                          className="usa-input-error"
+                        >
+                          <label
+                            className="usa-input-error-label"
+                            htmlFor="day-MOCK-GUID"
+                          >
+                            Day
+                          </label>
+                          <input
+                            aria-describedby="day-error"
+                            aria-label="Day"
+                            autoCapitalize={true}
+                            autoComplete={true}
+                            autoCorrect={true}
+                            className=""
+                            disabled={false}
+                            id="day-MOCK-GUID"
+                            maxLength="2"
+                            name="day"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            pattern="^(\\\\s*|\\\\d+)$"
+                            placeholder="##"
+                            spellCheck={true}
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        className="usa-form-group year"
+                      >
+                        <div
+                          className="usa-input-error"
+                        >
+                          <label
+                            className="usa-input-error-label"
+                            htmlFor="year-MOCK-GUID"
+                          >
+                            Year
+                          </label>
+                          <input
+                            aria-describedby="year-error"
+                            aria-label="Year"
+                            autoCapitalize={true}
+                            autoComplete={true}
+                            autoCorrect={true}
+                            className=""
+                            disabled={false}
+                            id="year-MOCK-GUID"
+                            maxLength="4"
+                            name="year"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            pattern="^(\\\\s*|\\\\d+)$"
+                            placeholder="####"
+                            spellCheck={true}
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="flags"
+                    >
+                      <div
+                        className="estimated block"
+                      >
+                        <input
+                          aria-label="Estimated for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="estimated-MOCK-GUID"
+                          name="estimated"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="checkbox"
+                          value={false}
+                        />
+                        <label
+                          className="checkbox no-toggle"
+                          htmlFor="estimated-MOCK-GUID"
+                        >
+                          <span>
+                            Estimated
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.date.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    <span>
+                      <div>
+                        <p>
+                          All parts of the date are required even if it is 
+                          <strong>
+                            estimated
+                          </strong>
+                          .
+                        </p>
+                      </div>
+                    </span>
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content applicant-birthplace"
+          data-section="identification"
+          data-subsection="birthplace"
+        >
+          <div
+            aria-label="Provide your place of birth"
+            className="field required"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Provide your place of birth
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div
+                    className="location"
+                  >
+                    <div
+                      className="fields"
+                    >
+                      <div
+                        className="toggleable-location"
+                      >
+                        <div
+                          className="blocks option-list branch usa-input-error"
+                        >
+                          <label>
+                            Were you born in the United States?
+                          </label>
+                          <div
+                            className="yes block"
+                          >
+                            <label
+                              className=""
+                              htmlFor="birthplace-MOCK-GUID"
+                            >
+                              <input
+                                aria-label="Yes for null"
+                                checked={false}
+                                className="usa-input-success"
+                                disabled={false}
+                                id="birthplace-MOCK-GUID"
+                                name="birthplace-MOCK-GUID"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                type="radio"
+                                value="Yes"
+                              />
+                              <span>
+                                Yes
+                              </span>
+                            </label>
+                          </div>
+                          <div
+                            className="no block"
+                          >
+                            <label
+                              className=""
+                              htmlFor="birthplace-MOCK-GUID"
+                            >
+                              <input
+                                aria-label="No for null"
+                                checked={false}
+                                className="usa-input-success"
+                                disabled={false}
+                                id="birthplace-MOCK-GUID"
+                                name="birthplace-MOCK-GUID"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                type="radio"
+                                value="No"
+                              />
+                              <span>
+                                No
+                              </span>
+                            </label>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.location.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content applicant-ssn"
+          data-section="identification"
+          data-subsection="ssn"
+        >
+          <div
+            aria-label="Provide your U.S. Social Security Number"
+            className="field required"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Provide your U.S. Social Security Number
+            </h2>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Provide your U.S. Social Security Number"
+                className="toggle h2"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Provide your U.S. Social Security Number"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div
+                    className="ssn applicant-ssn-initial"
+                  >
+                    <div
+                      className="first eapp-short-input usa-input-error"
+                    >
+                      <input
+                        aria-describedby="first-error"
+                        aria-label={null}
+                        autoCapitalize={true}
+                        autoComplete={true}
+                        autoCorrect={true}
+                        className=""
+                        disabled={false}
+                        id="first-MOCK-GUID"
+                        maxLength="3"
+                        name="first"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onCopy={[Function]}
+                        onCut={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onPaste={[Function]}
+                        pattern="^[0-9]{3}$"
+                        placeholder="###"
+                        spellCheck={true}
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                    <div
+                      className="middle eapp-short-input usa-input-error"
+                    >
+                      <input
+                        aria-describedby="middle-error"
+                        aria-label={null}
+                        autoCapitalize={true}
+                        autoComplete={true}
+                        autoCorrect={true}
+                        className=""
+                        disabled={false}
+                        id="middle-MOCK-GUID"
+                        maxLength="2"
+                        name="middle"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onCopy={[Function]}
+                        onCut={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onPaste={[Function]}
+                        pattern="^[0-9]{2}$"
+                        placeholder="##"
+                        spellCheck={true}
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                    <div
+                      className="last eapp-short-input usa-input-error"
+                    >
+                      <input
+                        aria-describedby="last-error"
+                        aria-label={null}
+                        autoCapitalize={true}
+                        autoComplete={true}
+                        autoCorrect={true}
+                        className=""
+                        disabled={false}
+                        id="last-MOCK-GUID"
+                        maxLength="4"
+                        name="last"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onCopy={[Function]}
+                        onCut={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onPaste={[Function]}
+                        pattern="^[0-9]{4}$"
+                        placeholder="####"
+                        spellCheck={true}
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                    <div
+                      className="flags"
+                    >
+                      <div
+                        className="not-applicable block"
+                      >
+                        <input
+                          aria-label="Not applicable for null"
+                          checked={false}
+                          className="usa-input-success"
+                          id="notApplicable-MOCK-GUID"
+                          name="notApplicable"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="checkbox"
+                          value={false}
+                        />
+                        <label
+                          className="checkbox no-toggle"
+                          htmlFor="notApplicable-MOCK-GUID"
+                        >
+                          <span>
+                            Not applicable
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.ssn.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content physical"
+          data-section="identification"
+          data-subsection="physical"
+        >
+          <div
+            aria-label="Provide your identifying information"
+            className="field   no-margin-bottom"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Provide your identifying information
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                />
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+          </div>
+          <div
+            aria-label="Height"
+            className="field required"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Height
+            </h3>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Height"
+                className="toggle h3  adjust-for-labels"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Height"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="height"
+                  >
+                    <div
+                      className="feet"
+                    >
+                      <div
+                        className="usa-input-error"
+                      >
+                        <label
+                          className="usa-input-error-label"
+                          htmlFor="feet-MOCK-GUID"
+                        >
+                          Feet
+                        </label>
+                        <input
+                          aria-describedby="feet-error"
+                          aria-label="Feet"
+                          autoCapitalize={true}
+                          autoComplete={true}
+                          autoCorrect={true}
+                          className=""
+                          disabled={false}
+                          id="feet-MOCK-GUID"
+                          maxLength="1"
+                          name="feet"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          pattern="^(\\\\s*|\\\\d+)$"
+                          placeholder="#"
+                          spellCheck={true}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
+                      className="inches"
+                    >
+                      <div
+                        className="usa-input-error"
+                      >
+                        <label
+                          className="usa-input-error-label"
+                          htmlFor="inches-MOCK-GUID"
+                        >
+                          Inches
+                        </label>
+                        <input
+                          aria-describedby="inches-error"
+                          aria-label="Inches"
+                          autoCapitalize={true}
+                          autoComplete={true}
+                          autoCorrect={true}
+                          className=""
+                          disabled={false}
+                          id="inches-MOCK-GUID"
+                          maxLength="2"
+                          name="inches"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          pattern="^(\\\\s*|\\\\d+)$"
+                          placeholder="##"
+                          spellCheck={true}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.height.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+          <div
+            aria-label="Weight"
+            className="field required"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Weight
+            </h3>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Weight"
+                className="toggle h3  adjust-for-labels"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Weight"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="weight"
+                  >
+                    <div
+                      className="pounds"
+                    >
+                      <div
+                        className="usa-input-error"
+                      >
+                        <label
+                          className="usa-input-error-label"
+                          htmlFor="pounds-MOCK-GUID"
+                        >
+                          Pounds
+                        </label>
+                        <input
+                          aria-describedby="pounds-error"
+                          aria-label="Pounds"
+                          autoCapitalize={true}
+                          autoComplete={true}
+                          autoCorrect={true}
+                          className=""
+                          disabled={false}
+                          id="pounds-MOCK-GUID"
+                          maxLength="3"
+                          name="pounds"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          pattern="^(\\\\s*|\\\\d+)$"
+                          placeholder="###"
+                          spellCheck={true}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.weight.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+          <div
+            aria-label="Hair color"
+            className="field required"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Hair color
+            </h3>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Hair color"
+                className="toggle h3  adjust-for-big-buttons"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Hair color"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div
+                    className=" hair-colors"
+                  >
+                    <label />
+                    <div
+                      className="blocks option-list eapp-extend-labels usa-input-error"
+                    >
+                      <div
+                        className="black block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="hair-black-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Black for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="hair-black-MOCK-GUID"
+                            name="hair-black-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Black"
+                          />
+                          <div
+                            className="hair-icon black"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 18 32"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 18 32"
+                            >
+                              <path
+                                d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Black
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="brown block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="hair-brown-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Brown for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="hair-brown-MOCK-GUID"
+                            name="hair-brown-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Brown"
+                          />
+                          <div
+                            className="hair-icon brown"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 18 32"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 18 32"
+                            >
+                              <path
+                                d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Brown
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="red block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="hair-red-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Red or auburn for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="hair-red-MOCK-GUID"
+                            name="hair-red-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Red"
+                          />
+                          <div
+                            className="hair-icon red"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 18 32"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 18 32"
+                            >
+                              <path
+                                d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Red or auburn
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="blonde block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="hair-blonde-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Blonde or strawberry for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="hair-blonde-MOCK-GUID"
+                            name="hair-blonde-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Blonde"
+                          />
+                          <div
+                            className="hair-icon blonde"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 18 32"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 18 32"
+                            >
+                              <path
+                                d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Blonde or strawberry
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="sandy block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="hair-sandy-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Sandy for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="hair-sandy-MOCK-GUID"
+                            name="hair-sandy-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Sandy"
+                          />
+                          <div
+                            className="hair-icon sandy"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 18 32"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 18 32"
+                            >
+                              <path
+                                d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Sandy
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="gray block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="hair-gray-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Gray or partially gray for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="hair-gray-MOCK-GUID"
+                            name="hair-gray-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Gray"
+                          />
+                          <div
+                            className="hair-icon gray"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 18 32"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 18 32"
+                            >
+                              <path
+                                d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Gray or partially gray
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="white block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="hair-white-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="White for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="hair-white-MOCK-GUID"
+                            name="hair-white-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="White"
+                          />
+                          <div
+                            className="hair-icon white"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 18 32"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 18 32"
+                            >
+                              <path
+                                d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            White
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="bald block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="hair-bald-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Bald for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="hair-bald-MOCK-GUID"
+                            name="hair-bald-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Bald"
+                          />
+                          <div
+                            className="hair-icon bald"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 18.01 30.87"
+                            >
+                              <path
+                                d="M11.571,30.953h-1.328L10.04,30.9c-0.377-0.188-0.754-0.378-1.226-0.566l0.371-0.928 c0.018,0.007,0.035,0.014,0.051,0.021c-0.007-0.018-0.014-0.034-0.021-0.052l0.928-0.371c0.173,0.431,0.351,0.877,0.569,1.095 L11.571,30.953z"
+                              />
+                              <path
+                                d="M6.4,28.932c-0.853-0.538-1.63-1.108-2.31-1.696l0.653-0.756c0.643,0.555,1.379,1.095,2.189,1.606L6.4,28.932 z M2.102,25.136c-0.599-0.789-1.088-1.638-1.456-2.521L1.57,22.23c0.334,0.806,0.782,1.58,1.329,2.302L2.102,25.136z M-0.118,19.807c-0.086-0.607-0.13-1.244-0.13-1.893c0-0.352,0.018-0.688,0.053-1.013l0.994,0.107 c-0.031,0.289-0.047,0.591-0.047,0.905c0,0.602,0.041,1.19,0.121,1.752L-0.118,19.807z M1.53,14.525l-0.891-0.454 c0.418-0.819,0.987-1.591,1.739-2.36l0.715,0.699C2.413,13.105,1.901,13.797,1.53,14.525z M5.152,10.626L4.537,9.838l0.451-0.35 c0.61-0.472,1.186-0.918,1.697-1.38L7.355,8.85c-0.54,0.488-1.13,0.946-1.756,1.43L5.152,10.626z M9.168,6.477L8.243,6.095 C8.416,5.677,8.5,5.25,8.5,4.791c0-0.332-0.05-0.744-0.138-1.13l0.975-0.222C9.44,3.895,9.5,4.388,9.5,4.791 C9.5,5.375,9.388,5.943,9.168,6.477z"
+                              />
+                              <path
+                                d="M7.855,1.963C7.666,1.491,7.478,1.018,7.289,0.64L6.928-0.083h0.927l0.203,0.053 c0.381,0.19,0.757,0.379,1.226,0.566L8.912,1.464C8.838,1.435,8.767,1.405,8.697,1.376C8.726,1.448,8.755,1.52,8.784,1.592 L7.855,1.963z"
+                              />
+                              <path
+                                d="M8.667,27.461C8.556,27.004,8.5,26.539,8.5,26.079c0-0.576,0.104-1.134,0.31-1.656l0.931,0.365 C9.579,25.2,9.5,25.622,9.5,26.079c0,0.381,0.046,0.767,0.138,1.147L8.667,27.461z M11.267,22.762l-0.676-0.738 c0.563-0.516,1.186-0.994,1.845-1.501l0.361-0.278l0.611,0.791l-0.363,0.28C12.404,21.809,11.798,22.274,11.267,22.762z M15.579,19.179l-0.709-0.705c0.687-0.688,1.203-1.375,1.581-2.1l0.887,0.463C16.913,17.652,16.337,18.418,15.579,19.179z M18.191,14.012l-0.994-0.112c0.034-0.301,0.052-0.615,0.052-0.943c0-0.585-0.038-1.162-0.111-1.714l0.99-0.133 c0.08,0.596,0.121,1.217,0.121,1.847C18.249,13.323,18.229,13.675,18.191,14.012z M16.469,8.668 c-0.326-0.812-0.763-1.59-1.299-2.315l0.803-0.595c0.588,0.793,1.066,1.646,1.424,2.538L16.469,8.668z M13.345,4.394 c-0.638-0.558-1.372-1.099-2.182-1.61l0.533-0.846c0.854,0.539,1.63,1.112,2.307,1.703L13.345,4.394z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Bald
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="blue block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="hair-blue-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Blue for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="hair-blue-MOCK-GUID"
+                            name="hair-blue-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Blue"
+                          />
+                          <div
+                            className="hair-icon blue"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 18 32"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 18 32"
+                            >
+                              <path
+                                d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Blue
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="green block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="hair-green-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Green for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="hair-green-MOCK-GUID"
+                            name="hair-green-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Green"
+                          />
+                          <div
+                            className="hair-icon green"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 18 32"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 18 32"
+                            >
+                              <path
+                                d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Green
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="orange block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="hair-orange-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Orange for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="hair-orange-MOCK-GUID"
+                            name="hair-orange-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Orange"
+                          />
+                          <div
+                            className="hair-icon orange"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 18 32"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 18 32"
+                            >
+                              <path
+                                d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Orange
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="pink block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="hair-pink-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Pink for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="hair-pink-MOCK-GUID"
+                            name="hair-pink-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Pink"
+                          />
+                          <div
+                            className="hair-icon pink"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 18 32"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 18 32"
+                            >
+                              <path
+                                d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Pink
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="purple block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="hair-purple-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Purple for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="hair-purple-MOCK-GUID"
+                            name="hair-purple-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Purple"
+                          />
+                          <div
+                            className="hair-icon purple"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 18 32"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 18 32"
+                            >
+                              <path
+                                d="M9,26.37c0,1.41,0.7,3.28,1.35,4.5l-0.08-0.02l0.02,0.02C4.74,28.32,0,24.8,0,18.01c0-7.7,9-8.38,9-13.5 C9,3.1,8.3,1.23,7.68,0l0.06,0.02L7.72,0c5.55,2.55,10.29,6.07,10.29,12.86C18.01,20.56,9,21.24,9,26.37z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Purple
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="unknown block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="hair-unknown-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Unspecified or unknown for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="hair-unknown-MOCK-GUID"
+                            name="hair-unknown-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Unknown"
+                          />
+                          <div
+                            className="hair-icon unknown"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 30.86 36.84"
+                            >
+                              <path
+                                d="M15.43,34.25C6.91,34.25,0,27.34,0,18.82C0,10.3,6.91,3.39,15.43,3.39s15.43,6.91,15.43,15.43 C30.87,27.34,23.95,34.25,15.43,34.25z M15.84,8.53c-3.28,0-5.73,1.41-7.46,4.28c-0.18,0.28-0.1,0.64,0.16,0.84l2.65,2.01 c0.1,0.08,0.24,0.12,0.38,0.12c0.18,0,0.38-0.08,0.5-0.24c0.94-1.21,1.35-1.57,1.73-1.85c0.34-0.24,1-0.48,1.73-0.48 c1.29,0,2.47,0.82,2.47,1.71c0,1.04-0.54,1.57-1.77,2.13c-1.43,0.64-3.38,2.31-3.38,4.26v0.72c0,0.36,0.28,0.64,0.64,0.64h3.86 c0.36,0,0.64-0.28,0.64-0.64c0-0.46,0.58-1.45,1.53-1.99c1.53-0.87,3.62-2.03,3.62-5.08C23.15,11.28,19.29,8.53,15.84,8.53z M18.01,24.61c0-0.36-0.28-0.64-0.64-0.64H13.5c-0.36,0-0.64,0.28-0.64,0.64v3.86c0,0.36,0.28,0.64,0.64,0.64h3.86 c0.36,0,0.64-0.28,0.64-0.64V24.61z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Unspecified or unknown
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+          <div
+            aria-label="Eye color"
+            className="field required"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Eye color
+            </h3>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Eye color"
+                className="toggle h3  adjust-for-big-buttons"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Eye color"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div
+                    className=" eye-colors"
+                  >
+                    <label />
+                    <div
+                      className="blocks option-list eapp-extend-labels usa-input-error"
+                    >
+                      <div
+                        className="brown block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="eye-brown-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Brown for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="eye-brown-MOCK-GUID"
+                            name="eye-brown-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Brown"
+                          />
+                          <div
+                            className="eye-icon brown"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 36 36.84"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 36 36.84"
+                            >
+                              <path
+                                d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Brown
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="hazel block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="eye-hazel-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Hazel for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="eye-hazel-MOCK-GUID"
+                            name="eye-hazel-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Hazel"
+                          />
+                          <div
+                            className="eye-icon hazel"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 36 36.84"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 36 36.84"
+                            >
+                              <path
+                                d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Hazel
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="blue block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="eye-blue-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Blue for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="eye-blue-MOCK-GUID"
+                            name="eye-blue-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Blue"
+                          />
+                          <div
+                            className="eye-icon blue"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 36 36.84"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 36 36.84"
+                            >
+                              <path
+                                d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Blue
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="green block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="eye-green-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Green for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="eye-green-MOCK-GUID"
+                            name="eye-green-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Green"
+                          />
+                          <div
+                            className="eye-icon green"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 36 36.84"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 36 36.84"
+                            >
+                              <path
+                                d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Green
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="gray block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="eye-gray-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Gray for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="eye-gray-MOCK-GUID"
+                            name="eye-gray-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Gray"
+                          />
+                          <div
+                            className="eye-icon gray"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 36 36.84"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 36 36.84"
+                            >
+                              <path
+                                d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Gray
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="maroon block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="eye-maroon-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Maroon for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="eye-maroon-MOCK-GUID"
+                            name="eye-maroon-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Maroon"
+                          />
+                          <div
+                            className="eye-icon maroon"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 36 36.84"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 36 36.84"
+                            >
+                              <path
+                                d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Maroon
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="black block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="eye-black-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Black for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="eye-black-MOCK-GUID"
+                            name="eye-black-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Black"
+                          />
+                          <div
+                            className="eye-icon black"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 36 36.84"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 36 36.84"
+                            >
+                              <path
+                                d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Black
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="multi block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="eye-multi-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Multicolored for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="eye-multi-MOCK-GUID"
+                            name="eye-multi-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Multicolored"
+                          />
+                          <div
+                            className="eye-icon multi"
+                          >
+                            <img
+                              alt="Scalable vector graphic"
+                              className="svg"
+                              src="/img/eye-multicolor.svg"
+                            />
+                          </div>
+                          <span>
+                            Multicolored
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="pink block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="eye-pink-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Pink for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="eye-pink-MOCK-GUID"
+                            name="eye-pink-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Pink"
+                          />
+                          <div
+                            className="eye-icon pink"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              enableBackground="new 0 0 36 36.84"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 36 36.84"
+                            >
+                              <path
+                                d="M35.61,21.49c-3.7,6.09-10.47,10.19-17.6,10.19S4.1,27.56,0.4,21.49C0.16,21.07,0,20.61,0,20.11 c0-0.5,0.16-0.96,0.4-1.39c3.7-6.07,10.47-10.19,17.6-10.19s13.91,4.12,17.6,10.19c0.24,0.42,0.4,0.88,0.4,1.39 C36.01,20.61,35.85,21.07,35.61,21.49z M25.78,13.01c0.8,1.37,1.23,2.93,1.23,4.52c0,4.96-4.04,9-9,9s-9-4.04-9-9 c0-1.59,0.42-3.16,1.23-4.52c-3.13,1.61-5.75,4.14-7.66,7.09c3.44,5.3,8.98,9,15.43,9s12-3.7,15.43-9 C31.53,17.15,28.92,14.62,25.78,13.01z M18.01,11.42c-3.36,0-6.11,2.75-6.11,6.11c0,0.52,0.44,0.96,0.96,0.96s0.96-0.44,0.96-0.96 c0-2.29,1.89-4.18,4.18-4.18c0.52,0,0.96-0.44,0.96-0.96C18.97,11.87,18.53,11.42,18.01,11.42z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Pink
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="unknown block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="eye-unknown-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Unknown for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="eye-unknown-MOCK-GUID"
+                            name="eye-unknown-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Unknown"
+                          />
+                          <div
+                            className="eye-icon unknown"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 30.86 36.84"
+                            >
+                              <path
+                                d="M15.43,34.25C6.91,34.25,0,27.34,0,18.82C0,10.3,6.91,3.39,15.43,3.39s15.43,6.91,15.43,15.43 C30.87,27.34,23.95,34.25,15.43,34.25z M15.84,8.53c-3.28,0-5.73,1.41-7.46,4.28c-0.18,0.28-0.1,0.64,0.16,0.84l2.65,2.01 c0.1,0.08,0.24,0.12,0.38,0.12c0.18,0,0.38-0.08,0.5-0.24c0.94-1.21,1.35-1.57,1.73-1.85c0.34-0.24,1-0.48,1.73-0.48 c1.29,0,2.47,0.82,2.47,1.71c0,1.04-0.54,1.57-1.77,2.13c-1.43,0.64-3.38,2.31-3.38,4.26v0.72c0,0.36,0.28,0.64,0.64,0.64h3.86 c0.36,0,0.64-0.28,0.64-0.64c0-0.46,0.58-1.45,1.53-1.99c1.53-0.87,3.62-2.03,3.62-5.08C23.15,11.28,19.29,8.53,15.84,8.53z M18.01,24.61c0-0.36-0.28-0.64-0.64-0.64H13.5c-0.36,0-0.64,0.28-0.64,0.64v3.86c0,0.36,0.28,0.64,0.64,0.64h3.86 c0.36,0,0.64-0.28,0.64-0.64V24.61z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Unknown
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+          <div
+            aria-label="Select your sex"
+            className="field required"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Select your sex
+            </h3>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Select your sex"
+                className="toggle h3  adjust-for-big-buttons"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Select your sex"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className=" sex"
+                  >
+                    <label />
+                    <div
+                      className="blocks  usa-input-error"
+                    >
+                      <div
+                        className="female block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="sex-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Female for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="sex-MOCK-GUID"
+                            name="sex-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Female"
+                          />
+                          <div
+                            className="sex-icon"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="0 0 50.81 79.19"
+                            >
+                              <path
+                                d="M50.81,25.4C50.81,11.37,39.43,0,25.4,0S0,11.37,0,25.4c0,12.32,8.77,22.59,20.4,24.91v9.09h-9.79v10h9.79v9.79 h10V69.4h9.79v-10H30.4v-9.09C42.04,47.99,50.81,37.72,50.81,25.4z M10,25.4C10,16.91,16.91,10,25.4,10s15.4,6.91,15.4,15.4 s-6.91,15.4-15.4,15.4S10,33.9,10,25.4z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Female
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="male block extended"
+                      >
+                        <label
+                          className=""
+                          htmlFor="sex-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Male for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="sex-MOCK-GUID"
+                            name="sex-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Male"
+                          />
+                          <div
+                            className="sex-icon"
+                          >
+                            <svg
+                              alt="Scalable vector graphic"
+                              focusable="false"
+                              tabIndex="-1"
+                              viewBox="-10 -10 80 80"
+                            >
+                              <path
+                                d="M62.77,0.12V0H37.69v10h8.64l-6.4,6.4c-4.35-3.04-9.43-4.56-14.52-4.56c-6.5,0-13,2.48-17.96,7.44 c-9.92,9.92-9.92,26.01,0,35.93c4.96,4.96,11.46,7.44,17.96,7.44c6.5,0,13-2.48,17.96-7.44c8.58-8.58,9.73-21.76,3.48-31.58 l6.05-6.05v7.64h10V0.12H62.77z M36.3,48.14c-2.91,2.91-6.78,4.51-10.89,4.51c-4.11,0-7.98-1.6-10.89-4.51 C11.6,45.23,10,41.36,10,37.24c0-4.11,1.6-7.98,4.51-10.89s6.78-4.51,10.89-4.51c4.11,0,7.98,1.6,10.89,4.51s4.51,6.78,4.51,10.89 C40.81,41.36,39.21,45.23,36.3,48.14z"
+                              />
+                            </svg>
+                          </div>
+                          <span>
+                            Male
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                  <a
+                    className="comments-button add"
+                    href="javascript:;;"
+                    onClick={[Function]}
+                  >
+                    <span>
+                      Add a comment
+                    </span>
+                    <i
+                      className="fa fa-plus-circle"
+                    />
+                  </a>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          aria-label="Add a comment to clarify any of your responses in the information about you section"
+          className="field   section-comment"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h4
+            className="title h4"
+          >
+            Add a comment to clarify any of your responses in the information about you section
+            <span
+              className="optional"
+            >
+              (Optional)
+            </span>
+          </h4>
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
+            >
+              <span
+                className="component"
+              >
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="Comments-error"
+                    aria-label={null}
+                    autoCapitalize={true}
+                    autoComplete={true}
+                    autoCorrect={true}
+                    className=""
+                    id="Comments-MOCK-GUID"
+                    maxLength={255}
+                    name="Comments"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    pattern=".*"
+                    spellCheck={true}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </span>
+            </span>
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="section-print-container"
+    >
+      <h3
+        className="section-print-header"
+      >
+        Your history
+      </h3>
+      <div>
+        <div
+          className="section-content residence"
+          data-section="history"
+          data-subsection="residence"
+        >
+          <div>
+            <div
+              className="accordion"
+            >
+              <strong
+                className="aria-description"
+              >
+                Summary of places you have lived
+              </strong>
+              <div
+                className="items"
+              />
+              <div
+                className="append-button"
+              />
+            </div>
+            <div
+              aria-label="Do you have an additional residence to report?"
+              className="field required  branch addendum"
+              data-uuid="field-MOCK-GUID"
+            >
+              <a
+                aria-hidden="true"
+                className="anchor"
+                id="field-MOCK-GUID"
+                name="field-MOCK-GUID"
+              />
+              <h3
+                className="title h3"
+              >
+                Do you have an additional residence to report?
+              </h3>
+              <span
+                className="icon"
+              />
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages help-messages"
+                />
+              </div>
+              <div
+                className="table"
+              >
+                <span
+                  className="content"
+                >
+                  <span
+                    className="component shrink"
+                  >
+                    <div
+                      className="content"
+                    />
+                    <div
+                      className="blocks option-list branch usa-input-error"
+                    >
+                      <div
+                        className="yes block"
+                      >
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Yes for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="radio_input-MOCK-GUID"
+                            name="radio_input-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Yes"
+                          />
+                          <span>
+                            Yes
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="no block"
+                      >
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="No for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="radio_input-MOCK-GUID"
+                            name="radio_input-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="No"
+                          />
+                          <span>
+                            No
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </span>
+                </span>
+              </div>
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages error-messages"
+                  role="alert"
+                >
+                  <div
+                    aria-live="polite"
+                    className="message error"
+                    role="alert"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="fa fa-exclamation"
+                    />
+                    <div
+                      data-i18n="error.required"
+                    >
+                      <h5>
+                        Your response is required
+                      </h5>
+                      
+                      
+                    </div>
+                  </div>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="section-content employment"
+          data-section="history"
+          data-subsection="employment"
+        >
+          <div>
+            <div
+              className="accordion"
+            >
+              <strong
+                className="aria-description"
+              >
+                Summary of your work history
+              </strong>
+              <div
+                className="items"
+              />
+              <div
+                className="append-button"
+              />
+            </div>
+            <div
+              aria-label="Do you have an additional employment activity to enter?"
+              className="field required  branch addendum no-margin-bottom"
+              data-uuid="field-MOCK-GUID"
+            >
+              <a
+                aria-hidden="true"
+                className="anchor"
+                id="field-MOCK-GUID"
+                name="field-MOCK-GUID"
+              />
+              <h3
+                className="title h3"
+              >
+                Do you have an additional employment activity to enter?
+              </h3>
+              <span
+                className="icon"
+              />
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages help-messages"
+                />
+              </div>
+              <div
+                className="table"
+              >
+                <span
+                  className="content"
+                >
+                  <span
+                    className="component shrink"
+                  >
+                    <div
+                      className="content"
+                    />
+                    <div
+                      className="blocks option-list branch usa-input-error"
+                    >
+                      <div
+                        className="yes block"
+                      >
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Yes for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="radio_input-MOCK-GUID"
+                            name="radio_input-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Yes"
+                          />
+                          <span>
+                            Yes
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="no block"
+                      >
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="No for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="radio_input-MOCK-GUID"
+                            name="radio_input-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="No"
+                          />
+                          <span>
+                            No
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </span>
+                </span>
+              </div>
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages error-messages"
+                  role="alert"
+                >
+                  <div
+                    aria-live="polite"
+                    className="message error"
+                    role="alert"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="fa fa-exclamation"
+                    />
+                    <div
+                      data-i18n="error.required"
+                    >
+                      <h5>
+                        Your response is required
+                      </h5>
+                      
+                      
+                    </div>
+                  </div>
+                </span>
+              </div>
+            </div>
+          </div>
+          <hr
+            className="section-divider"
+          />
+          <div
+            aria-label="Have any of the following happened to you in the last seven (7) years at employment activities that you have not previously listed?"
+            className="field required  branch employment-record"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Have any of the following happened to you in the last seven (7) years at employment activities that you have not previously listed?
+            </h3>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <div>
+                      <ul>
+                        <li>
+                          Fired from a job?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <ul>
+                        <li>
+                          Quit a job after being told you would be fired?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <ul>
+                        <li>
+                          Have you left a job by mutual agreement following charges or allegations of misconduct?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <ul>
+                        <li>
+                          Left a job by mutual agreement following notice of unsatisfactory performance?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <ul>
+                        <li>
+                          Received a written warning, been officially reprimanded, suspended, or disciplined for misconduct in the workplace, such as violation of security policy?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <p>
+                        If you answer "Yes", you will be required to add an additional employment record above.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="radio_input-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="radio_input-MOCK-GUID"
+                          name="radio_input-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="radio_input-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="radio_input-MOCK-GUID"
+                          name="radio_input-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content federal"
+          data-section="history"
+          data-subsection="federal"
+        >
+          <div
+            aria-label="Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?
+            </h2>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
+                className="toggle h2  adjust-for-buttons"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_federalservice-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_federalservice-MOCK-GUID"
+                          name="has_federalservice-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_federalservice-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_federalservice-MOCK-GUID"
+                          name="has_federalservice-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          aria-label="Add a comment to clarify any of your responses in the your history section"
+          className="field   section-comment"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h4
+            className="title h4"
+          >
+            Add a comment to clarify any of your responses in the your history section
+            <span
+              className="optional"
+            >
+              (Optional)
+            </span>
+          </h4>
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
+            >
+              <span
+                className="component"
+              >
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="Comments-error"
+                    aria-label={null}
+                    autoCapitalize={true}
+                    autoComplete={true}
+                    autoCorrect={true}
+                    className=""
+                    id="Comments-MOCK-GUID"
+                    maxLength={255}
+                    name="Comments"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    pattern=".*"
+                    spellCheck={true}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </span>
+            </span>
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="section-print-container"
+    >
+      <h3
+        className="section-print-header"
+      >
+        Relationships
+      </h3>
+      <div>
+        <div
+          className="section-content marital"
+          data-section="relationships"
+          data-subsection="status/marital"
+        >
+          <div
+            aria-label="Provide your current marital/relationship status with regard to civil marriage, legally recognized civil union, or legally recognized domestic partnership."
+            className="field required"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Provide your current marital/relationship status with regard to civil marriage, legally recognized civil union, or legally recognized domestic partnership.
+            </h3>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div
+                    className="blocks status-options usa-input-error"
+                  >
+                    <div
+                      className="status-never block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="status-MOCK-GUID-status-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="[object Object] for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="status-MOCK-GUID-status-MOCK-GUID"
+                          name="status-MOCK-GUID-status-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="NeverMarried"
+                        />
+                        <span>
+                          <div>
+                            <p>
+                              Never entered into a civil marriage, legally recognized civil union, or legally recognized domestic partnership
+                            </p>
+                          </div>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="status-married block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="status-MOCK-GUID-status-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="[object Object] for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="status-MOCK-GUID-status-MOCK-GUID"
+                          name="status-MOCK-GUID-status-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Married"
+                        />
+                        <span>
+                          <div>
+                            <p>
+                              Currently in a civil marriage
+                            </p>
+                          </div>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="status-civil-union block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="status-MOCK-GUID-status-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="[object Object] for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="status-MOCK-GUID-status-MOCK-GUID"
+                          name="status-MOCK-GUID-status-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="InCivilUnion"
+                        />
+                        <span>
+                          <div>
+                            <p>
+                              Currently in a legally recognized domestic partnership or legally recognized civil union
+                            </p>
+                          </div>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="status-separated block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="status-MOCK-GUID-status-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="[object Object] for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="status-MOCK-GUID-status-MOCK-GUID"
+                          name="status-MOCK-GUID-status-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Separated"
+                        />
+                        <span>
+                          <div>
+                            <p>
+                              Separated
+                            </p>
+                          </div>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="status-annulled block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="status-MOCK-GUID-status-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="[object Object] for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="status-MOCK-GUID-status-MOCK-GUID"
+                          name="status-MOCK-GUID-status-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Annulled"
+                        />
+                        <span>
+                          <div>
+                            <p>
+                              Annulled
+                            </p>
+                          </div>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="status-divorced block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="status-MOCK-GUID-status-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="[object Object] for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="status-MOCK-GUID-status-MOCK-GUID"
+                          name="status-MOCK-GUID-status-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Divorced"
+                        />
+                        <span>
+                          <div>
+                            <p>
+                              Divorced/dissolved
+                            </p>
+                          </div>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="status-widowed block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="status-MOCK-GUID-status-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="[object Object] for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="status-MOCK-GUID-status-MOCK-GUID"
+                          name="status-MOCK-GUID-status-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Widowed"
+                        />
+                        <span>
+                          <div>
+                            <p>
+                              Widowed
+                            </p>
+                          </div>
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content cohabitants"
+          data-section="relationships"
+          data-subsection="status/cohabitant"
+        >
+          <div
+            aria-label="Do you presently reside with a person, other than a spouse or legally recognized civil union/domestic partner, with whom you share bonds of affection, obligation, or other commitment, as opposed to a person with whom you live for reasons of convenience?"
+            className="field required  branch has-cohabitant"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Do you presently reside with a person, other than a spouse or legally recognized civil union/domestic partner, with whom you share bonds of affection, obligation, or other commitment, as opposed to a person with whom you live for reasons of convenience?
+            </h3>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Do you presently reside with a person, other than a spouse or legally recognized civil union/domestic partner, with whom you share bonds of affection, obligation, or other commitment, as opposed to a person with whom you live for reasons of convenience?"
+                className="toggle h3  adjust-for-buttons"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Do you presently reside with a person, other than a spouse or legally recognized civil union/domestic partner, with whom you share bonds of affection, obligation, or other commitment, as opposed to a person with whom you live for reasons of convenience?"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="hasCohabitant-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="hasCohabitant-MOCK-GUID"
+                          name="hasCohabitant-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="hasCohabitant-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="hasCohabitant-MOCK-GUID"
+                          name="hasCohabitant-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="section-content people"
+          data-section="relationships"
+          data-subsection="people"
+        >
+          <div>
+            <h3>
+              Provide three people who know you well and who preferably live in the U.S.
+            </h3>
+            <p>
+              They should be friends, peers, colleagues, college roommates, associates, etc., who are collectively aware of your activities outside of your workplace, school, or neighborhood, and whose combined association with you 
+              <strong>
+                covers at least the last seven (7) years.
+              </strong>
+            </p>
+            <p>
+              <strong>
+                Do not list your spouse, former spouse (s), other relatives, or anyone listed elsewhere on this form.
+              </strong>
+            </p>
+          </div>
+          <span
+            id="scrollToPeople"
+          />
+          <div
+            className="summaryprogress progress"
+          >
+            <div
+              className="summary-progress people-summary"
+            >
+              <div
+                className="content"
+              >
+                <div>
+                  <div
+                    className="summary-icon"
+                  >
+                    <img
+                      alt="People who know you well 7 year coverage"
+                      className="svg"
+                      src="/img/people-who-know-you.svg"
+                    />
+                  </div>
+                  <span
+                    className="title"
+                  >
+                    People who know you well 7 year coverage
+                  </span>
+                </div>
+                <div
+                  className="progress"
+                />
+              </div>
+              <div
+                className="stats"
+              >
+                <div
+                  className="fraction"
+                >
+                  <span
+                    className="completed"
+                  >
+                    0
+                  </span>
+                  <span
+                    className="slash"
+                  >
+                    /
+                  </span>
+                  <span
+                    className="total"
+                  >
+                    7
+                  </span>
+                </div>
+                <span
+                  className="unit"
+                >
+                  Years covered
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            className="summaryprogress counter"
+          >
+            <div
+              className="people-counter"
+            >
+              <div
+                className="count"
+              >
+                0
+                /
+                3
+              </div>
+              <div
+                className="unit"
+              >
+                People added
+              </div>
+            </div>
+          </div>
+          <div>
+            <div
+              className="accordion"
+            >
+              <strong
+                className="aria-description"
+              >
+                Summary of people who know you
+              </strong>
+              <div
+                className="items"
+              />
+              <div
+                className="append-button"
+              />
+            </div>
+            <div
+              aria-label="Do you have an additional person who knows you well to list?"
+              className="field required  branch addendum"
+              data-uuid="field-MOCK-GUID"
+            >
+              <a
+                aria-hidden="true"
+                className="anchor"
+                id="field-MOCK-GUID"
+                name="field-MOCK-GUID"
+              />
+              <h3
+                className="title h3"
+              >
+                Do you have an additional person who knows you well to list?
+              </h3>
+              <span
+                className="icon"
+              />
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages help-messages"
+                />
+              </div>
+              <div
+                className="table"
+              >
+                <span
+                  className="content"
+                >
+                  <span
+                    className="component shrink"
+                  >
+                    <div
+                      className="content"
+                    />
+                    <div
+                      className="blocks option-list branch usa-input-error"
+                    >
+                      <div
+                        className="yes block"
+                      >
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Yes for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="radio_input-MOCK-GUID"
+                            name="radio_input-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Yes"
+                          />
+                          <span>
+                            Yes
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="no block"
+                      >
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="No for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="radio_input-MOCK-GUID"
+                            name="radio_input-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="No"
+                          />
+                          <span>
+                            No
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </span>
+                </span>
+              </div>
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages error-messages"
+                  role="alert"
+                >
+                  <div
+                    aria-live="polite"
+                    className="message error"
+                    role="alert"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="fa fa-exclamation"
+                    />
+                    <div
+                      data-i18n="error.required"
+                    >
+                      <h5>
+                        Your response is required
+                      </h5>
+                      
+                      
+                    </div>
+                  </div>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content relatives"
+          data-section="relationships"
+          data-subsection="relatives"
+        >
+          <div
+            aria-label="Add each relative applicable to you, regardless if they are living or deceased."
+            className="field   no-margin-bottom"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Add each relative applicable to you, regardless if they are living or deceased.
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div>
+                    <p>
+                      An opportunity will be provided to list multiple relatives for each type.
+                    </p>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+          </div>
+          <div>
+            <div
+              className="accordion"
+            >
+              <strong
+                className="aria-description"
+              >
+                Summary of relatives
+              </strong>
+              <div
+                className="items"
+              />
+              <div
+                className="append-button"
+              />
+            </div>
+            <div
+              aria-label="Do you have an additional relative to enter?"
+              className="field required  branch addendum"
+              data-uuid="field-MOCK-GUID"
+            >
+              <a
+                aria-hidden="true"
+                className="anchor"
+                id="field-MOCK-GUID"
+                name="field-MOCK-GUID"
+              />
+              <h3
+                className="title h3"
+              >
+                Do you have an additional relative to enter?
+              </h3>
+              <span
+                className="icon"
+              />
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages help-messages"
+                />
+              </div>
+              <div
+                className="table"
+              >
+                <span
+                  className="content"
+                >
+                  <span
+                    className="component shrink"
+                  >
+                    <div
+                      className="content"
+                    />
+                    <div
+                      className="blocks option-list branch usa-input-error"
+                    >
+                      <div
+                        className="yes block"
+                      >
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Yes for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="radio_input-MOCK-GUID"
+                            name="radio_input-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Yes"
+                          />
+                          <span>
+                            Yes
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="no block"
+                      >
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="No for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="radio_input-MOCK-GUID"
+                            name="radio_input-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="No"
+                          />
+                          <span>
+                            No
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </span>
+                </span>
+              </div>
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages error-messages"
+                  role="alert"
+                >
+                  <div
+                    aria-live="polite"
+                    className="message error"
+                    role="alert"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="fa fa-exclamation"
+                    />
+                    <div
+                      data-i18n="error.required"
+                    >
+                      <h5>
+                        Your response is required
+                      </h5>
+                      
+                      
+                    </div>
+                  </div>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          aria-label="Add a comment to clarify any of your responses in the relationships section"
+          className="field   section-comment"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h4
+            className="title h4"
+          >
+            Add a comment to clarify any of your responses in the relationships section
+            <span
+              className="optional"
+            >
+              (Optional)
+            </span>
+          </h4>
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
+            >
+              <span
+                className="component"
+              >
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="Comments-error"
+                    aria-label={null}
+                    autoCapitalize={true}
+                    autoComplete={true}
+                    autoCorrect={true}
+                    className=""
+                    id="Comments-MOCK-GUID"
+                    maxLength={255}
+                    name="Comments"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    pattern=".*"
+                    spellCheck={true}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </span>
+            </span>
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="section-print-container"
+    >
+      <h3
+        className="section-print-header"
+      >
+        Citizenship
+      </h3>
+      <div>
+        <div
+          className="section-content status"
+          data-section="citizenship"
+          data-subsection="status"
+        >
+          <div
+            aria-label="Citizenship status"
+            className="field   no-margin-bottom"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Citizenship status
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                />
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+          </div>
+          <div
+            aria-label="Provide your current citizenship status"
+            className="field required"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Provide your current citizenship status
+            </h3>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div
+                    className="blocks citizenship-status usa-input-error"
+                  >
+                    <div
+                      className="citizenship-status-citizen block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="citizenship-status-citizen-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="[object Object] for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="citizenship-status-citizen-MOCK-GUID"
+                          name="citizenship-status-citizen-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Citizen"
+                        />
+                        <span>
+                          <div>
+                            <p>
+                              I am a U.S. citizen or national by birth in the U.S. or U.S. territory/commonwealth
+                            </p>
+                          </div>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="citizenship-status-foreignborn block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="citizenship-status-foreignborn-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="[object Object] for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="citizenship-status-foreignborn-MOCK-GUID"
+                          name="citizenship-status-foreignborn-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="ForeignBorn"
+                        />
+                        <span>
+                          <div>
+                            <p>
+                              I am a U.S. citizen or national by birth, born to U.S. parent(s), in a foreign country
+                            </p>
+                          </div>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="citizenship-status-naturalized block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="citizenship-status-naturalized-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="[object Object] for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="citizenship-status-naturalized-MOCK-GUID"
+                          name="citizenship-status-naturalized-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Naturalized"
+                        />
+                        <span>
+                          <div>
+                            <p>
+                              I am a naturalized U.S. citizen
+                            </p>
+                          </div>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="citizenship-status-derived block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="citizenship-status-derived-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="[object Object] for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="citizenship-status-derived-MOCK-GUID"
+                          name="citizenship-status-derived-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Derived"
+                        />
+                        <span>
+                          <div>
+                            <p>
+                              I am a derived U.S. citizen
+                            </p>
+                          </div>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="citizenship-status-notcitizen block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="citizenship-status-notcitizen-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="[object Object] for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="citizenship-status-notcitizen-MOCK-GUID"
+                          name="citizenship-status-notcitizen-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="NotCitizen"
+                        />
+                        <span>
+                          <div>
+                            <p>
+                              I am not a U.S. citizen
+                            </p>
+                          </div>
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content multiple"
+          data-section="citizenship"
+          data-subsection="multiple"
+        >
+          <div
+            aria-label="Dual/multiple citizenship"
+            className="field   no-margin-bottom"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Dual/multiple citizenship
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                />
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+          </div>
+          <div
+            aria-label="Do you now or have you EVER held dual/multiple citizenships?"
+            className="field required  branch has-multiple"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Do you now or have you EVER held dual/multiple citizenships?
+            </h3>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_multiple-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_multiple-MOCK-GUID"
+                          name="has_multiple-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_multiple-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_multiple-MOCK-GUID"
+                          name="has_multiple-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content passports"
+          data-section="citizenship"
+          data-subsection="passports"
+        >
+          <div
+            aria-label="Foreign passport information"
+            className="field   no-margin-bottom"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Foreign passport information
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                />
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+          </div>
+          <div
+            className="has-foreignpassport"
+          >
+            <div>
+              <div
+                aria-label="Have you EVER been issued a passport (or identity card for travel) by a country other than the U.S.?"
+                className="field required  branch"
+                data-uuid="field-MOCK-GUID"
+              >
+                <a
+                  aria-hidden="true"
+                  className="anchor"
+                  id="field-MOCK-GUID"
+                  name="field-MOCK-GUID"
+                />
+                <h3
+                  className="title h3"
+                >
+                  Have you EVER been issued a passport (or identity card for travel) by a country other than the U.S.?
+                </h3>
+                <span
+                  className="icon"
+                />
+                <div
+                  className="table expand"
+                >
+                  <span
+                    aria-live="polite"
+                    className="messages help-messages"
+                  />
+                </div>
+                <div
+                  className="table"
+                >
+                  <span
+                    className="content"
+                  >
+                    <span
+                      className="component shrink"
+                    >
+                      <div
+                        className="content"
+                      />
+                      <div
+                        className="blocks option-list branch usa-input-error"
+                      >
+                        <div
+                          className="yes block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="branchcollection-MOCK-GUID"
+                          >
+                            <input
+                              aria-label="Yes for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="branchcollection-MOCK-GUID"
+                              name="branchcollection-MOCK-GUID"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="Yes"
+                            />
+                            <span>
+                              Yes
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="no block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="branchcollection-MOCK-GUID"
+                          >
+                            <input
+                              aria-label="No for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="branchcollection-MOCK-GUID"
+                              name="branchcollection-MOCK-GUID"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="No"
+                            />
+                            <span>
+                              No
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </span>
+                  </span>
+                </div>
+                <div
+                  className="table expand"
+                >
+                  <span
+                    aria-live="polite"
+                    className="messages error-messages"
+                    role="alert"
+                  >
+                    <div
+                      aria-live="polite"
+                      className="message error"
+                      role="alert"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="fa fa-exclamation"
+                      />
+                      <div
+                        data-i18n="error.required"
+                      >
+                        <h5>
+                          Your response is required
+                        </h5>
+                        
+                        
+                      </div>
+                    </div>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          aria-label="Add a comment to clarify any of your responses in the citizenship section"
+          className="field   section-comment"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h4
+            className="title h4"
+          >
+            Add a comment to clarify any of your responses in the citizenship section
+            <span
+              className="optional"
+            >
+              (Optional)
+            </span>
+          </h4>
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
+            >
+              <span
+                className="component"
+              >
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="Comments-error"
+                    aria-label={null}
+                    autoCapitalize={true}
+                    autoComplete={true}
+                    autoCorrect={true}
+                    className=""
+                    id="Comments-MOCK-GUID"
+                    maxLength={255}
+                    name="Comments"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    pattern=".*"
+                    spellCheck={true}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </span>
+            </span>
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="section-print-container"
+    >
+      <h3
+        className="section-print-header"
+      >
+        Military history
+      </h3>
+      <div>
+        <span>
+          <div
+            className="section-content selective"
+            data-section="military"
+            data-subsection="selective"
+          >
+            <div
+              aria-label="Were you born a male after December 31, 1959?"
+              className="field required  branch born"
+              data-uuid="field-MOCK-GUID"
+            >
+              <a
+                aria-hidden="true"
+                className="anchor"
+                id="field-MOCK-GUID"
+                name="field-MOCK-GUID"
+              />
+              <h2
+                className="title h2"
+              >
+                Were you born a male after December 31, 1959?
+              </h2>
+              <span
+                className="icon"
+              >
+                <a
+                  aria-label="Show help for Were you born a male after December 31, 1959?"
+                  className="toggle h2  adjust-for-buttons"
+                  href="javascript:;"
+                  onClick={[Function]}
+                  title="Show help for Were you born a male after December 31, 1959?"
+                >
+                  <svg
+                    alt="Scalable vector graphic"
+                    focusable="false"
+                    height="14.57px"
+                    tabIndex="-1"
+                    viewBox="0 0 14.57 14.57"
+                    width="14.57px"
+                  >
+                    <g>
+                      <path
+                        className="eapp-help-icon"
+                        d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                      />
+                    </g>
+                  </svg>
+                </a>
+              </span>
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages help-messages"
+                />
+              </div>
+              <div
+                className="table"
+              >
+                <span
+                  className="content"
+                >
+                  <span
+                    className="component shrink"
+                  >
+                    <div
+                      className="content"
+                    />
+                    <div
+                      className="blocks option-list branch usa-input-error"
+                    >
+                      <div
+                        className="yes block"
+                      >
+                        <label
+                          className=""
+                          htmlFor="was_bornafter-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="Yes for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="was_bornafter-MOCK-GUID"
+                            name="was_bornafter-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Yes"
+                          />
+                          <span>
+                            Yes
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="no block"
+                      >
+                        <label
+                          className=""
+                          htmlFor="was_bornafter-MOCK-GUID"
+                        >
+                          <input
+                            aria-label="No for null"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="was_bornafter-MOCK-GUID"
+                            name="was_bornafter-MOCK-GUID"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="No"
+                          />
+                          <span>
+                            No
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </span>
+                </span>
+              </div>
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages error-messages"
+                  role="alert"
+                >
+                  <div
+                    aria-live="polite"
+                    className="message error"
+                    role="alert"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="fa fa-exclamation"
+                    />
+                    <div
+                      data-i18n="error.required"
+                    >
+                      <h5>
+                        Your response is required
+                      </h5>
+                      
+                      
+                    </div>
+                  </div>
+                </span>
+              </div>
+            </div>
+          </div>
+          <hr
+            className="section-divider"
+          />
+        </span>
+        <div
+          className="section-content military-history"
+          data-section="military"
+          data-subsection="history"
+        >
+          <div
+            aria-label="Have you ever served in the U.S. Military?"
+            className="field required  branch served"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you ever served in the U.S. Military?
+            </h2>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Have you ever served in the U.S. Military?"
+                className="toggle h2  adjust-for-buttons"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Have you ever served in the U.S. Military?"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_served-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_served-MOCK-GUID"
+                          name="has_served-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_served-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_served-MOCK-GUID"
+                          name="has_served-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content foreign"
+          data-section="military"
+          data-subsection="foreign"
+        >
+          <div>
+            <div>
+              <div
+                aria-label="Have you ever served, as a civilian or military member in a foreign country's military, intelligence, diplomatic, security forces, militia, other defense force, or government agency?"
+                className="field required  branch"
+                data-uuid="field-MOCK-GUID"
+              >
+                <a
+                  aria-hidden="true"
+                  className="anchor"
+                  id="field-MOCK-GUID"
+                  name="field-MOCK-GUID"
+                />
+                <h2
+                  className="title h2"
+                >
+                  Have you ever served, as a civilian or military member in a foreign country's military, intelligence, diplomatic, security forces, militia, other defense force, or government agency?
+                </h2>
+                <span
+                  className="icon"
+                />
+                <div
+                  className="table expand"
+                >
+                  <span
+                    aria-live="polite"
+                    className="messages help-messages"
+                  />
+                </div>
+                <div
+                  className="table"
+                >
+                  <span
+                    className="content"
+                  >
+                    <span
+                      className="component shrink"
+                    >
+                      <div
+                        className="content"
+                      />
+                      <div
+                        className="blocks option-list branch usa-input-error"
+                      >
+                        <div
+                          className="yes block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="has_foreign-MOCK-GUID"
+                          >
+                            <input
+                              aria-label="Yes for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="has_foreign-MOCK-GUID"
+                              name="has_foreign-MOCK-GUID"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="Yes"
+                            />
+                            <span>
+                              Yes
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="no block"
+                        >
+                          <label
+                            className=""
+                            htmlFor="has_foreign-MOCK-GUID"
+                          >
+                            <input
+                              aria-label="No for null"
+                              checked={false}
+                              className="usa-input-success"
+                              disabled={false}
+                              id="has_foreign-MOCK-GUID"
+                              name="has_foreign-MOCK-GUID"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              type="radio"
+                              value="No"
+                            />
+                            <span>
+                              No
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </span>
+                  </span>
+                </div>
+                <div
+                  className="table expand"
+                >
+                  <span
+                    aria-live="polite"
+                    className="messages error-messages"
+                    role="alert"
+                  >
+                    <div
+                      aria-live="polite"
+                      className="message error"
+                      role="alert"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="fa fa-exclamation"
+                      />
+                      <div
+                        data-i18n="error.required"
+                      >
+                        <h5>
+                          Your response is required
+                        </h5>
+                        
+                        
+                      </div>
+                    </div>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          aria-label="Add a comment to clarify any of your responses in the military history section"
+          className="field   section-comment"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h4
+            className="title h4"
+          >
+            Add a comment to clarify any of your responses in the military history section
+            <span
+              className="optional"
+            >
+              (Optional)
+            </span>
+          </h4>
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
+            >
+              <span
+                className="component"
+              >
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="Comments-error"
+                    aria-label={null}
+                    autoCapitalize={true}
+                    autoComplete={true}
+                    autoCorrect={true}
+                    className=""
+                    id="Comments-MOCK-GUID"
+                    maxLength={255}
+                    name="Comments"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    pattern=".*"
+                    spellCheck={true}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </span>
+            </span>
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="section-print-container"
+    >
+      <h3
+        className="section-print-header"
+      >
+        Foreign associations
+      </h3>
+      <div>
+        <div
+          className="section-content passport"
+          data-section="foreign"
+          data-subsection="passport"
+        >
+          <div
+            aria-label="U.S. passport information"
+            className="field   no-margin-bottom"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              U.S. passport information
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                />
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+          </div>
+          <p>
+            Provide the following information for the most recent U.S. passport you currently possess.
+          </p>
+          <p>
+            <a
+              href="https://travel.state.gov/content/travel/en.html"
+              rel="noopener noreferrer"
+              target="_blank"
+              title="U.S. State Department Help"
+            >
+              U.S. State Department passport help
+            </a>
+          </p>
+          <div
+            aria-label="Do you possess a U.S. passport (current or expired)?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Do you possess a U.S. passport (current or expired)?
+            </h3>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_passport-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_passport-MOCK-GUID"
+                          name="has_passport-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_passport-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_passport-MOCK-GUID"
+                          name="has_passport-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content foreign-contacts"
+          data-section="foreign"
+          data-subsection="contacts"
+        >
+          <div>
+            <p>
+              A foreign national is defined as any person who is not a citizen or national of the U.S.
+            </p>
+          </div>
+          <div
+            aria-label="Do you have, or have you had, close and/or continuing contact with a foreign national within the last seven (7) years with whom you, or your spouse, or legally recognized civil union/domestic partner, or cohabitant are bound by affection, influence, common interests, and/or obligation?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Do you have, or have you had, close and/or continuing contact with a foreign national within the last seven (7) years with whom you, or your spouse, or legally recognized civil union/domestic partner, or cohabitant are bound by affection, influence, common interests, and/or obligation?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <div>
+                      <p>
+                        Include associates as well as relatives, not previously listed in the relatives section.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_contacts-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_contacts-MOCK-GUID"
+                          name="has_foreign_contacts-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_contacts-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_contacts-MOCK-GUID"
+                          name="has_foreign_contacts-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content direct"
+          data-section="foreign"
+          data-subsection="activities/direct"
+        >
+          <div
+            aria-label="Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children EVER had any foreign financial interests in which you or they have direct control or direct ownership?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children EVER had any foreign financial interests in which you or they have direct control or direct ownership?
+            </h2>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children EVER had any foreign financial interests in which you or they have direct control or direct ownership?"
+                className="toggle h2  adjust-for-buttons"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children EVER had any foreign financial interests in which you or they have direct control or direct ownership?"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <div>
+                      <p>
+                        Foreign financial interest examples:  stocks, property, investments, bank accounts, ownership of corporate entities, corporate interests or exchange traded funds (ETFs) held in specific geographical or economic sectors.
+                      </p>
+                    </div>
+                    <div>
+                      <p>
+                        <strong>
+                          Exclude financial interests in companies or diversified mutual funds or diversified ETFs that are publicly traded on a U.S. exchange.
+                        </strong>
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_interests-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_interests-MOCK-GUID"
+                          name="has_interests-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_interests-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_interests-MOCK-GUID"
+                          name="has_interests-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content indirect"
+          data-section="foreign"
+          data-subsection="activities/indirect"
+        >
+          <div
+            aria-label="Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children EVER had any foreign financial interests that someone controlled on your behalf?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children EVER had any foreign financial interests that someone controlled on your behalf?
+            </h2>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children EVER had any foreign financial interests that someone controlled on your behalf?"
+                className="toggle h2  adjust-for-buttons"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children EVER had any foreign financial interests that someone controlled on your behalf?"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_interests-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_interests-MOCK-GUID"
+                          name="has_interests-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_interests-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_interests-MOCK-GUID"
+                          name="has_interests-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content realestate"
+          data-section="foreign"
+          data-subsection="activities/realestate"
+        >
+          <div
+            aria-label="Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children EVER owned, or do you anticipate owning, or plan to purchase real estate in a foreign country?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children EVER owned, or do you anticipate owning, or plan to purchase real estate in a foreign country?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_interests-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_interests-MOCK-GUID"
+                          name="has_interests-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_interests-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_interests-MOCK-GUID"
+                          name="has_interests-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content benefit-activity"
+          data-section="foreign"
+          data-subsection="activities/benefits"
+        >
+          <div
+            aria-label="As a U.S. citizen, have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children received in the last seven (7) years, or are eligible to receive in the future, any educational, medical, retirement, social welfare, or other such benefit from a foreign country?"
+            className="field required  branch has-benefits"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              As a U.S. citizen, have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children received in the last seven (7) years, or are eligible to receive in the future, any educational, medical, retirement, social welfare, or other such benefit from a foreign country?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_benefit-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_benefit-MOCK-GUID"
+                          name="has_benefit-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_benefit-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_benefit-MOCK-GUID"
+                          name="has_benefit-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content foreign-activities-support"
+          data-section="foreign"
+          data-subsection="activities/support"
+        >
+          <div
+            aria-label="Have you EVER provided financial support for any foreign national?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER provided financial support for any foreign national?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_support-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_support-MOCK-GUID"
+                          name="has_foreign_support-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_support-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_support-MOCK-GUID"
+                          name="has_foreign_support-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content foreign-business-advice"
+          data-section="foreign"
+          data-subsection="business/advice"
+        >
+          <div
+            aria-label="Have you in the last seven (7) years provided advice or support to any individual associated with a foreign business or other foreign organization that you have not previously listed as a former employer?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you in the last seven (7) years provided advice or support to any individual associated with a foreign business or other foreign organization that you have not previously listed as a former employer?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <div>
+                      <p>
+                        Answer "No" if 
+                        <strong>
+                          all
+                        </strong>
+                         your advice or support was authorized pursuant to official U.S. Government business.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_advice-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_advice-MOCK-GUID"
+                          name="has_foreign_advice-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_advice-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_advice-MOCK-GUID"
+                          name="has_foreign_advice-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content foreign-business-family"
+          data-section="foreign"
+          data-subsection="business/family"
+        >
+          <div
+            aria-label="Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or any member of your immediate family in the last seven (7) years been asked to provide advice or serve as a consultant, even informally, by any foreign government official or agency?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or any member of your immediate family in the last seven (7) years been asked to provide advice or serve as a consultant, even informally, by any foreign government official or agency?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <div>
+                      <p>
+                        For this question, "Immediate Family" means your spouse or legally recognized civil union/domestic partner, parents, step-parents, siblings, half and step-siblings, children, step-children, and cohabitant.
+                      </p>
+                    </div>
+                    <div>
+                      <p>
+                        Answer 
+                        <strong>
+                          "No"
+                        </strong>
+                         if all the advice or support was authorized pursuant to official U.S. Government business.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_family-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_family-MOCK-GUID"
+                          name="has_foreign_family-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_family-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_family-MOCK-GUID"
+                          name="has_foreign_family-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content foreign-business-employment"
+          data-section="foreign"
+          data-subsection="business/employment"
+        >
+          <div
+            aria-label="Has any foreign national in the last seven (7) years offered you a job, asked you to work as a consultant, or consider employment with them?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Has any foreign national in the last seven (7) years offered you a job, asked you to work as a consultant, or consider employment with them?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_employment-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_employment-MOCK-GUID"
+                          name="has_foreign_employment-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_employment-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_employment-MOCK-GUID"
+                          name="has_foreign_employment-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content foreign-business-ventures"
+          data-section="foreign"
+          data-subsection="business/ventures"
+        >
+          <div
+            aria-label="Have you in the last seven (7) years been involved in any other type of business venture with a foreign national not described above?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you in the last seven (7) years been involved in any other type of business venture with a foreign national not described above?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <div>
+                      <p>
+                        Own, co-own, serve as a business consultant, provide financial support, etc.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_ventures-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_ventures-MOCK-GUID"
+                          name="has_foreign_ventures-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_ventures-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_ventures-MOCK-GUID"
+                          name="has_foreign_ventures-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content foreign-business-conferences"
+          data-section="foreign"
+          data-subsection="business/conferences"
+        >
+          <div
+            aria-label="Have you in the last seven (7) years attended or participated in any conferences, trade shows, seminars, or meetings outside the U.S.?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you in the last seven (7) years attended or participated in any conferences, trade shows, seminars, or meetings outside the U.S.?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <div>
+                      <p>
+                        Do not include those you attended or participated in on official business for the U.S. government.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_conferences-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_conferences-MOCK-GUID"
+                          name="has_foreign_conferences-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_conferences-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_conferences-MOCK-GUID"
+                          name="has_foreign_conferences-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content foreign-business-contact"
+          data-section="foreign"
+          data-subsection="business/contact"
+        >
+          <div>
+            <p>
+              For Section 7, "Immediate Family" means your spouse, parents, step-parents, siblings, half and step-siblings, children, stepchildren, and cohabitant.
+            </p>
+          </div>
+          <div
+            aria-label="Have you or any member of your immediate family in the last seven (7) years had any contact with a foreign government, its establishment or its representatives, whether inside or outside the U.S.?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you or any member of your immediate family in the last seven (7) years had any contact with a foreign government, its establishment or its representatives, whether inside or outside the U.S.?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <div>
+                      <p>
+                        Such as  embassy, consulate, agency, military service, intelligence or security service, etc.
+                      </p>
+                    </div>
+                    <div>
+                      <p>
+                        Answer "No" if the contact was for routine visa applications and border crossings related to either official U.S.  Government travel, foreign travel on a U.S. passport, or as a U.S. military service member in conjunction with a U.S. Government military duty.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_contact-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_contact-MOCK-GUID"
+                          name="has_foreign_contact-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_contact-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_contact-MOCK-GUID"
+                          name="has_foreign_contact-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content foreign-business-sponsorship"
+          data-section="foreign"
+          data-subsection="business/sponsorship"
+        >
+          <div
+            aria-label="Have you in the last seven (7) years sponsored any foreign national to come to the U.S. as a student, for work, or for permanent residence?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you in the last seven (7) years sponsored any foreign national to come to the U.S. as a student, for work, or for permanent residence?
+            </h2>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Have you in the last seven (7) years sponsored any foreign national to come to the U.S. as a student, for work, or for permanent residence?"
+                className="toggle h2  adjust-for-buttons"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Have you in the last seven (7) years sponsored any foreign national to come to the U.S. as a student, for work, or for permanent residence?"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_sponsorship-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_sponsorship-MOCK-GUID"
+                          name="has_foreign_sponsorship-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_sponsorship-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_sponsorship-MOCK-GUID"
+                          name="has_foreign_sponsorship-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content foreign-business-political"
+          data-section="foreign"
+          data-subsection="business/political"
+        >
+          <div
+            aria-label="Have you EVER held political office in a foreign country?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER held political office in a foreign country?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_political-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_political-MOCK-GUID"
+                          name="has_foreign_political-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_political-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_political-MOCK-GUID"
+                          name="has_foreign_political-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content foreign-business-voting"
+          data-section="foreign"
+          data-subsection="business/voting"
+        >
+          <div
+            aria-label="Have you EVER voted in the election of a foreign country?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER voted in the election of a foreign country?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_voting-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_voting-MOCK-GUID"
+                          name="has_foreign_voting-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_voting-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_voting-MOCK-GUID"
+                          name="has_foreign_voting-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content foreign-travel"
+          data-section="foreign"
+          data-subsection="travel"
+        >
+          <div
+            aria-label="Have you traveled outside the U.S. in the last past seven (7) years?"
+            className="field required  branch foreign-travel-outside"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you traveled outside the U.S. in the last past seven (7) years?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_travel_outside-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_travel_outside-MOCK-GUID"
+                          name="has_foreign_travel_outside-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_foreign_travel_outside-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_foreign_travel_outside-MOCK-GUID"
+                          name="has_foreign_travel_outside-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          aria-label="Add a comment to clarify any of your responses in the foreign associations section"
+          className="field   section-comment"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h4
+            className="title h4"
+          >
+            Add a comment to clarify any of your responses in the foreign associations section
+            <span
+              className="optional"
+            >
+              (Optional)
+            </span>
+          </h4>
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
+            >
+              <span
+                className="component"
+              >
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="Comments-error"
+                    aria-label={null}
+                    autoCapitalize={true}
+                    autoComplete={true}
+                    autoCorrect={true}
+                    className=""
+                    id="Comments-MOCK-GUID"
+                    maxLength={255}
+                    name="Comments"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    pattern=".*"
+                    spellCheck={true}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </span>
+            </span>
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="section-print-container"
+    >
+      <h3
+        className="section-print-header"
+      >
+        Financial record
+      </h3>
+      <div>
+        <div
+          className="section-content bankruptcies"
+          data-section="financial"
+          data-subsection="bankruptcy"
+        >
+          <div
+            aria-label="In the last seven (7) years have you filed a petition under any chapter of the bankruptcy code?"
+            className="field required  branch bankruptcy-branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              In the last seven (7) years have you filed a petition under any chapter of the bankruptcy code?
+            </h2>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for In the last seven (7) years have you filed a petition under any chapter of the bankruptcy code?"
+                className="toggle h2  adjust-for-buttons"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for In the last seven (7) years have you filed a petition under any chapter of the bankruptcy code?"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_bankruptcydebt-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_bankruptcydebt-MOCK-GUID"
+                          name="has_bankruptcydebt-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_bankruptcydebt-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_bankruptcydebt-MOCK-GUID"
+                          name="has_bankruptcydebt-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content gambling"
+          data-section="financial"
+          data-subsection="gambling"
+        >
+          <div
+            aria-label="Have you ever experienced financial problems due to gambling?"
+            className="field required  branch has-gambling-debt"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you ever experienced financial problems due to gambling?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_gamblingdebt-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_gamblingdebt-MOCK-GUID"
+                          name="has_gamblingdebt-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_gamblingdebt-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_gamblingdebt-MOCK-GUID"
+                          name="has_gamblingdebt-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content taxes"
+          data-section="financial"
+          data-subsection="taxes"
+        >
+          <div
+            aria-label="In the last seven (7) years have you failed to file or pay Federal, state, or other taxes when required by law or ordinance?"
+            className="field required  branch taxes-branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              In the last seven (7) years have you failed to file or pay Federal, state, or other taxes when required by law or ordinance?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_taxes-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_taxes-MOCK-GUID"
+                          name="has_taxes-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_taxes-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_taxes-MOCK-GUID"
+                          name="has_taxes-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content card-abuse"
+          data-section="financial"
+          data-subsection="card"
+        >
+          <div
+            aria-label="In the last seven (7) years have you been counseled, warned, or disciplined for violating the terms of agreement for your travel or credit card provided by your employer?"
+            className="field required  branch card-branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              In the last seven (7) years have you been counseled, warned, or disciplined for violating the terms of agreement for your travel or credit card provided by your employer?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_cardabuse-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_cardabuse-MOCK-GUID"
+                          name="has_cardabuse-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_cardabuse-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_cardabuse-MOCK-GUID"
+                          name="has_cardabuse-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content credit-counseling"
+          data-section="financial"
+          data-subsection="credit"
+        >
+          <div
+            aria-label="Are you currently utilizing, or seeking assistance from, a credit counseling service or other similar resource to resolve your financial difficulties?"
+            className="field required  branch credit-branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Are you currently utilizing, or seeking assistance from, a credit counseling service or other similar resource to resolve your financial difficulties?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_credit-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_credit-MOCK-GUID"
+                          name="has_credit-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_credit-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_credit-MOCK-GUID"
+                          name="has_credit-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content delinquent"
+          data-section="financial"
+          data-subsection="delinquent"
+        >
+          <div
+            aria-label="Other than previously listed, have any of the following happened to you?"
+            className="field required  branch delinquent-branch eapp-field-wrap"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Other than previously listed, have any of the following happened to you?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <div>
+                      <p>
+                        You will be asked to provide details about each financial obligation that pertains to the items identified below.
+                      </p>
+                    </div>
+                    <ul>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              In the last seven (7) years,
+                            </strong>
+                             you have been delinquent on alimony or child support payments.
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              In the last seven (7) years,
+                            </strong>
+                             you had a judgement entered against you. (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              In the last seven (7) years,
+                            </strong>
+                             you had a lien placed against your property for failing to pay taxes or other debts. (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            You are currently delinquent on any Federal debt. (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                          </p>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_delinquent-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_delinquent-MOCK-GUID"
+                          name="has_delinquent-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_delinquent-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_delinquent-MOCK-GUID"
+                          name="has_delinquent-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content nonpayment"
+          data-section="financial"
+          data-subsection="nonpayment"
+        >
+          <div
+            aria-label="Other than previously listed, have any of the following happened?"
+            className="field required  branch nonpayment-branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Other than previously listed, have any of the following happened?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <ul>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              In the last seven (7) years,
+                            </strong>
+                             you had any possessions or property voluntarily or involuntarily repossessed or foreclosed? (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              In the last seven (7) years,
+                            </strong>
+                             you defaulted on any type of loan? (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              In the last seven (7) years,
+                            </strong>
+                             you had bills or debts turned over to a collection agency? (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              In the last seven (7) years,
+                            </strong>
+                             you had any account or credit card suspended, charged off, or cancelled for failing to pay as agreed? (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              In the last seven (7) years,
+                            </strong>
+                             you were evicted for non-payment?
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              In the last seven (7) years,
+                            </strong>
+                             you had your wages, benefits, or assets garnished or attached for any reason?
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              In the last seven (7) years,
+                            </strong>
+                             you have been over 120 days delinquent on any debt not previously entered? (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            You are currently over 120 days delinquent on any debt? (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                          </p>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_nonpayment-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_nonpayment-MOCK-GUID"
+                          name="has_nonpayment-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_nonpayment-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_nonpayment-MOCK-GUID"
+                          name="has_nonpayment-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          aria-label="Add a comment to clarify any of your responses in the financial record section"
+          className="field   section-comment"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h4
+            className="title h4"
+          >
+            Add a comment to clarify any of your responses in the financial record section
+            <span
+              className="optional"
+            >
+              (Optional)
+            </span>
+          </h4>
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
+            >
+              <span
+                className="component"
+              >
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="Comments-error"
+                    aria-label={null}
+                    autoCapitalize={true}
+                    autoComplete={true}
+                    autoCorrect={true}
+                    className=""
+                    id="Comments-MOCK-GUID"
+                    maxLength={255}
+                    name="Comments"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    pattern=".*"
+                    spellCheck={true}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </span>
+            </span>
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="section-print-container"
+    >
+      <h3
+        className="section-print-header"
+      >
+        Substance use
+      </h3>
+      <div>
+        <div
+          className="section-content drug-uses"
+          data-section="substance"
+          data-subsection="drugs/usage"
+        >
+          <div>
+            <p>
+              We note, with reference to this section, that neither your truthful responses nor information derived from your responses to this section will be used as evidence against you in a subsequent criminal proceeding. As to this particular section, this applies whether or not you are currently employed by the Federal government. The following questions pertain to the illegal use of drugs or controlled substances or drug or controlled substance activity in accordance with Federal laws, even though permissible under state laws.
+            </p>
+          </div>
+          <div
+            aria-label="In the last seven (7) years, have you illegally used any drugs or controlled substances?"
+            className="field required  branch used-drugs"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              In the last seven (7) years, have you illegally used any drugs or controlled substances?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <div>
+                      <p>
+                        Use of a drug or controlled substance includes injecting, snorting, inhaling, swallowing, experimenting with or otherwise consuming any drug or controlled substance.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="UsedDrugs-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="UsedDrugs-MOCK-GUID"
+                          name="UsedDrugs-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="UsedDrugs-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="UsedDrugs-MOCK-GUID"
+                          name="UsedDrugs-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content drug-involvements"
+          data-section="substance"
+          data-subsection="drugs/purchase"
+        >
+          <div
+            aria-label="In the last seven (7) years, have you been involved in the illegal purchase, manufacture, cultivation, trafficking, production, transfer, shipping, receiving, handling or sale of any drug or controlled substance?"
+            className="field required  branch involved"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              In the last seven (7) years, have you been involved in the illegal purchase, manufacture, cultivation, trafficking, production, transfer, shipping, receiving, handling or sale of any drug or controlled substance?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="Involved-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="Involved-MOCK-GUID"
+                          name="Involved-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="Involved-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="Involved-MOCK-GUID"
+                          name="Involved-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content drug-clearance-uses"
+          data-section="substance"
+          data-subsection="drugs/clearance"
+        >
+          <div
+            aria-label="Have you EVER illegally used or otherwise been illegally involved with a drug or controlled substance while possessing a security clearance other than previously listed?"
+            className="field required  branch used-drugs"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER illegally used or otherwise been illegally involved with a drug or controlled substance while possessing a security clearance other than previously listed?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="UsedDrugs-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="UsedDrugs-MOCK-GUID"
+                          name="UsedDrugs-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="UsedDrugs-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="UsedDrugs-MOCK-GUID"
+                          name="UsedDrugs-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content drug-public-safety-uses"
+          data-section="substance"
+          data-subsection="drugs/publicsafety"
+        >
+          <div
+            aria-label="Have you EVER illegally used or otherwise been involved with a drug or controlled substance while employed as a law enforcement officer, prosecutor, or courtroom official; or while in a position directly and immediately affecting the public safety other than previously listed?"
+            className="field required  branch used-drugs"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER illegally used or otherwise been involved with a drug or controlled substance while employed as a law enforcement officer, prosecutor, or courtroom official; or while in a position directly and immediately affecting the public safety other than previously listed?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="UsedDrugs-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="UsedDrugs-MOCK-GUID"
+                          name="UsedDrugs-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="UsedDrugs-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="UsedDrugs-MOCK-GUID"
+                          name="UsedDrugs-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content prescription-uses"
+          data-section="substance"
+          data-subsection="drugs/misuse"
+        >
+          <div
+            aria-label="In the last seven (7) years have you intentionally engaged in the misuse of prescription drugs, regardless of whether or not the drugs were prescribed for you or someone else?"
+            className="field required  branch misused"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              In the last seven (7) years have you intentionally engaged in the misuse of prescription drugs, regardless of whether or not the drugs were prescribed for you or someone else?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="Misused-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="Misused-MOCK-GUID"
+                          name="Misused-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="Misused-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="Misused-MOCK-GUID"
+                          name="Misused-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content ordered-treatments"
+          data-section="substance"
+          data-subsection="drugs/ordered"
+        >
+          <div
+            aria-label="Have you EVER been ordered, advised, or asked to seek counseling or treatment as a result of your illegal use of drugs or controlled substances?"
+            className="field required  branch treatment-ordered"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER been ordered, advised, or asked to seek counseling or treatment as a result of your illegal use of drugs or controlled substances?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="TreatmentOrdered-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="TreatmentOrdered-MOCK-GUID"
+                          name="TreatmentOrdered-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="TreatmentOrdered-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="TreatmentOrdered-MOCK-GUID"
+                          name="TreatmentOrdered-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content voluntary-treatments"
+          data-section="substance"
+          data-subsection="drugs/voluntary"
+        >
+          <div
+            aria-label="Have you EVER voluntarily sought counseling or treatment as a result of your use of a drug or controlled substance?"
+            className="field required  branch treatment-voluntary"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER voluntarily sought counseling or treatment as a result of your use of a drug or controlled substance?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="TreatmentVoluntary-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="TreatmentVoluntary-MOCK-GUID"
+                          name="TreatmentVoluntary-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="TreatmentVoluntary-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="TreatmentVoluntary-MOCK-GUID"
+                          name="TreatmentVoluntary-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content negative-impacts"
+          data-section="substance"
+          data-subsection="alcohol/negative"
+        >
+          <div
+            aria-label="In the last seven (7) years has your use of alcohol had a negative impact on your work performance, your professional or personal relationships, your finances, or resulted in intervention by law enforcement/public safety personnel?"
+            className="field required  branch has-impacts"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              In the last seven (7) years has your use of alcohol had a negative impact on your work performance, your professional or personal relationships, your finances, or resulted in intervention by law enforcement/public safety personnel?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_impacts-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_impacts-MOCK-GUID"
+                          name="has_impacts-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_impacts-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_impacts-MOCK-GUID"
+                          name="has_impacts-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content ordered-counselings"
+          data-section="substance"
+          data-subsection="alcohol/ordered"
+        >
+          <div
+            aria-label="Have you EVER been ordered, advised, or asked to seek counseling or treatment as a result of your use of alcohol?"
+            className="field required  branch has-been-ordered"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER been ordered, advised, or asked to seek counseling or treatment as a result of your use of alcohol?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="HasBeenOrdered-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="HasBeenOrdered-MOCK-GUID"
+                          name="HasBeenOrdered-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="HasBeenOrdered-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="HasBeenOrdered-MOCK-GUID"
+                          name="HasBeenOrdered-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content voluntary-counselings"
+          data-section="substance"
+          data-subsection="alcohol/voluntary"
+        >
+          <div
+            aria-label="Have you EVER voluntarily sought counseling or treatment as a result of your use of alcohol?"
+            className="field required  branch sought-treatment"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER voluntarily sought counseling or treatment as a result of your use of alcohol?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="SoughtTreatment-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="SoughtTreatment-MOCK-GUID"
+                          name="SoughtTreatment-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="SoughtTreatment-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="SoughtTreatment-MOCK-GUID"
+                          name="SoughtTreatment-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content received-counselings"
+          data-section="substance"
+          data-subsection="alcohol/additional"
+        >
+          <div
+            aria-label="Have you EVER received counseling or treatment as a result of your use of alcohol in addition to what you have already listed on this form?"
+            className="field required  branch received-treatment"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER received counseling or treatment as a result of your use of alcohol in addition to what you have already listed on this form?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="ReceivedTreatment-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="ReceivedTreatment-MOCK-GUID"
+                          name="ReceivedTreatment-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="ReceivedTreatment-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="ReceivedTreatment-MOCK-GUID"
+                          name="ReceivedTreatment-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          aria-label="Add a comment to clarify any of your responses in the substance use section"
+          className="field   section-comment"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h4
+            className="title h4"
+          >
+            Add a comment to clarify any of your responses in the substance use section
+            <span
+              className="optional"
+            >
+              (Optional)
+            </span>
+          </h4>
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
+            >
+              <span
+                className="component"
+              >
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="Comments-error"
+                    aria-label={null}
+                    autoCapitalize={true}
+                    autoComplete={true}
+                    autoCorrect={true}
+                    className=""
+                    id="Comments-MOCK-GUID"
+                    maxLength={255}
+                    name="Comments"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    pattern=".*"
+                    spellCheck={true}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </span>
+            </span>
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="section-print-container"
+    >
+      <h3
+        className="section-print-header"
+      >
+        Investigative and criminal history
+      </h3>
+      <div>
+        <div
+          aria-label="Police record"
+          className="field   no-margin-bottom"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h2
+            className="title h2"
+          >
+            Police record
+          </h2>
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
+            >
+              <span
+                className="component"
+              >
+                <div>
+                  <p>
+                    For this section report information regardless of whether the record in your case has been sealed, expunged, or otherwise stricken from the court record, or the charge was dismissed.
+                  </p>
+                </div>
+                <div>
+                  <p>
+                    You need not report convictions under the Federal Controlled Substances Act for which the court issued an expungement order under the authority of 21 U.S.C 844 or 18 U.S.C. 3607.
+                  </p>
+                </div>
+                <div>
+                  <p>
+                    <strong>
+                      Be sure to include all incidents whether occurring in the U.S. or abroad.
+                    </strong>
+                  </p>
+                </div>
+              </span>
+            </span>
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+        </div>
+        <div
+          className="section-content police-offenses"
+          data-section="legal"
+          data-subsection="police/offenses"
+        >
+          <div
+            aria-label="Have any of the following happened?"
+            className="field required  branch has-offenses"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have any of the following happened?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <ul>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              In the last seven (7) years
+                            </strong>
+                             have you been issued a summons, citation, or ticket to appear in court in a criminal proceeding against you? Do not check if all the citations involved traffic infractions where the fine was less than $300 and did not include alcohol or drugs.
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              In the last seven (7) years
+                            </strong>
+                             have you been arrested by any police officer, sheriff, marshal or any other type of law enforcement official?
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              In the last seven (7) years
+                            </strong>
+                             have you been charged with, convicted of, or sentenced for a crime in any court? Include all qualifying charges, convictions or sentences in any federal, state, local, military, or non-U.S. court, even if previously listed on this form.
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              In the last seven (7) years
+                            </strong>
+                             have you been or are you currently on probation or parole?
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            Are you currently on trial or awaiting a trial on criminal charges?
+                          </p>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_offenses-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_offenses-MOCK-GUID"
+                          name="has_offenses-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_offenses-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_offenses-MOCK-GUID"
+                          name="has_offenses-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content police-other-offenses"
+          data-section="legal"
+          data-subsection="police/additionaloffenses"
+        >
+          <div
+            aria-label="Other than those offenses already listed, have you EVER had the following happen to you?"
+            className="field required  branch has-otheroffenses"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Other than those offenses already listed, have you EVER had the following happen to you?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <ul>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              Have you EVER been convicted
+                            </strong>
+                             in any court of the United States of a crime, sentenced to imprisonment for a term exceeding 1 year for that crime, and incarcerated as a result of that sentence for not less than 1 year? Include all qualifying convictions in Federal, state, local, or military court, even if previously listed on this form
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              Have you EVER been charged
+                            </strong>
+                             with any felony offense? Include those under the Uniform Code of Military Justice and non-military/civilian offenses
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              Have you EVER been convicted
+                            </strong>
+                             of an offense involving domestic violence or a crime of violence (such as battery or assault) against your child, dependent, cohabitant, spouse or legally recognized civil union/domestic partner, former spouse or legally recognized civil union/domestic partner, or someone with whom you share a child in common?
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              Have you EVER been charged
+                            </strong>
+                             with an offense involving firearms or explosives?
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <p>
+                            <strong>
+                              Have you EVER been charged
+                            </strong>
+                             with an offense involving alcohol or drugs?
+                          </p>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_otheroffenses-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_otheroffenses-MOCK-GUID"
+                          name="has_otheroffenses-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_otheroffenses-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_otheroffenses-MOCK-GUID"
+                          name="has_otheroffenses-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content domestic-violence-list"
+          data-section="legal"
+          data-subsection="police/domesticviolence"
+        >
+          <div
+            aria-label="Is there currently a domestic violence protective order or restraining order issued against you?"
+            className="field required  branch has-domestic-violence"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Is there currently a domestic violence protective order or restraining order issued against you?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_domestic_violence-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_domestic_violence-MOCK-GUID"
+                          name="has_domestic_violence-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_domestic_violence-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_domestic_violence-MOCK-GUID"
+                          name="has_domestic_violence-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content investigations-history"
+          data-section="legal"
+          data-subsection="investigations/history"
+        >
+          <div
+            aria-label="Has the U.S. Government (or a foreign government) EVER investigated your background and/or granted you a security clearance eligibility/access?"
+            className="field required  branch legal-investigations-history-has-history"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Has the U.S. Government (or a foreign government) EVER investigated your background and/or granted you a security clearance eligibility/access?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_history-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_history-MOCK-GUID"
+                          name="has_history-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_history-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_history-MOCK-GUID"
+                          name="has_history-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content investigations-revoked"
+          data-section="legal"
+          data-subsection="investigations/revoked"
+        >
+          <div
+            aria-label="Have you EVER had a security clearance eligibility/access authorization denied, suspended, or revoked?"
+            className="field required  branch legal-investigations-revoked-has-revocations"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER had a security clearance eligibility/access authorization denied, suspended, or revoked?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <div>
+                      <p>
+                        Note: An administrative downgrade or administrative termination of a security clearance is not a revocation.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_revoked-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_revoked-MOCK-GUID"
+                          name="has_revoked-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_revoked-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_revoked-MOCK-GUID"
+                          name="has_revoked-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content investigations-debarred"
+          data-section="legal"
+          data-subsection="investigations/debarred"
+        >
+          <div
+            aria-label="Have you EVER been debarred from government employment?"
+            className="field required  branch legal-investigations-debarred-has-debarment"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER been debarred from government employment?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_debarred-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_debarred-MOCK-GUID"
+                          name="has_debarred-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_debarred-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_debarred-MOCK-GUID"
+                          name="has_debarred-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content non-criminal-court-actions"
+          data-section="legal"
+          data-subsection="court"
+        >
+          <div
+            aria-label="In the last ten (10) years, have you been a party to any public record civil court action not listed elsewhere on this form?"
+            className="field required  branch has-court-actions"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              In the last ten (10) years, have you been a party to any public record civil court action not listed elsewhere on this form?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="HasCourtActions-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="HasCourtActions-MOCK-GUID"
+                          name="HasCourtActions-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="HasCourtActions-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="HasCourtActions-MOCK-GUID"
+                          name="HasCourtActions-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content legal-technology-unauthorized"
+          data-section="legal"
+          data-subsection="technology/unauthorized"
+        >
+          <div>
+            <p>
+              We note, with reference to this section, that neither your truthful responses nor information derived from your responses to this section will be used as evidence against you in a subsequent criminal proceeding.
+            </p>
+          </div>
+          <div>
+            <p>
+              As to this particular section, this applies whether or not you are currently employed by the Federal government. The following questions ask about your use of information technology systems. Information technology systems include all related computer hardware, software, firmware, and data used for the communication, transmission, processing, manipulation, storage or protection of information.
+            </p>
+          </div>
+          <div
+            aria-label="In the last seven (7) years have you illegally or without proper authorization accessed or attempted to access any information technology system?"
+            className="field required  branch legal-technology-unauthorized-has-unauthorized"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              In the last seven (7) years have you illegally or without proper authorization accessed or attempted to access any information technology system?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_unauthorized-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_unauthorized-MOCK-GUID"
+                          name="has_unauthorized-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_unauthorized-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_unauthorized-MOCK-GUID"
+                          name="has_unauthorized-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content legal-technology-manipulating"
+          data-section="legal"
+          data-subsection="technology/manipulating"
+        >
+          <div
+            aria-label="In the last seven (7) years have you illegally or without authorization, modified, destroyed, manipulated, or denied others access to information residing on an information technology system or attempted any of the above?"
+            className="field required  branch legal-technology-manipulating-has-manipulating"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              In the last seven (7) years have you illegally or without authorization, modified, destroyed, manipulated, or denied others access to information residing on an information technology system or attempted any of the above?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_manipulating-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_manipulating-MOCK-GUID"
+                          name="has_manipulating-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_manipulating-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_manipulating-MOCK-GUID"
+                          name="has_manipulating-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content legal-technology-unlawful"
+          data-section="legal"
+          data-subsection="technology/unlawful"
+        >
+          <div
+            aria-label="In the last seven (7) years have you introduced, removed, or used hardware, software, or media in connection with any information technology system without authorization, when specifically prohibited by rules, procedures, guidelines, or regulations or attempted any of the above?"
+            className="field required  branch legal-technology-unlawful-has-unlawful"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              In the last seven (7) years have you introduced, removed, or used hardware, software, or media in connection with any information technology system without authorization, when specifically prohibited by rules, procedures, guidelines, or regulations or attempted any of the above?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_unlawful-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_unlawful-MOCK-GUID"
+                          name="has_unlawful-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_unlawful-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_unlawful-MOCK-GUID"
+                          name="has_unlawful-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content legal-associations-terrorist"
+          data-section="legal"
+          data-subsection="associations/terrorist-organization"
+        >
+          <div>
+            <p>
+              The following pertain to your associations. You are required to answer the questions fully and truthfully, and your failure to do so could be grounds for an adverse employment, security, or credentialing decision.
+            </p>
+          </div>
+          <div>
+            <p>
+              For the purpose of this question, terrorism is defined as any criminal acts that involve violence or are dangerous to human life and appear to be intended to intimidate or coerce a civilian population to influence the policy of a government by intimidation or coercion or to affect the conduct of a government by mass destruction, assassination or kidnapping.
+            </p>
+          </div>
+          <div
+            aria-label="Are you now or have you EVER been a member of an organization dedicated to terrorism, either with an awareness of the organization's dedication to that end, or with the specific intent to further such activities?"
+            className="field required  branch legal-associations-terrorist-has-terrorist"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Are you now or have you EVER been a member of an organization dedicated to terrorism, either with an awareness of the organization's dedication to that end, or with the specific intent to further such activities?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_terrorist-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_terrorist-MOCK-GUID"
+                          name="has_terrorist-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_terrorist-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_terrorist-MOCK-GUID"
+                          name="has_terrorist-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content legal-associations-engaged"
+          data-section="legal"
+          data-subsection="associations/engaged-in-terrorism"
+        >
+          <div
+            aria-label="Have you EVER knowingly engaged in any acts of terrorism?"
+            className="field required  branch legal-associations-engaged-has-engaged"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER knowingly engaged in any acts of terrorism?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_engaged-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_engaged-MOCK-GUID"
+                          name="has_engaged-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_engaged-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_engaged-MOCK-GUID"
+                          name="has_engaged-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content legal-associations-advocating"
+          data-section="legal"
+          data-subsection="associations/advocating"
+        >
+          <div
+            aria-label="Have you EVER advocated any acts of terrorism or activities designed to overthrow the U.S. Government by force?"
+            className="field required  branch legal-associations-advocating-has-advocated"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER advocated any acts of terrorism or activities designed to overthrow the U.S. Government by force?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_advocated-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_advocated-MOCK-GUID"
+                          name="has_advocated-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_advocated-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_advocated-MOCK-GUID"
+                          name="has_advocated-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content legal-associations-overthrow"
+          data-section="legal"
+          data-subsection="associations/membership-overthrow"
+        >
+          <div
+            aria-label="Have you EVER been a member of an organization dedicated to the use of violence or force to overthrow the United States Government, and which engaged in activities to that end with an awareness of the organization's dedication to that end or with the specific intent to further such activities?"
+            className="field required  branch legal-associations-overthrow-has-overthrow"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER been a member of an organization dedicated to the use of violence or force to overthrow the United States Government, and which engaged in activities to that end with an awareness of the organization's dedication to that end or with the specific intent to further such activities?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_overthrow-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_overthrow-MOCK-GUID"
+                          name="has_overthrow-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_overthrow-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_overthrow-MOCK-GUID"
+                          name="has_overthrow-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content legal-associations-violence"
+          data-section="legal"
+          data-subsection="associations/membership-violence-or-force"
+        >
+          <div
+            aria-label="Have you EVER been a member of an organization that advocates or practices commission of acts of force or violence to discourage others from exercising their rights under the U.S. Constitution or any state of the United States with the specific intent to further such action?"
+            className="field required  branch legal-associations-violence-has-violence"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER been a member of an organization that advocates or practices commission of acts of force or violence to discourage others from exercising their rights under the U.S. Constitution or any state of the United States with the specific intent to further such action?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_violence-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_violence-MOCK-GUID"
+                          name="has_violence-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_violence-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_violence-MOCK-GUID"
+                          name="has_violence-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content legal-associations-activities"
+          data-section="legal"
+          data-subsection="associations/activities-to-overthrow"
+        >
+          <div
+            aria-label="Have you EVER knowingly engaged in activities designed to overthrow the U.S. Government by force?"
+            className="field required  branch legal-associations-activities-has-activities"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER knowingly engaged in activities designed to overthrow the U.S. Government by force?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_activities-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_activities-MOCK-GUID"
+                          name="has_activities-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_activities-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_activities-MOCK-GUID"
+                          name="has_activities-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content legal-associations-terrorism"
+          data-section="legal"
+          data-subsection="associations/terrorism-association"
+        >
+          <div
+            aria-label="Have you EVER associated with anyone involved in activities to further terrorism?"
+            className="field required  branch legal-associations-terrorism-has-terrorism"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER associated with anyone involved in activities to further terrorism?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_terrorsim-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_terrorsim-MOCK-GUID"
+                          name="has_terrorsim-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="has_terrorsim-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_terrorsim-MOCK-GUID"
+                          name="has_terrorsim-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          aria-label="Add a comment to clarify any of your responses in the investigative and criminal history section"
+          className="field   section-comment"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h4
+            className="title h4"
+          >
+            Add a comment to clarify any of your responses in the investigative and criminal history section
+            <span
+              className="optional"
+            >
+              (Optional)
+            </span>
+          </h4>
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
+            >
+              <span
+                className="component"
+              >
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="Comments-error"
+                    aria-label={null}
+                    autoCapitalize={true}
+                    autoComplete={true}
+                    autoCorrect={true}
+                    className=""
+                    id="Comments-MOCK-GUID"
+                    maxLength={255}
+                    name="Comments"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    pattern=".*"
+                    spellCheck={true}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </span>
+            </span>
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="section-print-container"
+    >
+      <h3
+        className="section-print-header"
+      >
+        Psychological and emotional health
+      </h3>
+      <div>
+        <div
+          className="section-content competence"
+          data-section="psychological"
+          data-subsection="competence"
+        >
+          <div
+            aria-label="Has a court or administrative agency ever issued an order declaring you mentally incompetent?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Has a court or administrative agency ever issued an order declaring you mentally incompetent?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="is_incompetent-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="is_incompetent-MOCK-GUID"
+                          name="is_incompetent-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="is_incompetent-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="is_incompetent-MOCK-GUID"
+                          name="is_incompetent-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content consultation"
+          data-section="psychological"
+          data-subsection="consultations"
+        >
+          <div
+            aria-label="Has a court or administrative agency EVER ordered you to consult with a mental health professional?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Has a court or administrative agency EVER ordered you to consult with a mental health professional?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <div>
+                      <p>
+                        <strong>
+                          For example, a psychiatrist, psychologist, licensed clinical social worker, etc.
+                        </strong>
+                      </p>
+                      <p>
+                        An order to a military member by a superior officer is not within the scope of this question, and therefore would not require an affirmative response.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="is_incompetent-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="is_incompetent-MOCK-GUID"
+                          name="is_incompetent-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="is_incompetent-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="is_incompetent-MOCK-GUID"
+                          name="is_incompetent-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content hospitalizations"
+          data-section="psychological"
+          data-subsection="hospitalizations"
+        >
+          <div
+            aria-label="Have you EVER been hospitalized for a mental health condition?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER been hospitalized for a mental health condition?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="hospitalized-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="hospitalized-MOCK-GUID"
+                          name="hospitalized-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="hospitalized-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="hospitalized-MOCK-GUID"
+                          name="hospitalized-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          className="section-content diagnoses"
+          data-section="psychological"
+          data-subsection="diagnoses"
+        >
+          <div>
+            <p>
+              The following question asks whether you have been diagnosed with a specified mental health condition that may, particularly if untreated, impact your judgment, reliability, or trustworthiness. If you answer in the affirmative, we will seek additional information about the seriousness and symptoms of the condition, as well as any applicable course of treatment.
+            </p>
+            <p>
+              It is important to note that any such diagnosis, in and of itself, 
+              <strong>
+                is not a reason
+              </strong>
+               to revoke or deny eligibility/or access to classified information or for holding a sensitive position, suitability or fitness to obtain or retain Federal or contract employment, or eligibility for physical or logical access to federally controlled facilities or information systems.
+            </p>
+          </div>
+          <div
+            aria-label="Have you EVER been diagnosed by a physician or other health professional with psychotic disorder, schizophrenia, schizoaffective disorder, delusional disorder, bipolar mood disorder, borderline personality disorder, or antisocial personality disorder?"
+            className="field required  branch diagnosed"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h2
+              className="title h2"
+            >
+              Have you EVER been diagnosed by a physician or other health professional with psychotic disorder, schizophrenia, schizoaffective disorder, delusional disorder, bipolar mood disorder, borderline personality disorder, or antisocial personality disorder?
+            </h2>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  >
+                    <div>
+                      <p>
+                        Health professional examples: a psychiatrist, psychologist, licensed clinical social worker, or nurse practitioner.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="diagnosed-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="diagnosed-MOCK-GUID"
+                          name="diagnosed-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <label
+                        className=""
+                        htmlFor="diagnosed-MOCK-GUID"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="diagnosed-MOCK-GUID"
+                          name="diagnosed-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              >
+                <div
+                  aria-live="polite"
+                  className="message error"
+                  role="alert"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-exclamation"
+                  />
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5>
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div
+          aria-label="Add a comment to clarify any of your responses in the psychological and emotional health section"
+          className="field   section-comment"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h4
+            className="title h4"
+          >
+            Add a comment to clarify any of your responses in the psychological and emotional health section
+            <span
+              className="optional"
+            >
+              (Optional)
+            </span>
+          </h4>
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
+            >
+              <span
+                className="component"
+              >
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="Comments-error"
+                    aria-label={null}
+                    autoCapitalize={true}
+                    autoComplete={true}
+                    autoCorrect={true}
+                    className=""
+                    id="Comments-MOCK-GUID"
+                    maxLength={255}
+                    name="Comments"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    pattern=".*"
+                    spellCheck={true}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </span>
+            </span>
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
The `Attachments` and `Print` subcomponents were subclassing the `SectionElement` base class when they didn't need to be. This was causing a problem where it giving a warning for certain [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html) not being set in those components, even though they weren't necessary.

Not exactly sure why this wasn't being caught in the linting/tests...