### PR TITLE
Show accurate validity of review page in nav

### DIFF
--- a/src/components/Navigation/SectionLink.jsx
+++ b/src/components/Navigation/SectionLink.jsx
@@ -43,14 +43,10 @@ class SectionLink extends React.Component {
     return className
   }
 
-  getActiveClassName () {
-    return this.hasErrors() ? '' : 'usa-current'
-  }
-
   render () {
     return (
       <li>
-        <NavLink to={this.href()} activeClassName={this.getActiveClassName()} className={this.getClassName()}>
+        <NavLink to={this.href()} activeClassName="usa-current" className={this.getClassName()}>
           <span className="section-name">
             {this.props.section.name}
           </span>

--- a/src/components/Navigation/SectionLink.jsx
+++ b/src/components/Navigation/SectionLink.jsx
@@ -18,6 +18,9 @@ class SectionLink extends React.Component {
   }
 
   hasErrors () {
+    if (this.props.section.name === 'Review') {
+      return hasErrors(this.props.baseUrl, this.props.errors)
+    }
     return hasErrors(this.url(), this.props.errors)
   }
 
@@ -40,10 +43,14 @@ class SectionLink extends React.Component {
     return className
   }
 
+  getActiveClassName () {
+    return this.hasErrors() ? '' : 'usa-current'
+  }
+
   render () {
     return (
       <li>
-        <NavLink to={this.href()} activeClassName="usa-current" className={this.getClassName()}>
+        <NavLink to={this.href()} activeClassName={this.getActiveClassName()} className={this.getClassName()}>
           <span className="section-name">
             {this.props.section.name}
           </span>


### PR DESCRIPTION
Checks the validity of the entire section for the `Review` link and adds invalid styling if there are issues, and the default `usa-current` class if it is valid. Fixes https://github.com/18F/e-QIP-prototype/issues/553

**Before:**
![screen shot 2018-08-13 at 3 43 09 pm](https://user-images.githubusercontent.com/1178494/44054148-d8fe3b0e-9f0f-11e8-80dd-d9b7f53557a8.png)

**After:**
![screen shot 2018-08-13 at 3 42 06 pm](https://user-images.githubusercontent.com/1178494/44054139-d612b622-9f0f-11e8-9149-1d7f7b75e89f.png)
