### PR TITLE
Small UI tweak to side navigation

### DIFF
--- a/src/components/Main/__snapshots__/App.test.jsx.snap
+++ b/src/components/Main/__snapshots__/App.test.jsx.snap
@@ -544,13 +544,13 @@ exports[`Renders homepage 1`] = `
             <div
               aria-label="Persons completing this form should begin after carefully reading the preceding instructions"
               className="field   branch introduction-acceptance"
-              data-uuid="field-6bfb022c-6c86-cdbe-5379-b13984d95d63"
+              data-uuid="field-f5e7bff5-7ac0-49ce-a5dd-6e16bef4c99e"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-6bfb022c-6c86-cdbe-5379-b13984d95d63"
-                name="field-6bfb022c-6c86-cdbe-5379-b13984d95d63"
+                id="field-f5e7bff5-7ac0-49ce-a5dd-6e16bef4c99e"
+                name="field-f5e7bff5-7ac0-49ce-a5dd-6e16bef4c99e"
               />
               <h3
                 className="title h3"
@@ -594,15 +594,15 @@ exports[`Renders homepage 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="acceptance_of_terms-cb1b76c1-7ddc-f166-0422-de1df2363d18"
+                          htmlFor="acceptance_of_terms-b12b81e3-6145-8b9c-1a43-98d89f3f165d"
                         >
                           <input
                             aria-label="Yes, I agree to this agreement"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="acceptance_of_terms-cb1b76c1-7ddc-f166-0422-de1df2363d18"
-                            name="acceptance_of_terms-cb1b76c1-7ddc-f166-0422-de1df2363d18"
+                            id="acceptance_of_terms-b12b81e3-6145-8b9c-1a43-98d89f3f165d"
+                            name="acceptance_of_terms-b12b81e3-6145-8b9c-1a43-98d89f3f165d"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -621,15 +621,15 @@ exports[`Renders homepage 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="acceptance_of_terms-d4a4c5e4-2c13-2605-47f2-e02fbee444c8"
+                          htmlFor="acceptance_of_terms-41f39eca-5162-1c7e-5336-6b27c8a61c58"
                         >
                           <input
                             aria-label="No, I do not agree to this agreement"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="acceptance_of_terms-d4a4c5e4-2c13-2605-47f2-e02fbee444c8"
-                            name="acceptance_of_terms-d4a4c5e4-2c13-2605-47f2-e02fbee444c8"
+                            id="acceptance_of_terms-41f39eca-5162-1c7e-5336-6b27c8a61c58"
+                            name="acceptance_of_terms-41f39eca-5162-1c7e-5336-6b27c8a61c58"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}

--- a/src/components/Main/__snapshots__/App.test.jsx.snap
+++ b/src/components/Main/__snapshots__/App.test.jsx.snap
@@ -5,6 +5,664 @@ exports[`Renders homepage 1`] = `
   className=""
 >
   <div
+    className="introduction-modal"
+  >
+    <div
+      aria-hidden="false"
+      className="modal"
+      onClick={[Function]}
+      role="dialog"
+    >
+      <div
+        className="modal-wrap"
+      >
+        <div
+          className="modal-content introduction-content"
+          onClick={[Function]}
+        >
+          <div>
+            <div
+              className="introduction-legal"
+            >
+              <div>
+                <h1>
+                  Questionnaire for National Security Positions
+                </h1>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    Follow instructions completely or your form will be unable to be processed. If you have any questions, contact the office that provided you the form.
+                  </strong>
+                </p>
+              </div>
+              <div>
+                <h2>
+                  Instructions for completing this form
+                </h2>
+              </div>
+              <div>
+                <ol>
+                  <li>
+                    <strong>
+                      Follow the instructions provided to you by the office that gave you this form
+                    </strong>
+                     and any other clarifying instructions, provided by that office, to assist you with completion of this form. You should retain a copy of the completed form for your records.
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <ol
+                  start="2"
+                >
+                  <li>
+                    <strong>
+                      All questions on this form must be answered
+                    </strong>
+                    . If no response is necessary or applicable, indicate this on the form by checking the associated "Not Applicable" checkbox, unless otherwise noted.
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <ol
+                  start="3"
+                >
+                  <li>
+                    <strong>
+                      Do not abbreviate the names of cities or foreign countries
+                    </strong>
+                    .
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <ol
+                  start="4"
+                >
+                  <li>
+                    <strong>
+                      All dates provided in this form must be in Month/Day/Year or Month/Year format
+                    </strong>
+                    . The year should be entered as a four character number (e.g., 1978 or 2001). If you are unable to report an exact date, approximate or estimate the date to the best of your ability, and indicate this by checking the "Estimated" checkbox.
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <p>
+                  All questions on this form must be answered 
+                  <strong>
+                    completely and truthfully
+                  </strong>
+                   in order that the Government may make the determinations described below on a complete record. Penalties for inaccurate or false statements are discussed below. 
+                  <strong>
+                    If you are a current civilian employee of the federal government:
+                  </strong>
+                   failure to answer any questions completely and truthfully could result in an adverse personnel action against you, including loss of employment; with respect to these sections: Illegal Use of Drugs and Drug Activity, Use of Information Technology Systems, and Association Record, however, neither your truthful responses nor information derived from those responses will be used as evidence against you in a subsequent criminal proceeding.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  How to save your progress
+                </h1>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    This form will auto save your progress continuously throughout.
+                  </strong>
+                   Each input will be validated and save as you enter your information.
+                </p>
+              </div>
+              <div>
+                <p>
+                  To confirm you're auto saving and find out when the last save was check for the save icon on each screen.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Purpose of this form
+                </h1>
+              </div>
+              <div>
+                <p>
+                  This form will be used by the United States (U.S.) Government in conducting background investigations, reinvestigations, and continuous evaluations of persons under consideration for, or retention of, national security positions as defined in 5 CFR 732, and for individuals requiring eligibility for access to classified information under Executive Order 12968. This form may also be used by agencies in determining whether a subject performing work for, or on behalf of, the Government under a contract should be deemed eligible for logical or physical access when the nature of the work to be performed is sensitive and could bring about an adverse effect on the national security.
+                </p>
+              </div>
+              <div>
+                <p>
+                  Providing this information is voluntary. If you do not provide each item of requested information, however, we will not be able to complete your investigation, which will adversely affect your eligibility for a national security position, eligibility for access to classified information, or logical or physical access. It is imperative that the information provided be true and accurate, to the best of your knowledge. Any information that you provide is evaluated on the basis of its currency, seriousness, relevance to the position and duties, and consistency with all other information about you. Withholding, misrepresenting, or falsifying information may affect your eligibility for access to classified information, eligibility for a sensitive position, or your ability to obtain or retain Federal or contract employment. In addition, withholding, misrepresenting, or falsifying information may affect your eligibility for physical and logical access to federally controlled facilities or information systems. Withholding, misrepresenting, or falsifying information may also negatively affect your employment prospects and job status, and the potential consequences include, but are not limited to, removal, debarment from Federal service, loss of eligibility for access to classified information, or prosecution.
+                </p>
+              </div>
+              <div>
+                <p>
+                  This form may become a permanent document that may be used as the basis for future investigations, eligibility determinations for access to classified information, or to hold a sensitive position, suitability or fitness for Federal employment, fitness for contract employment, or eligibility for physical and logical access to federally controlled facilities or information systems. Your responses to this form may be compared with your responses to previous SF-86 questionnaires.
+                </p>
+              </div>
+              <div>
+                <p>
+                  The investigation conducted on the basis of information provided on this form may be selected for studies and analyses in support of evaluating and improving the effectiveness and efficiency of the investigative and adjudicative methodologies. All study results released to the general public will delete personal identifiers such as name, Social Security Number, and date and place of birth.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Authority to request this information
+                </h1>
+              </div>
+              <div>
+                <p>
+                  Depending upon the purpose of your investigation, the U.S. Government is authorized to ask for this information under Executive Orders 10450, 10865, 12333, and 12968; sections 3301, 3302, and 9101 of title 5, United States Code (U.S.C.); sections 2165 and 2201 of title 42, U.S.C.; chapter 23 of title 50, U.S.C.; and parts 2, 5, 731, 732, and 736 of title 5, Code of Federal Regulations (CFR).
+                </p>
+              </div>
+              <div>
+                <p>
+                  Your Social Security Number (SSN) is needed to identify records unique to you. Although disclosure of your SSN is not mandatory, failure to disclose your SSN may prevent or delay the processing of your background investigation. The authority for soliciting and verifying your SSN is Executive Order 9397, as amended by EO 13478.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  The investigative process
+                </h1>
+              </div>
+              <div>
+                <p>
+                  Background investigations for national security positions are conducted to gather information to determine whether you are reliable, trustworthy, of good conduct and character, and loyal to the U.S. The information that you provide on this form may be confirmed during the investigation. The investigation may extend beyond the time covered by this form, when necessary to resolve issues. Your current employer may be contacted as part of the investigation, although you may have previously indicated on applications or other forms that you do not want your current employer to be contacted. If you have a security freeze on your consumer or credit report file, then we may not be able to complete your investigation, which can adversely affect your eligibility for a national security position. To avoid such delays, you should request that the consumer reporting agencies lift the freeze in these instances.
+                </p>
+              </div>
+              <div>
+                <p>
+                  In addition to the questions on this form, inquiry also is made about your adherence to security requirements, your honesty and integrity, vulnerability to exploitation or coercion, falsification, misrepresentation, and any other behavior, activities, or associations that tend to demonstrate a person is not reliable, trustworthy, or loyal. Federal agency records checks may be conducted on your spouse or legally recognized civil union/domestic partner, cohabitant(s), and immediate family members. After an eligibility determination has been completed, you also may be subject to continuous evaluation, which may include periodic reinvestigations, to determine whether retention in your position is clearly consistent with the interests of national security.
+                </p>
+              </div>
+              <div>
+                <p>
+                  The information you provide on this form may be confirmed during the investigation, and may be used for identification purposes throughout the investigation process.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Your personal interview
+                </h1>
+              </div>
+              <div>
+                <p>
+                  Some investigations will include an interview with you as a routine part of the investigative process. The investigator may ask you to explain your answers to any question on this form. This provides you the opportunity to update, clarify, and explain information on your form more completely, which often assists in completing your investigation. It is imperative that the interview be conducted as soon as possible after you are contacted. Postponements will delay the processing of your investigation, and declining to be interviewed may result in your investigation being delayed or canceled.
+                </p>
+              </div>
+              <div>
+                <p>
+                  For the interview, you will be required to provide photo identification, such as a valid state driver's license. You may be required to provide other documents to verify your identity, as instructed by your investigator. These documents may include certification of any legal name change, Social Security card, passport, and/or your birth certificate. You may also be asked to provide documents regarding information that you provide on this form, or about other matters requiring specific attention. These matters include (a) alien registration or naturalization documentation; (b) delinquent loans or taxes, bankruptcies, judgments, liens, or other financial obligations; (c) agreements involving child custody or support, alimony, or property settlements; (d) arrests, convictions, probation, and/or parole; or (e) other matters described in court records.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Final determination on your eligibility
+                </h1>
+              </div>
+              <div>
+                <p>
+                  Final determination on your eligibility for a national security position is the responsibility of the Federal agency that requested your investigation and the agency that conducted your investigation. You will be provided the opportunity to explain, refute, or clarify any information before a final decision is made, if an unfavorable decision is considered. The United States Government does not discriminate on the basis of prohibited categories, including but not limited to race, color, religion, sex (including pregnancy and gender identity), national origin, disability, or sexual orientation when granting access to classified information.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Penalties for inaccurate or false statements
+                </h1>
+              </div>
+              <div>
+                <p>
+                  The U.S. Criminal Code (title 18, section 1001) provides that knowingly falsifying or concealing a material fact is a felony which may result in fines and/or up to five (5) years imprisonment. In addition, Federal agencies generally fire, do not grant a security clearance, or disqualify individuals who have materially and deliberately falsified these forms, and this remains a part of the permanent record for future placements. Your prospects of placement or security clearance are better if you answer all questions truthfully and completely. You will have adequate opportunity to explain any information you provide on this form and to make your comments part of the record.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Disclosure information
+                </h1>
+              </div>
+              <div>
+                <p>
+                  The information you provide is for the purpose of investigating you for a national security position, and the information will be protected from unauthorized disclosure. The collection, maintenance, and disclosure of background investigative information are governed by the Privacy Act. The agency that requested the investigation and the agency that conducted the investigation have published notices in the Federal Register describing the systems of records in which your records will be maintained. The information you provide on this form, and information collected during an investigation, may be disclosed without your consent by an agency maintaining the information in a system of records as permitted by the Privacy Act [5 U.S.C. 552a(b)], and by routine uses, a list of which are published by the agency in the Federal Register. The office that gave you this form will provide you a copy of its routine uses.
+                </p>
+              </div>
+              <div>
+                <p>
+                  You will not receive prior notice of such disclosures under a routine use.
+                </p>
+              </div>
+              <div>
+                <p>
+                  In addition to those disclosures generally permitted under the Privacy Act, all or a portion of the records or information you provide on this form or during your investigation may be disclosed outside of OPM as a routine use as outlined below.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Office of Personnel Management (OPM) routine uses
+                </h1>
+              </div>
+              <div>
+                <p>
+                  OPM has published the following Privacy Act routine uses for its system of records for background investigations:
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    a.
+                  </strong>
+                   To designated officers and employees of agencies, offices, and other establishments in the executive, legislative, and judicial branches of the Federal Government or the Government of the District of Columbia having a need to investigate, evaluate, or make a determination regarding loyalty to the United States; qualifications, suitability, or fitness for Government employment or military service; eligibility for logical or physical access to federally-controlled facilities or information systems; eligibility for access to classified information or to hold a sensitive position; qualifications or fitness to perform work for or on behalf of the Government under contract, grant, or other agreement; or access to restricted areas.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    b.
+                  </strong>
+                   To an element of the U.S. Intelligence Community as identified in E.O. 12333, as amended, for use in intelligence activities for the purpose of protecting United States national security interests.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    c.
+                  </strong>
+                   To any source from which information is requested in the course of an investigation, to the extent necessary to identify the individual, inform the source of the nature and purpose of the investigation, and to identify the type of information requested.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    d.
+                  </strong>
+                   To the appropriate Federal, state, local, tribal, foreign, or other public authority responsible for investigating, prosecuting, enforcing, or implementing a statute, rule, regulation, or order where OPM becomes aware of an indication of a violation or potential violation of civil or criminal law or regulation.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    e.
+                  </strong>
+                   To an agency, office, or other establishment in the executive, legislative, or judicial branches of the Federal Government in response to its request, in connection with its current employee’s, contractor employee’s, or military member’s retention; loyalty; qualifications, suitability, or fitness for employment; eligibility for logical or physical access to federally-controlled facilities or information systems; eligibility for access to classified information or to hold a sensitive position; qualifications or fitness to perform work for or on behalf of the Government under contract, grant, or other agreement; or access to restricted areas.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    f.
+                  </strong>
+                   To provide information to a congressional office from the record of an individual in response to an inquiry from the congressional office made at the request of that individual. However, the investigative file, or parts thereof, will only be released to a congressional office if OPM receives a notarized authorization or signed statement under 28 U.S.C. 1746 from the subject of the investigation.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    g.
+                  </strong>
+                   To disclose information to contractors, grantees, or volunteers performing or working on a contract, service, grant, cooperative agreement, or job for the Federal Government.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    h.
+                  </strong>
+                   For agencies that use adjudicative support services of another agency, at the request of the original agency, the results will be furnished to the agency providing the adjudicative support.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    i.
+                  </strong>
+                   To provide criminal history record information to the FBI, to help ensure the accuracy and completeness of FBI and OPM records.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    j.
+                  </strong>
+                   To appropriate agencies, entities, and persons when (1) OPM suspects or has confirmed that there has been a breach of the system of records; (2) OPM has determined that as a result of the suspected or confirmed breach there is a risk of harm to individuals, the agency (including its information systems, programs and operations), the Federal Government, or national security; and (3) the disclosure made to such agencies, entities, and persons is reasonably necessary to assist in connection with OPM’s efforts to respond to the suspected or confirmed breach or to prevent, minimize, or remedy such harm.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    k.
+                  </strong>
+                   To another Federal agency or Federal entity, when OPM determines that information from this system of records is reasonably necessary to assist the recipient agency or entity in (1) responding to a suspected or confirmed breach or (2) preventing, minimizing, or remedying the risk of harm to individuals, the agency (including its information systems, programs and operations), the Federal Government, or national security, resulting from a suspected or confirmed breach.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    l.
+                  </strong>
+                   To disclose information to another Federal agency, to a court, or a party in litigation before a court or in an administrative proceeding being conducted by a Federal agency, when the Government is a party to the judicial or administrative proceeding. In those cases where the Government is not a party to the proceeding, records may be disclosed if a subpoena has been signed by a judge.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    m.
+                  </strong>
+                   To disclose information to the National Archives and Records Administration for use in records management inspections.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    n.
+                  </strong>
+                   To disclose information to the Department of Justice, or in a proceeding before a court, adjudicative body, or other administrative body before which OPM is authorized to appear, when:
+                </p>
+              </div>
+              <div>
+                <ol>
+                  <li>
+                    OPM, or any component thereof; or
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <ol
+                  start="2"
+                >
+                  <li>
+                    Any employee of OPM in his or her official capacity; or
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <ol
+                  start="3"
+                >
+                  <li>
+                    Any employee of OPM in his or her individual capacity where the Department of Justice or OPM has agreed to represent the employee; or
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <ol
+                  start="4"
+                >
+                  <li>
+                    The United States, when OPM determines that litigation is likely to affect OPM or any of its components; is a party to litigation or has an interest in such litigation, and the use of such records by the Department of Justice or OPM is deemed by OPM to be relevant and necessary to the litigation, provided, however, that the disclosure is compatible with the purpose for which records were collected.
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    o.
+                  </strong>
+                   For the Merit Systems Protection Board--To disclose information to officials of the Merit Systems Protection Board or the Office of the Special Counsel, when requested in connection with appeals, special studies of the civil service and other merit systems, review of OPM rules and regulations, investigations of alleged or possible prohibited personnel practices, and such other functions, e.g., as promulgated in 5 U.S.C. 1205 and 1206, or as may be authorized by law.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    p.
+                  </strong>
+                   To disclose information to an agency Equal Employment Opportunity (EEO) office or to the Equal Employment Opportunity Commission when requested in connection with investigations into alleged or possible discrimination practices in the Federal sector, or in the processing of a Federal-sector EEO complaint.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    q.
+                  </strong>
+                   To disclose information to the Federal Labor Relations Authority or its General Counsel when requested in connection with investigations of allegations of unfair labor practices or matters before the Federal Service Impasses Panel.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    r.
+                  </strong>
+                   To another Federal agency’s Office of Inspector General when OPM becomes aware of an indication of misconduct or fraud during the applicant’s submission of the standard forms.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    s.
+                  </strong>
+                   To another Federal agency’s Office of Inspector General in connection with its inspection or audit activity of the investigative or adjudicative processes and procedures of its agency as authorized by the Inspector General Act of 1978, as amended, exclusive of requests for civil or criminal law enforcement activities.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    t.
+                  </strong>
+                   To a Federal agency or state unemployment compensation office upon its request in order to adjudicate a claim for unemployment compensation benefits when the claim for benefits is made as the result of a qualifications, suitability, fitness, security, identity credential, or access determination.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    u.
+                  </strong>
+                   To appropriately cleared individuals in Federal agencies, to determine whether information obtained in the course of processing the background investigation is or should be classified.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    v.
+                  </strong>
+                   To the Office of the Director of National Intelligence for inclusion in its Scattered Castles system in order to facilitate reciprocity of background investigations and security clearances within the intelligence community or assist agencies in obtaining information required by the Federal Investigative Standards.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    w.
+                  </strong>
+                   To the Director of National Intelligence, or assignee, such information as may be requested and relevant to implement the responsibilities of the Security Executive Agent for personnel security, and pertinent personnel security research and oversight, consistent with law or executive order.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    x.
+                  </strong>
+                   To Executive Branch Agency insider threat, counterintelligence, and counterterrorism officials to fulfill their responsibilities under applicable Federal law and policy, including but not limited to E.O. 12333, 13587 and the National Insider Threat Policy and Minimum Standards.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    y.
+                  </strong>
+                   To the appropriate Federal, State, local, tribal, foreign, or other public authority in the event of a natural or manmade disaster. The record will be used to provide leads to assist in locating missing subjects or assist in determining the health and safety of the subject. The record will also be used to assist in identifying victims and locating any surviving next of kin.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    z.
+                  </strong>
+                   To Federal, State, and local government agencies, if necessary, to obtain information from them which will assist OPM in its responsibilities as the authorized Investigation Service Provider in conducting studies and analyses in support of evaluating and improving the effectiveness and efficiency of the background investigation methodologies.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    aa.
+                  </strong>
+                   To an agency, office, or other establishment in the executive, legislative, or judicial branches of the Federal Government in response to its request, in connection with the classifying of jobs, the letting of a contract, or the issuance of a license, grant, or other benefit by the requesting agency, to the extent that the information is relevant and necessary to the requesting agency’s decision on the matter.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Public burden information
+                </h1>
+              </div>
+              <div>
+                <p>
+                  Public burden reporting for this collection of information is 
+                  <strong>
+                    estimated to average 150 minutes per response
+                  </strong>
+                  , including time for reviewing instructions, searching existing data sources, gathering and maintaining the data needed, and completing and reviewing the collection of information. Send comments regarding the burden estimate or any other aspect of this collection of information, including suggestions for reducing this burden, to U.S. Office of Personnel Management, Federal Investigative Services, Attn: OMB Number 3206-0005, 1900 E Street, N.W., Washington, DC 20415. The OMB clearance number, 3206-0005, is currently valid. OPM may not collect this information, and you are not required to respond, unless this number is displayed.
+                </p>
+              </div>
+            </div>
+            <div
+              aria-label="Persons completing this form should begin after carefully reading the preceding instructions"
+              className="field   branch introduction-acceptance"
+              data-uuid="field-6bfb022c-6c86-cdbe-5379-b13984d95d63"
+            >
+              <a
+                aria-hidden="true"
+                className="anchor"
+                id="field-6bfb022c-6c86-cdbe-5379-b13984d95d63"
+                name="field-6bfb022c-6c86-cdbe-5379-b13984d95d63"
+              />
+              <h3
+                className="title h3"
+              >
+                Persons completing this form should begin after carefully reading the preceding instructions
+              </h3>
+              <span
+                className="icon"
+              />
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages help-messages"
+                />
+              </div>
+              <div
+                className="table"
+              >
+                <span
+                  className="content"
+                >
+                  <span
+                    className="component shrink"
+                  >
+                    <div
+                      className="content"
+                    >
+                      <div>
+                        <p>
+                          I have read the instructions and I understand that if I withhold, misrepresent, or falsify information on this form, I am subject to the penalties for inaccurate or false statement (per U. S. Criminal Code, Title 18, section 1001), denial or revocation of a security clearance, and/or removal and debarment from Federal Service.
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      className="blocks option-list branch"
+                    >
+                      <div
+                        className="yes block"
+                      >
+                        <label
+                          className=""
+                          htmlFor="acceptance_of_terms-cb1b76c1-7ddc-f166-0422-de1df2363d18"
+                        >
+                          <input
+                            aria-label="Yes, I agree to this agreement"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="acceptance_of_terms-cb1b76c1-7ddc-f166-0422-de1df2363d18"
+                            name="acceptance_of_terms-cb1b76c1-7ddc-f166-0422-de1df2363d18"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Yes"
+                          />
+                          <span>
+                            Yes
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="no block"
+                      >
+                        <label
+                          className=""
+                          htmlFor="acceptance_of_terms-d4a4c5e4-2c13-2605-47f2-e02fbee444c8"
+                        >
+                          <input
+                            aria-label="No, I do not agree to this agreement"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="acceptance_of_terms-d4a4c5e4-2c13-2605-47f2-e02fbee444c8"
+                            name="acceptance_of_terms-d4a4c5e4-2c13-2605-47f2-e02fbee444c8"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="No"
+                          />
+                          <span>
+                            No
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </span>
+                </span>
+              </div>
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages error-messages"
+                  role="alert"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
     id="scrollTo"
   />
   <a

--- a/src/components/Navigation/ToggleItem.jsx
+++ b/src/components/Navigation/ToggleItem.jsx
@@ -40,19 +40,12 @@ class ToggleItem extends React.Component {
   render() {
     const url = this.url()
     const active = this.isActive()
-    const sectionName = this.props.section.name.split(' ')
-    const lastWord = sectionName.pop()
 
     return (
       <li className="toggle-item">
         <a className={this.getClassName()} aria-controls={url} aria-expanded={active} role="button">
           <span className="section-name">
-            {sectionName.join(' ')}{' '}
-            <span className="no-wrap">
-              {lastWord}
-              <i className="fa fa-angle-up"></i>
-              <i className="fa fa-angle-down"></i>
-            </span>
+            {this.props.section.name}
           </span>
           <span className="eapp-status-icon"></span>
         </a>

--- a/src/components/Navigation/ToggleItem.jsx
+++ b/src/components/Navigation/ToggleItem.jsx
@@ -40,14 +40,19 @@ class ToggleItem extends React.Component {
   render() {
     const url = this.url()
     const active = this.isActive()
+    const sectionName = this.props.section.name.split(' ')
+    const lastWord = sectionName.pop()
 
     return (
       <li className="toggle-item">
         <a className={this.getClassName()} aria-controls={url} aria-expanded={active} role="button">
           <span className="section-name">
-            {this.props.section.name}
-            <i className="fa fa-angle-up"></i>
-            <i className="fa fa-angle-down"></i>
+            {sectionName.join(' ')}{' '}
+            <span className="no-wrap">
+              {lastWord}
+              <i className="fa fa-angle-up"></i>
+              <i className="fa fa-angle-down"></i>
+            </span>
           </span>
           <span className="eapp-status-icon"></span>
         </a>

--- a/src/components/Navigation/ToggleItem.scss
+++ b/src/components/Navigation/ToggleItem.scss
@@ -1,22 +1,21 @@
 .toggle-item {
   // expand/collapse indicators
-
-  .fa-angle-down,
-  .fa-angle-up {
-    margin-left: 0.5rem;
+  .section-name::after {
     color: $eapp-grey-darker;
+    display: inline;
+    font-family: FontAwesome;
+    margin-left: 0.5rem;
   }
 
-  .fa-angle-up {
-    display: none;
+  [aria-expanded='false'] {
+    .section-name::after {
+      content: '\f107';
+    }
   }
 
   [aria-expanded='true'] {
-    .fa-angle-down {
-      display: none;
-    }
-    .fa-angle-up {
-      display: inline-block;
+    .section-name::after {
+      content: '\f106';
     }
   }
 }

--- a/src/components/Navigation/__snapshots__/Navigation.test.jsx.snap
+++ b/src/components/Navigation/__snapshots__/Navigation.test.jsx.snap
@@ -20,19 +20,7 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Information about
-           
-          <span
-            className="no-wrap"
-          >
-            you
-            <i
-              className="fa fa-angle-up"
-            />
-            <i
-              className="fa fa-angle-down"
-            />
-          </span>
+          Information about you
         </span>
         <span
           className="eapp-status-icon"
@@ -214,19 +202,7 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Your
-           
-          <span
-            className="no-wrap"
-          >
-            history
-            <i
-              className="fa fa-angle-up"
-            />
-            <i
-              className="fa fa-angle-down"
-            />
-          </span>
+          Your history
         </span>
         <span
           className="eapp-status-icon"
@@ -357,19 +333,7 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          
-           
-          <span
-            className="no-wrap"
-          >
-            Relationships
-            <i
-              className="fa fa-angle-up"
-            />
-            <i
-              className="fa fa-angle-down"
-            />
-          </span>
+          Relationships
         </span>
         <span
           className="eapp-status-icon"
@@ -412,19 +376,7 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Marital & relationship
-                 
-                <span
-                  className="no-wrap"
-                >
-                  status
-                  <i
-                    className="fa fa-angle-up"
-                  />
-                  <i
-                    className="fa fa-angle-down"
-                  />
-                </span>
+                Marital & relationship status
               </span>
               <span
                 className="eapp-status-icon"
@@ -541,19 +493,7 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          
-           
-          <span
-            className="no-wrap"
-          >
-            Citizenship
-            <i
-              className="fa fa-angle-up"
-            />
-            <i
-              className="fa fa-angle-down"
-            />
-          </span>
+          Citizenship
         </span>
         <span
           className="eapp-status-icon"
@@ -667,19 +607,7 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Military
-           
-          <span
-            className="no-wrap"
-          >
-            history
-            <i
-              className="fa fa-angle-up"
-            />
-            <i
-              className="fa fa-angle-down"
-            />
-          </span>
+          Military history
         </span>
         <span
           className="eapp-status-icon"
@@ -810,19 +738,7 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Foreign
-           
-          <span
-            className="no-wrap"
-          >
-            associations
-            <i
-              className="fa fa-angle-up"
-            />
-            <i
-              className="fa fa-angle-down"
-            />
-          </span>
+          Foreign associations
         </span>
         <span
           className="eapp-status-icon"
@@ -899,19 +815,7 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Foreign
-                 
-                <span
-                  className="no-wrap"
-                >
-                  activities
-                  <i
-                    className="fa fa-angle-up"
-                  />
-                  <i
-                    className="fa fa-angle-down"
-                  />
-                </span>
+                Foreign activities
               </span>
               <span
                 className="eapp-status-icon"
@@ -1025,19 +929,7 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Foreign business, professional activities, and government
-                 
-                <span
-                  className="no-wrap"
-                >
-                  contacts
-                  <i
-                    className="fa fa-angle-up"
-                  />
-                  <i
-                    className="fa fa-angle-down"
-                  />
-                </span>
+                Foreign business, professional activities, and government contacts
               </span>
               <span
                 className="eapp-status-icon"
@@ -1256,19 +1148,7 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Financial
-           
-          <span
-            className="no-wrap"
-          >
-            record
-            <i
-              className="fa fa-angle-up"
-            />
-            <i
-              className="fa fa-angle-down"
-            />
-          </span>
+          Financial record
         </span>
         <span
           className="eapp-status-icon"
@@ -1450,19 +1330,7 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Substance
-           
-          <span
-            className="no-wrap"
-          >
-            use
-            <i
-              className="fa fa-angle-up"
-            />
-            <i
-              className="fa fa-angle-down"
-            />
-          </span>
+          Substance use
         </span>
         <span
           className="eapp-status-icon"
@@ -1505,19 +1373,7 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Illegal use of drugs and drug
-                 
-                <span
-                  className="no-wrap"
-                >
-                  activity
-                  <i
-                    className="fa fa-angle-up"
-                  />
-                  <i
-                    className="fa fa-angle-down"
-                  />
-                </span>
+                Illegal use of drugs and drug activity
               </span>
               <span
                 className="eapp-status-icon"
@@ -1665,19 +1521,7 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Use of
-                 
-                <span
-                  className="no-wrap"
-                >
-                  alcohol
-                  <i
-                    className="fa fa-angle-up"
-                  />
-                  <i
-                    className="fa fa-angle-down"
-                  />
-                </span>
+                Use of alcohol
               </span>
               <span
                 className="eapp-status-icon"
@@ -1794,19 +1638,7 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Investigative and criminal
-           
-          <span
-            className="no-wrap"
-          >
-            history
-            <i
-              className="fa fa-angle-up"
-            />
-            <i
-              className="fa fa-angle-down"
-            />
-          </span>
+          Investigative and criminal history
         </span>
         <span
           className="eapp-status-icon"
@@ -1849,19 +1681,7 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Police
-                 
-                <span
-                  className="no-wrap"
-                >
-                  record
-                  <i
-                    className="fa fa-angle-up"
-                  />
-                  <i
-                    className="fa fa-angle-down"
-                  />
-                </span>
+                Police record
               </span>
               <span
                 className="eapp-status-icon"
@@ -1958,19 +1778,7 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Investigations and clearance
-                 
-                <span
-                  className="no-wrap"
-                >
-                  record
-                  <i
-                    className="fa fa-angle-up"
-                  />
-                  <i
-                    className="fa fa-angle-down"
-                  />
-                </span>
+                Investigations and clearance record
               </span>
               <span
                 className="eapp-status-icon"
@@ -2067,19 +1875,7 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Use of information technology
-                 
-                <span
-                  className="no-wrap"
-                >
-                  systems
-                  <i
-                    className="fa fa-angle-up"
-                  />
-                  <i
-                    className="fa fa-angle-down"
-                  />
-                </span>
+                Use of information technology systems
               </span>
               <span
                 className="eapp-status-icon"
@@ -2159,19 +1955,7 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Association
-                 
-                <span
-                  className="no-wrap"
-                >
-                  record
-                  <i
-                    className="fa fa-angle-up"
-                  />
-                  <i
-                    className="fa fa-angle-down"
-                  />
-                </span>
+                Association record
               </span>
               <span
                 className="eapp-status-icon"
@@ -2339,19 +2123,7 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Psychological and emotional
-           
-          <span
-            className="no-wrap"
-          >
-            health
-            <i
-              className="fa fa-angle-up"
-            />
-            <i
-              className="fa fa-angle-down"
-            />
-          </span>
+          Psychological and emotional health
         </span>
         <span
           className="eapp-status-icon"
@@ -2499,19 +2271,7 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Review and
-           
-          <span
-            className="no-wrap"
-          >
-            submit
-            <i
-              className="fa fa-angle-up"
-            />
-            <i
-              className="fa fa-angle-down"
-            />
-          </span>
+          Review and submit
         </span>
         <span
           className="eapp-status-icon"

--- a/src/components/Navigation/__snapshots__/Navigation.test.jsx.snap
+++ b/src/components/Navigation/__snapshots__/Navigation.test.jsx.snap
@@ -20,13 +20,19 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Information about you
-          <i
-            className="fa fa-angle-up"
-          />
-          <i
-            className="fa fa-angle-down"
-          />
+          Information about
+           
+          <span
+            className="no-wrap"
+          >
+            you
+            <i
+              className="fa fa-angle-up"
+            />
+            <i
+              className="fa fa-angle-down"
+            />
+          </span>
         </span>
         <span
           className="eapp-status-icon"
@@ -208,13 +214,19 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Your history
-          <i
-            className="fa fa-angle-up"
-          />
-          <i
-            className="fa fa-angle-down"
-          />
+          Your
+           
+          <span
+            className="no-wrap"
+          >
+            history
+            <i
+              className="fa fa-angle-up"
+            />
+            <i
+              className="fa fa-angle-down"
+            />
+          </span>
         </span>
         <span
           className="eapp-status-icon"
@@ -345,13 +357,19 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Relationships
-          <i
-            className="fa fa-angle-up"
-          />
-          <i
-            className="fa fa-angle-down"
-          />
+          
+           
+          <span
+            className="no-wrap"
+          >
+            Relationships
+            <i
+              className="fa fa-angle-up"
+            />
+            <i
+              className="fa fa-angle-down"
+            />
+          </span>
         </span>
         <span
           className="eapp-status-icon"
@@ -394,13 +412,19 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Marital & relationship status
-                <i
-                  className="fa fa-angle-up"
-                />
-                <i
-                  className="fa fa-angle-down"
-                />
+                Marital & relationship
+                 
+                <span
+                  className="no-wrap"
+                >
+                  status
+                  <i
+                    className="fa fa-angle-up"
+                  />
+                  <i
+                    className="fa fa-angle-down"
+                  />
+                </span>
               </span>
               <span
                 className="eapp-status-icon"
@@ -517,13 +541,19 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Citizenship
-          <i
-            className="fa fa-angle-up"
-          />
-          <i
-            className="fa fa-angle-down"
-          />
+          
+           
+          <span
+            className="no-wrap"
+          >
+            Citizenship
+            <i
+              className="fa fa-angle-up"
+            />
+            <i
+              className="fa fa-angle-down"
+            />
+          </span>
         </span>
         <span
           className="eapp-status-icon"
@@ -637,13 +667,19 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Military history
-          <i
-            className="fa fa-angle-up"
-          />
-          <i
-            className="fa fa-angle-down"
-          />
+          Military
+           
+          <span
+            className="no-wrap"
+          >
+            history
+            <i
+              className="fa fa-angle-up"
+            />
+            <i
+              className="fa fa-angle-down"
+            />
+          </span>
         </span>
         <span
           className="eapp-status-icon"
@@ -774,13 +810,19 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Foreign associations
-          <i
-            className="fa fa-angle-up"
-          />
-          <i
-            className="fa fa-angle-down"
-          />
+          Foreign
+           
+          <span
+            className="no-wrap"
+          >
+            associations
+            <i
+              className="fa fa-angle-up"
+            />
+            <i
+              className="fa fa-angle-down"
+            />
+          </span>
         </span>
         <span
           className="eapp-status-icon"
@@ -857,13 +899,19 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Foreign activities
-                <i
-                  className="fa fa-angle-up"
-                />
-                <i
-                  className="fa fa-angle-down"
-                />
+                Foreign
+                 
+                <span
+                  className="no-wrap"
+                >
+                  activities
+                  <i
+                    className="fa fa-angle-up"
+                  />
+                  <i
+                    className="fa fa-angle-down"
+                  />
+                </span>
               </span>
               <span
                 className="eapp-status-icon"
@@ -977,13 +1025,19 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Foreign business, professional activities, and government contacts
-                <i
-                  className="fa fa-angle-up"
-                />
-                <i
-                  className="fa fa-angle-down"
-                />
+                Foreign business, professional activities, and government
+                 
+                <span
+                  className="no-wrap"
+                >
+                  contacts
+                  <i
+                    className="fa fa-angle-up"
+                  />
+                  <i
+                    className="fa fa-angle-down"
+                  />
+                </span>
               </span>
               <span
                 className="eapp-status-icon"
@@ -1202,13 +1256,19 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Financial record
-          <i
-            className="fa fa-angle-up"
-          />
-          <i
-            className="fa fa-angle-down"
-          />
+          Financial
+           
+          <span
+            className="no-wrap"
+          >
+            record
+            <i
+              className="fa fa-angle-up"
+            />
+            <i
+              className="fa fa-angle-down"
+            />
+          </span>
         </span>
         <span
           className="eapp-status-icon"
@@ -1390,13 +1450,19 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Substance use
-          <i
-            className="fa fa-angle-up"
-          />
-          <i
-            className="fa fa-angle-down"
-          />
+          Substance
+           
+          <span
+            className="no-wrap"
+          >
+            use
+            <i
+              className="fa fa-angle-up"
+            />
+            <i
+              className="fa fa-angle-down"
+            />
+          </span>
         </span>
         <span
           className="eapp-status-icon"
@@ -1439,13 +1505,19 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Illegal use of drugs and drug activity
-                <i
-                  className="fa fa-angle-up"
-                />
-                <i
-                  className="fa fa-angle-down"
-                />
+                Illegal use of drugs and drug
+                 
+                <span
+                  className="no-wrap"
+                >
+                  activity
+                  <i
+                    className="fa fa-angle-up"
+                  />
+                  <i
+                    className="fa fa-angle-down"
+                  />
+                </span>
               </span>
               <span
                 className="eapp-status-icon"
@@ -1593,13 +1665,19 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Use of alcohol
-                <i
-                  className="fa fa-angle-up"
-                />
-                <i
-                  className="fa fa-angle-down"
-                />
+                Use of
+                 
+                <span
+                  className="no-wrap"
+                >
+                  alcohol
+                  <i
+                    className="fa fa-angle-up"
+                  />
+                  <i
+                    className="fa fa-angle-down"
+                  />
+                </span>
               </span>
               <span
                 className="eapp-status-icon"
@@ -1716,13 +1794,19 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Investigative and criminal history
-          <i
-            className="fa fa-angle-up"
-          />
-          <i
-            className="fa fa-angle-down"
-          />
+          Investigative and criminal
+           
+          <span
+            className="no-wrap"
+          >
+            history
+            <i
+              className="fa fa-angle-up"
+            />
+            <i
+              className="fa fa-angle-down"
+            />
+          </span>
         </span>
         <span
           className="eapp-status-icon"
@@ -1765,13 +1849,19 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Police record
-                <i
-                  className="fa fa-angle-up"
-                />
-                <i
-                  className="fa fa-angle-down"
-                />
+                Police
+                 
+                <span
+                  className="no-wrap"
+                >
+                  record
+                  <i
+                    className="fa fa-angle-up"
+                  />
+                  <i
+                    className="fa fa-angle-down"
+                  />
+                </span>
               </span>
               <span
                 className="eapp-status-icon"
@@ -1868,13 +1958,19 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Investigations and clearance record
-                <i
-                  className="fa fa-angle-up"
-                />
-                <i
-                  className="fa fa-angle-down"
-                />
+                Investigations and clearance
+                 
+                <span
+                  className="no-wrap"
+                >
+                  record
+                  <i
+                    className="fa fa-angle-up"
+                  />
+                  <i
+                    className="fa fa-angle-down"
+                  />
+                </span>
               </span>
               <span
                 className="eapp-status-icon"
@@ -1971,13 +2067,19 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Use of information technology systems
-                <i
-                  className="fa fa-angle-up"
-                />
-                <i
-                  className="fa fa-angle-down"
-                />
+                Use of information technology
+                 
+                <span
+                  className="no-wrap"
+                >
+                  systems
+                  <i
+                    className="fa fa-angle-up"
+                  />
+                  <i
+                    className="fa fa-angle-down"
+                  />
+                </span>
               </span>
               <span
                 className="eapp-status-icon"
@@ -2057,13 +2159,19 @@ exports[`Navigation component renders correctly 1`] = `
               <span
                 className="section-name"
               >
-                Association record
-                <i
-                  className="fa fa-angle-up"
-                />
-                <i
-                  className="fa fa-angle-down"
-                />
+                Association
+                 
+                <span
+                  className="no-wrap"
+                >
+                  record
+                  <i
+                    className="fa fa-angle-up"
+                  />
+                  <i
+                    className="fa fa-angle-down"
+                  />
+                </span>
               </span>
               <span
                 className="eapp-status-icon"
@@ -2231,13 +2339,19 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Psychological and emotional health
-          <i
-            className="fa fa-angle-up"
-          />
-          <i
-            className="fa fa-angle-down"
-          />
+          Psychological and emotional
+           
+          <span
+            className="no-wrap"
+          >
+            health
+            <i
+              className="fa fa-angle-up"
+            />
+            <i
+              className="fa fa-angle-down"
+            />
+          </span>
         </span>
         <span
           className="eapp-status-icon"
@@ -2385,13 +2499,19 @@ exports[`Navigation component renders correctly 1`] = `
         <span
           className="section-name"
         >
-          Review and submit
-          <i
-            className="fa fa-angle-up"
-          />
-          <i
-            className="fa fa-angle-down"
-          />
+          Review and
+           
+          <span
+            className="no-wrap"
+          >
+            submit
+            <i
+              className="fa fa-angle-up"
+            />
+            <i
+              className="fa fa-angle-down"
+            />
+          </span>
         </span>
         <span
           className="eapp-status-icon"

--- a/src/sass/eqip.scss
+++ b/src/sass/eqip.scss
@@ -332,6 +332,10 @@ a:focus {
   text-transform: capitalize;
 }
 
+.no-wrap {
+  white-space: nowrap;
+}
+
 .no-gutter {
   margin-left: initial;
   margin-right: initial;

--- a/src/sass/eqip.scss
+++ b/src/sass/eqip.scss
@@ -332,10 +332,6 @@ a:focus {
   text-transform: capitalize;
 }
 
-.no-wrap {
-  white-space: nowrap;
-}
-
 .no-gutter {
   margin-left: initial;
   margin-right: initial;


### PR DESCRIPTION
Anchors caret to the last word of section name in side navigation to avoid the icon breaking onto it's own line.

Before:
<img width="327" alt="screen shot 2018-08-14 at 4 25 19 pm" src="https://user-images.githubusercontent.com/1178494/44116602-f5484b4a-9fde-11e8-99f1-7c94e32b8aad.png">
<img width="301" alt="screen shot 2018-08-14 at 4 26 41 pm" src="https://user-images.githubusercontent.com/1178494/44116608-fcbdd76e-9fde-11e8-8419-df8006d038b9.png">

After:
<img width="328" alt="screen shot 2018-08-14 at 4 23 40 pm" src="https://user-images.githubusercontent.com/1178494/44116613-0199907a-9fdf-11e8-9c09-9d7889fc2825.png">
<img width="311" alt="screen shot 2018-08-14 at 4 24 23 pm" src="https://user-images.githubusercontent.com/1178494/44116621-06e2b5ca-9fdf-11e8-8e3e-ee0087001aeb.png">
