### PR TITLE
use fake GUIDs for fields in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ TAGS
 xmlsec1
 
 # Test artifacts
+/api/coverage.txt
 /jest*
 /specs/reports
 /specs/screenshots

--- a/src/components/Form/ValidationElement/ValidationElement.jsx
+++ b/src/components/Form/ValidationElement/ValidationElement.jsx
@@ -1,8 +1,9 @@
 import React from 'react'
+import env from '../../../config/environment'
 import { newGuid, flattenObject, mergeError, triageErrors } from './helpers'
 
 export default class ValidationElement extends React.Component {
-  constructor (props) {
+  constructor(props) {
     super(props)
 
     this.handleChange = this.handleChange.bind(this)
@@ -12,7 +13,7 @@ export default class ValidationElement extends React.Component {
     this.handleValidation = this.handleValidation.bind(this)
   }
 
-  componentDidMount () {
+  componentDidMount() {
     let event = {
       target: {
         id: this.props.id || '',
@@ -20,7 +21,7 @@ export default class ValidationElement extends React.Component {
         value: this.props.value,
         checked: this.props.checked
       },
-      persist: function () {},
+      persist: function() {},
       fake: true
     }
 
@@ -30,7 +31,7 @@ export default class ValidationElement extends React.Component {
   /**
    * Handle the change event.
    */
-  handleChange (event) {
+  handleChange(event) {
     if (this.props.onChange) {
       this.props.onChange(event)
     }
@@ -39,7 +40,7 @@ export default class ValidationElement extends React.Component {
   /**
    * Handle the focus event.
    */
-  handleFocus (event) {
+  handleFocus(event) {
     if (this.props.onFocus) {
       this.props.onFocus(event)
     }
@@ -48,7 +49,7 @@ export default class ValidationElement extends React.Component {
   /**
    * Handle the blur event.
    */
-  handleBlur (event) {
+  handleBlur(event) {
     this.handleValidation(event)
     if (this.props.onBlur) {
       this.props.onBlur(event)
@@ -58,7 +59,7 @@ export default class ValidationElement extends React.Component {
   /**
    * Handle the validation event.
    */
-  handleValidation (event) {
+  handleValidation(event) {
     if (this.props.onValidate) {
       this.props.onValidate(event)
     }
@@ -67,26 +68,32 @@ export default class ValidationElement extends React.Component {
   /**
    * Handle the key down event.
    */
-  handleKeyDown (event) {
+  handleKeyDown(event) {
     if (this.props.onKeyDown) {
       this.props.onKeyDown(event)
     }
   }
 
-  flattenObject (obj) {
+  flattenObject(obj) {
     let o = flattenObject(obj)
     return o
   }
 
-  mergeError (previous, error) {
+  mergeError(previous, error) {
     return mergeError(previous, error)
   }
 
-  triageErrors (section, previous, codes) {
+  triageErrors(section, previous, codes) {
     return triageErrors(section, previous, codes)
   }
 
-  guid () {
-    return newGuid()
+  guid() {
+    // give a fake GUID so the field IDs don't differ between snapshots
+    // https://github.com/facebook/jest/issues/936#issuecomment-404246102
+    if (env.IsTest()) {
+      return 'MOCK-GUID'
+    } else {
+      return newGuid()
+    }
   }
 }

--- a/src/components/Form/ValidationElement/ValidationElement.jsx
+++ b/src/components/Form/ValidationElement/ValidationElement.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import env from '../../../config/environment'
-import { newGuid, flattenObject, mergeError, triageErrors } from './helpers'
+import { newGuid, newMockGuid, flattenObject, mergeError, triageErrors } from './helpers'
 
 export default class ValidationElement extends React.Component {
   constructor(props) {
@@ -89,9 +89,8 @@ export default class ValidationElement extends React.Component {
 
   guid() {
     // give a fake GUID so the field IDs don't differ between snapshots
-    // https://github.com/facebook/jest/issues/936#issuecomment-404246102
     if (env.IsTest()) {
-      return 'MOCK-GUID'
+      return newMockGuid()
     } else {
       return newGuid()
     }

--- a/src/components/Form/ValidationElement/helpers.js
+++ b/src/components/Form/ValidationElement/helpers.js
@@ -8,6 +8,11 @@ export const newGuid = () => {
   return `${s4()}${s4()}-${s4()}-${s4()}-${s4()}-${s4()}${s4()}${s4()}`
 }
 
+let mockGuid = 0;
+export const newMockGuid = () => {
+  return `MOCK-GUID-${mockGuid++}`
+}
+
 export const flattenObject = obj => {
   let s = ''
   let what = Object.prototype.toString.call(obj)

--- a/src/components/Main/__snapshots__/App.test.jsx.snap
+++ b/src/components/Main/__snapshots__/App.test.jsx.snap
@@ -5,6 +5,664 @@ exports[`Renders homepage 1`] = `
   className=""
 >
   <div
+    className="introduction-modal"
+  >
+    <div
+      aria-hidden="false"
+      className="modal"
+      onClick={[Function]}
+      role="dialog"
+    >
+      <div
+        className="modal-wrap"
+      >
+        <div
+          className="modal-content introduction-content"
+          onClick={[Function]}
+        >
+          <div>
+            <div
+              className="introduction-legal"
+            >
+              <div>
+                <h1>
+                  Questionnaire for National Security Positions
+                </h1>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    Follow instructions completely or your form will be unable to be processed. If you have any questions, contact the office that provided you the form.
+                  </strong>
+                </p>
+              </div>
+              <div>
+                <h2>
+                  Instructions for completing this form
+                </h2>
+              </div>
+              <div>
+                <ol>
+                  <li>
+                    <strong>
+                      Follow the instructions provided to you by the office that gave you this form
+                    </strong>
+                     and any other clarifying instructions, provided by that office, to assist you with completion of this form. You should retain a copy of the completed form for your records.
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <ol
+                  start="2"
+                >
+                  <li>
+                    <strong>
+                      All questions on this form must be answered
+                    </strong>
+                    . If no response is necessary or applicable, indicate this on the form by checking the associated "Not Applicable" checkbox, unless otherwise noted.
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <ol
+                  start="3"
+                >
+                  <li>
+                    <strong>
+                      Do not abbreviate the names of cities or foreign countries
+                    </strong>
+                    .
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <ol
+                  start="4"
+                >
+                  <li>
+                    <strong>
+                      All dates provided in this form must be in Month/Day/Year or Month/Year format
+                    </strong>
+                    . The year should be entered as a four character number (e.g., 1978 or 2001). If you are unable to report an exact date, approximate or estimate the date to the best of your ability, and indicate this by checking the "Estimated" checkbox.
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <p>
+                  All questions on this form must be answered 
+                  <strong>
+                    completely and truthfully
+                  </strong>
+                   in order that the Government may make the determinations described below on a complete record. Penalties for inaccurate or false statements are discussed below. 
+                  <strong>
+                    If you are a current civilian employee of the federal government:
+                  </strong>
+                   failure to answer any questions completely and truthfully could result in an adverse personnel action against you, including loss of employment; with respect to these sections: Illegal Use of Drugs and Drug Activity, Use of Information Technology Systems, and Association Record, however, neither your truthful responses nor information derived from those responses will be used as evidence against you in a subsequent criminal proceeding.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  How to save your progress
+                </h1>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    This form will auto save your progress continuously throughout.
+                  </strong>
+                   Each input will be validated and save as you enter your information.
+                </p>
+              </div>
+              <div>
+                <p>
+                  To confirm you're auto saving and find out when the last save was check for the save icon on each screen.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Purpose of this form
+                </h1>
+              </div>
+              <div>
+                <p>
+                  This form will be used by the United States (U.S.) Government in conducting background investigations, reinvestigations, and continuous evaluations of persons under consideration for, or retention of, national security positions as defined in 5 CFR 732, and for individuals requiring eligibility for access to classified information under Executive Order 12968. This form may also be used by agencies in determining whether a subject performing work for, or on behalf of, the Government under a contract should be deemed eligible for logical or physical access when the nature of the work to be performed is sensitive and could bring about an adverse effect on the national security.
+                </p>
+              </div>
+              <div>
+                <p>
+                  Providing this information is voluntary. If you do not provide each item of requested information, however, we will not be able to complete your investigation, which will adversely affect your eligibility for a national security position, eligibility for access to classified information, or logical or physical access. It is imperative that the information provided be true and accurate, to the best of your knowledge. Any information that you provide is evaluated on the basis of its currency, seriousness, relevance to the position and duties, and consistency with all other information about you. Withholding, misrepresenting, or falsifying information may affect your eligibility for access to classified information, eligibility for a sensitive position, or your ability to obtain or retain Federal or contract employment. In addition, withholding, misrepresenting, or falsifying information may affect your eligibility for physical and logical access to federally controlled facilities or information systems. Withholding, misrepresenting, or falsifying information may also negatively affect your employment prospects and job status, and the potential consequences include, but are not limited to, removal, debarment from Federal service, loss of eligibility for access to classified information, or prosecution.
+                </p>
+              </div>
+              <div>
+                <p>
+                  This form may become a permanent document that may be used as the basis for future investigations, eligibility determinations for access to classified information, or to hold a sensitive position, suitability or fitness for Federal employment, fitness for contract employment, or eligibility for physical and logical access to federally controlled facilities or information systems. Your responses to this form may be compared with your responses to previous SF-86 questionnaires.
+                </p>
+              </div>
+              <div>
+                <p>
+                  The investigation conducted on the basis of information provided on this form may be selected for studies and analyses in support of evaluating and improving the effectiveness and efficiency of the investigative and adjudicative methodologies. All study results released to the general public will delete personal identifiers such as name, Social Security Number, and date and place of birth.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Authority to request this information
+                </h1>
+              </div>
+              <div>
+                <p>
+                  Depending upon the purpose of your investigation, the U.S. Government is authorized to ask for this information under Executive Orders 10450, 10865, 12333, and 12968; sections 3301, 3302, and 9101 of title 5, United States Code (U.S.C.); sections 2165 and 2201 of title 42, U.S.C.; chapter 23 of title 50, U.S.C.; and parts 2, 5, 731, 732, and 736 of title 5, Code of Federal Regulations (CFR).
+                </p>
+              </div>
+              <div>
+                <p>
+                  Your Social Security Number (SSN) is needed to identify records unique to you. Although disclosure of your SSN is not mandatory, failure to disclose your SSN may prevent or delay the processing of your background investigation. The authority for soliciting and verifying your SSN is Executive Order 9397, as amended by EO 13478.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  The investigative process
+                </h1>
+              </div>
+              <div>
+                <p>
+                  Background investigations for national security positions are conducted to gather information to determine whether you are reliable, trustworthy, of good conduct and character, and loyal to the U.S. The information that you provide on this form may be confirmed during the investigation. The investigation may extend beyond the time covered by this form, when necessary to resolve issues. Your current employer may be contacted as part of the investigation, although you may have previously indicated on applications or other forms that you do not want your current employer to be contacted. If you have a security freeze on your consumer or credit report file, then we may not be able to complete your investigation, which can adversely affect your eligibility for a national security position. To avoid such delays, you should request that the consumer reporting agencies lift the freeze in these instances.
+                </p>
+              </div>
+              <div>
+                <p>
+                  In addition to the questions on this form, inquiry also is made about your adherence to security requirements, your honesty and integrity, vulnerability to exploitation or coercion, falsification, misrepresentation, and any other behavior, activities, or associations that tend to demonstrate a person is not reliable, trustworthy, or loyal. Federal agency records checks may be conducted on your spouse or legally recognized civil union/domestic partner, cohabitant(s), and immediate family members. After an eligibility determination has been completed, you also may be subject to continuous evaluation, which may include periodic reinvestigations, to determine whether retention in your position is clearly consistent with the interests of national security.
+                </p>
+              </div>
+              <div>
+                <p>
+                  The information you provide on this form may be confirmed during the investigation, and may be used for identification purposes throughout the investigation process.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Your personal interview
+                </h1>
+              </div>
+              <div>
+                <p>
+                  Some investigations will include an interview with you as a routine part of the investigative process. The investigator may ask you to explain your answers to any question on this form. This provides you the opportunity to update, clarify, and explain information on your form more completely, which often assists in completing your investigation. It is imperative that the interview be conducted as soon as possible after you are contacted. Postponements will delay the processing of your investigation, and declining to be interviewed may result in your investigation being delayed or canceled.
+                </p>
+              </div>
+              <div>
+                <p>
+                  For the interview, you will be required to provide photo identification, such as a valid state driver's license. You may be required to provide other documents to verify your identity, as instructed by your investigator. These documents may include certification of any legal name change, Social Security card, passport, and/or your birth certificate. You may also be asked to provide documents regarding information that you provide on this form, or about other matters requiring specific attention. These matters include (a) alien registration or naturalization documentation; (b) delinquent loans or taxes, bankruptcies, judgments, liens, or other financial obligations; (c) agreements involving child custody or support, alimony, or property settlements; (d) arrests, convictions, probation, and/or parole; or (e) other matters described in court records.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Final determination on your eligibility
+                </h1>
+              </div>
+              <div>
+                <p>
+                  Final determination on your eligibility for a national security position is the responsibility of the Federal agency that requested your investigation and the agency that conducted your investigation. You will be provided the opportunity to explain, refute, or clarify any information before a final decision is made, if an unfavorable decision is considered. The United States Government does not discriminate on the basis of prohibited categories, including but not limited to race, color, religion, sex (including pregnancy and gender identity), national origin, disability, or sexual orientation when granting access to classified information.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Penalties for inaccurate or false statements
+                </h1>
+              </div>
+              <div>
+                <p>
+                  The U.S. Criminal Code (title 18, section 1001) provides that knowingly falsifying or concealing a material fact is a felony which may result in fines and/or up to five (5) years imprisonment. In addition, Federal agencies generally fire, do not grant a security clearance, or disqualify individuals who have materially and deliberately falsified these forms, and this remains a part of the permanent record for future placements. Your prospects of placement or security clearance are better if you answer all questions truthfully and completely. You will have adequate opportunity to explain any information you provide on this form and to make your comments part of the record.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Disclosure information
+                </h1>
+              </div>
+              <div>
+                <p>
+                  The information you provide is for the purpose of investigating you for a national security position, and the information will be protected from unauthorized disclosure. The collection, maintenance, and disclosure of background investigative information are governed by the Privacy Act. The agency that requested the investigation and the agency that conducted the investigation have published notices in the Federal Register describing the systems of records in which your records will be maintained. The information you provide on this form, and information collected during an investigation, may be disclosed without your consent by an agency maintaining the information in a system of records as permitted by the Privacy Act [5 U.S.C. 552a(b)], and by routine uses, a list of which are published by the agency in the Federal Register. The office that gave you this form will provide you a copy of its routine uses.
+                </p>
+              </div>
+              <div>
+                <p>
+                  You will not receive prior notice of such disclosures under a routine use.
+                </p>
+              </div>
+              <div>
+                <p>
+                  In addition to those disclosures generally permitted under the Privacy Act, all or a portion of the records or information you provide on this form or during your investigation may be disclosed outside of OPM as a routine use as outlined below.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Office of Personnel Management (OPM) routine uses
+                </h1>
+              </div>
+              <div>
+                <p>
+                  OPM has published the following Privacy Act routine uses for its system of records for background investigations:
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    a.
+                  </strong>
+                   To designated officers and employees of agencies, offices, and other establishments in the executive, legislative, and judicial branches of the Federal Government or the Government of the District of Columbia having a need to investigate, evaluate, or make a determination regarding loyalty to the United States; qualifications, suitability, or fitness for Government employment or military service; eligibility for logical or physical access to federally-controlled facilities or information systems; eligibility for access to classified information or to hold a sensitive position; qualifications or fitness to perform work for or on behalf of the Government under contract, grant, or other agreement; or access to restricted areas.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    b.
+                  </strong>
+                   To an element of the U.S. Intelligence Community as identified in E.O. 12333, as amended, for use in intelligence activities for the purpose of protecting United States national security interests.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    c.
+                  </strong>
+                   To any source from which information is requested in the course of an investigation, to the extent necessary to identify the individual, inform the source of the nature and purpose of the investigation, and to identify the type of information requested.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    d.
+                  </strong>
+                   To the appropriate Federal, state, local, tribal, foreign, or other public authority responsible for investigating, prosecuting, enforcing, or implementing a statute, rule, regulation, or order where OPM becomes aware of an indication of a violation or potential violation of civil or criminal law or regulation.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    e.
+                  </strong>
+                   To an agency, office, or other establishment in the executive, legislative, or judicial branches of the Federal Government in response to its request, in connection with its current employee’s, contractor employee’s, or military member’s retention; loyalty; qualifications, suitability, or fitness for employment; eligibility for logical or physical access to federally-controlled facilities or information systems; eligibility for access to classified information or to hold a sensitive position; qualifications or fitness to perform work for or on behalf of the Government under contract, grant, or other agreement; or access to restricted areas.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    f.
+                  </strong>
+                   To provide information to a congressional office from the record of an individual in response to an inquiry from the congressional office made at the request of that individual. However, the investigative file, or parts thereof, will only be released to a congressional office if OPM receives a notarized authorization or signed statement under 28 U.S.C. 1746 from the subject of the investigation.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    g.
+                  </strong>
+                   To disclose information to contractors, grantees, or volunteers performing or working on a contract, service, grant, cooperative agreement, or job for the Federal Government.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    h.
+                  </strong>
+                   For agencies that use adjudicative support services of another agency, at the request of the original agency, the results will be furnished to the agency providing the adjudicative support.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    i.
+                  </strong>
+                   To provide criminal history record information to the FBI, to help ensure the accuracy and completeness of FBI and OPM records.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    j.
+                  </strong>
+                   To appropriate agencies, entities, and persons when (1) OPM suspects or has confirmed that there has been a breach of the system of records; (2) OPM has determined that as a result of the suspected or confirmed breach there is a risk of harm to individuals, the agency (including its information systems, programs and operations), the Federal Government, or national security; and (3) the disclosure made to such agencies, entities, and persons is reasonably necessary to assist in connection with OPM’s efforts to respond to the suspected or confirmed breach or to prevent, minimize, or remedy such harm.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    k.
+                  </strong>
+                   To another Federal agency or Federal entity, when OPM determines that information from this system of records is reasonably necessary to assist the recipient agency or entity in (1) responding to a suspected or confirmed breach or (2) preventing, minimizing, or remedying the risk of harm to individuals, the agency (including its information systems, programs and operations), the Federal Government, or national security, resulting from a suspected or confirmed breach.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    l.
+                  </strong>
+                   To disclose information to another Federal agency, to a court, or a party in litigation before a court or in an administrative proceeding being conducted by a Federal agency, when the Government is a party to the judicial or administrative proceeding. In those cases where the Government is not a party to the proceeding, records may be disclosed if a subpoena has been signed by a judge.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    m.
+                  </strong>
+                   To disclose information to the National Archives and Records Administration for use in records management inspections.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    n.
+                  </strong>
+                   To disclose information to the Department of Justice, or in a proceeding before a court, adjudicative body, or other administrative body before which OPM is authorized to appear, when:
+                </p>
+              </div>
+              <div>
+                <ol>
+                  <li>
+                    OPM, or any component thereof; or
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <ol
+                  start="2"
+                >
+                  <li>
+                    Any employee of OPM in his or her official capacity; or
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <ol
+                  start="3"
+                >
+                  <li>
+                    Any employee of OPM in his or her individual capacity where the Department of Justice or OPM has agreed to represent the employee; or
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <ol
+                  start="4"
+                >
+                  <li>
+                    The United States, when OPM determines that litigation is likely to affect OPM or any of its components; is a party to litigation or has an interest in such litigation, and the use of such records by the Department of Justice or OPM is deemed by OPM to be relevant and necessary to the litigation, provided, however, that the disclosure is compatible with the purpose for which records were collected.
+                  </li>
+                </ol>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    o.
+                  </strong>
+                   For the Merit Systems Protection Board--To disclose information to officials of the Merit Systems Protection Board or the Office of the Special Counsel, when requested in connection with appeals, special studies of the civil service and other merit systems, review of OPM rules and regulations, investigations of alleged or possible prohibited personnel practices, and such other functions, e.g., as promulgated in 5 U.S.C. 1205 and 1206, or as may be authorized by law.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    p.
+                  </strong>
+                   To disclose information to an agency Equal Employment Opportunity (EEO) office or to the Equal Employment Opportunity Commission when requested in connection with investigations into alleged or possible discrimination practices in the Federal sector, or in the processing of a Federal-sector EEO complaint.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    q.
+                  </strong>
+                   To disclose information to the Federal Labor Relations Authority or its General Counsel when requested in connection with investigations of allegations of unfair labor practices or matters before the Federal Service Impasses Panel.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    r.
+                  </strong>
+                   To another Federal agency’s Office of Inspector General when OPM becomes aware of an indication of misconduct or fraud during the applicant’s submission of the standard forms.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    s.
+                  </strong>
+                   To another Federal agency’s Office of Inspector General in connection with its inspection or audit activity of the investigative or adjudicative processes and procedures of its agency as authorized by the Inspector General Act of 1978, as amended, exclusive of requests for civil or criminal law enforcement activities.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    t.
+                  </strong>
+                   To a Federal agency or state unemployment compensation office upon its request in order to adjudicate a claim for unemployment compensation benefits when the claim for benefits is made as the result of a qualifications, suitability, fitness, security, identity credential, or access determination.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    u.
+                  </strong>
+                   To appropriately cleared individuals in Federal agencies, to determine whether information obtained in the course of processing the background investigation is or should be classified.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    v.
+                  </strong>
+                   To the Office of the Director of National Intelligence for inclusion in its Scattered Castles system in order to facilitate reciprocity of background investigations and security clearances within the intelligence community or assist agencies in obtaining information required by the Federal Investigative Standards.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    w.
+                  </strong>
+                   To the Director of National Intelligence, or assignee, such information as may be requested and relevant to implement the responsibilities of the Security Executive Agent for personnel security, and pertinent personnel security research and oversight, consistent with law or executive order.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    x.
+                  </strong>
+                   To Executive Branch Agency insider threat, counterintelligence, and counterterrorism officials to fulfill their responsibilities under applicable Federal law and policy, including but not limited to E.O. 12333, 13587 and the National Insider Threat Policy and Minimum Standards.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    y.
+                  </strong>
+                   To the appropriate Federal, State, local, tribal, foreign, or other public authority in the event of a natural or manmade disaster. The record will be used to provide leads to assist in locating missing subjects or assist in determining the health and safety of the subject. The record will also be used to assist in identifying victims and locating any surviving next of kin.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    z.
+                  </strong>
+                   To Federal, State, and local government agencies, if necessary, to obtain information from them which will assist OPM in its responsibilities as the authorized Investigation Service Provider in conducting studies and analyses in support of evaluating and improving the effectiveness and efficiency of the background investigation methodologies.
+                </p>
+              </div>
+              <div>
+                <p>
+                  <strong>
+                    aa.
+                  </strong>
+                   To an agency, office, or other establishment in the executive, legislative, or judicial branches of the Federal Government in response to its request, in connection with the classifying of jobs, the letting of a contract, or the issuance of a license, grant, or other benefit by the requesting agency, to the extent that the information is relevant and necessary to the requesting agency’s decision on the matter.
+                </p>
+              </div>
+              <div>
+                <hr />
+              </div>
+              <div>
+                <h1>
+                  Public burden information
+                </h1>
+              </div>
+              <div>
+                <p>
+                  Public burden reporting for this collection of information is 
+                  <strong>
+                    estimated to average 150 minutes per response
+                  </strong>
+                  , including time for reviewing instructions, searching existing data sources, gathering and maintaining the data needed, and completing and reviewing the collection of information. Send comments regarding the burden estimate or any other aspect of this collection of information, including suggestions for reducing this burden, to U.S. Office of Personnel Management, Federal Investigative Services, Attn: OMB Number 3206-0005, 1900 E Street, N.W., Washington, DC 20415. The OMB clearance number, 3206-0005, is currently valid. OPM may not collect this information, and you are not required to respond, unless this number is displayed.
+                </p>
+              </div>
+            </div>
+            <div
+              aria-label="Persons completing this form should begin after carefully reading the preceding instructions"
+              className="field   branch introduction-acceptance"
+              data-uuid="field-MOCK-GUID-0"
+            >
+              <a
+                aria-hidden="true"
+                className="anchor"
+                id="field-MOCK-GUID-0"
+                name="field-MOCK-GUID-0"
+              />
+              <h3
+                className="title h3"
+              >
+                Persons completing this form should begin after carefully reading the preceding instructions
+              </h3>
+              <span
+                className="icon"
+              />
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages help-messages"
+                />
+              </div>
+              <div
+                className="table"
+              >
+                <span
+                  className="content"
+                >
+                  <span
+                    className="component shrink"
+                  >
+                    <div
+                      className="content"
+                    >
+                      <div>
+                        <p>
+                          I have read the instructions and I understand that if I withhold, misrepresent, or falsify information on this form, I am subject to the penalties for inaccurate or false statement (per U. S. Criminal Code, Title 18, section 1001), denial or revocation of a security clearance, and/or removal and debarment from Federal Service.
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      className="blocks option-list branch"
+                    >
+                      <div
+                        className="yes block"
+                      >
+                        <label
+                          className=""
+                          htmlFor="acceptance_of_terms-MOCK-GUID-2"
+                        >
+                          <input
+                            aria-label="Yes, I agree to this agreement"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="acceptance_of_terms-MOCK-GUID-2"
+                            name="acceptance_of_terms-MOCK-GUID-2"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="Yes"
+                          />
+                          <span>
+                            Yes
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="no block"
+                      >
+                        <label
+                          className=""
+                          htmlFor="acceptance_of_terms-MOCK-GUID-3"
+                        >
+                          <input
+                            aria-label="No, I do not agree to this agreement"
+                            checked={false}
+                            className="usa-input-success"
+                            disabled={false}
+                            id="acceptance_of_terms-MOCK-GUID-3"
+                            name="acceptance_of_terms-MOCK-GUID-3"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            type="radio"
+                            value="No"
+                          />
+                          <span>
+                            No
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </span>
+                </span>
+              </div>
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages error-messages"
+                  role="alert"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
     id="scrollTo"
   />
   <a

--- a/src/components/Section/Identification/Identification.test.jsx
+++ b/src/components/Section/Identification/Identification.test.jsx
@@ -16,14 +16,6 @@ const applicationState = {
   }
 }
 
-// give a fake GUID so the field IDs don't differ between snapshots
-// https://github.com/facebook/jest/issues/936#issuecomment-404246102
-jest.mock('../../Form/ValidationElement/helpers', () =>
-  Object.assign(require.requireActual('../../Form/ValidationElement/helpers'), {
-    newGuid: jest.fn().mockReturnValue('MOCK-GUID')
-  })
-)
-
 describe('The identification section', () => {
   // Setup
   window.token = 'fake-token'

--- a/src/components/Section/Identification/__snapshots__/Identification.test.jsx.snap
+++ b/src/components/Section/Identification/__snapshots__/Identification.test.jsx.snap
@@ -18,13 +18,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Provide your date of birth"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-200"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-200"
+                name="field-MOCK-GUID-200"
               />
               <h2
                 className="title h2"
@@ -87,7 +87,7 @@ exports[`The identification section renders the Identification component for the
                           >
                             <label
                               className=""
-                              htmlFor="month-MOCK-GUID"
+                              htmlFor="month-MOCK-GUID-203"
                             >
                               Month
                             </label>
@@ -99,7 +99,7 @@ exports[`The identification section renders the Identification component for the
                               autoCorrect={true}
                               className=""
                               disabled={false}
-                              id="month-MOCK-GUID"
+                              id="month-MOCK-GUID-203"
                               maxLength="2"
                               name="month"
                               onBlur={[Function]}
@@ -122,7 +122,7 @@ exports[`The identification section renders the Identification component for the
                           >
                             <label
                               className=""
-                              htmlFor="day-MOCK-GUID"
+                              htmlFor="day-MOCK-GUID-205"
                             >
                               Day
                             </label>
@@ -134,7 +134,7 @@ exports[`The identification section renders the Identification component for the
                               autoCorrect={true}
                               className=""
                               disabled={false}
-                              id="day-MOCK-GUID"
+                              id="day-MOCK-GUID-205"
                               maxLength="2"
                               name="day"
                               onBlur={[Function]}
@@ -157,7 +157,7 @@ exports[`The identification section renders the Identification component for the
                           >
                             <label
                               className=""
-                              htmlFor="year-MOCK-GUID"
+                              htmlFor="year-MOCK-GUID-207"
                             >
                               Year
                             </label>
@@ -169,7 +169,7 @@ exports[`The identification section renders the Identification component for the
                               autoCorrect={true}
                               className=""
                               disabled={false}
-                              id="year-MOCK-GUID"
+                              id="year-MOCK-GUID-207"
                               maxLength="4"
                               name="year"
                               onBlur={[Function]}
@@ -196,7 +196,7 @@ exports[`The identification section renders the Identification component for the
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="estimated-MOCK-GUID"
+                            id="estimated-MOCK-GUID-208"
                             name="estimated"
                             onBlur={[Function]}
                             onChange={[Function]}
@@ -207,7 +207,7 @@ exports[`The identification section renders the Identification component for the
                           />
                           <label
                             className="checkbox no-toggle"
-                            htmlFor="estimated-MOCK-GUID"
+                            htmlFor="estimated-MOCK-GUID-208"
                           >
                             <span>
                               Estimated
@@ -336,13 +336,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Provide your place of birth"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-209"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-209"
+                name="field-MOCK-GUID-209"
               />
               <h2
                 className="title h2"
@@ -389,15 +389,15 @@ exports[`The identification section renders the Identification component for the
                             >
                               <label
                                 className=""
-                                htmlFor="birthplace-MOCK-GUID"
+                                htmlFor="birthplace-MOCK-GUID-213"
                               >
                                 <input
                                   aria-label="Yes for null"
                                   checked={false}
                                   className="usa-input-success"
                                   disabled={false}
-                                  id="birthplace-MOCK-GUID"
-                                  name="birthplace-MOCK-GUID"
+                                  id="birthplace-MOCK-GUID-213"
+                                  name="birthplace-MOCK-GUID-213"
                                   onBlur={[Function]}
                                   onChange={[Function]}
                                   onClick={[Function]}
@@ -416,15 +416,15 @@ exports[`The identification section renders the Identification component for the
                             >
                               <label
                                 className=""
-                                htmlFor="birthplace-MOCK-GUID"
+                                htmlFor="birthplace-MOCK-GUID-214"
                               >
                                 <input
                                   aria-label="No for null"
                                   checked={false}
                                   className="usa-input-success"
                                   disabled={false}
-                                  id="birthplace-MOCK-GUID"
-                                  name="birthplace-MOCK-GUID"
+                                  id="birthplace-MOCK-GUID-214"
+                                  name="birthplace-MOCK-GUID-214"
                                   onBlur={[Function]}
                                   onChange={[Function]}
                                   onClick={[Function]}
@@ -562,13 +562,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Provide your contact information"
               className="field   no-margin-bottom"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-193"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-193"
+                name="field-MOCK-GUID-193"
               />
               <h2
                 className="title h2"
@@ -610,13 +610,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Your email addresses"
               className="field   no-margin-bottom"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-194"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-194"
+                name="field-MOCK-GUID-194"
               />
               <h3
                 className="title h3"
@@ -719,13 +719,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Your phone numbers"
               className="field   no-margin-bottom"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-197"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-197"
+                name="field-MOCK-GUID-197"
               />
               <h3
                 className="title h3"
@@ -931,13 +931,13 @@ exports[`The identification section renders the Identification component for the
           <div
             aria-label="Section 1: Information about you"
             className="field   no-margin-bottom"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-160"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-160"
+              name="field-MOCK-GUID-160"
             />
             <h2
               className="title h2"
@@ -1058,13 +1058,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Provide your full name"
               className="field"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-161"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-161"
+                name="field-MOCK-GUID-161"
               />
               <h2
                 className="title h2"
@@ -1097,13 +1097,13 @@ exports[`The identification section renders the Identification component for the
                       <div
                         aria-label="First name"
                         className="field required"
-                        data-uuid="field-MOCK-GUID"
+                        data-uuid="field-MOCK-GUID-163"
                       >
                         <a
                           aria-hidden="true"
                           className="anchor"
-                          id="field-MOCK-GUID"
-                          name="field-MOCK-GUID"
+                          id="field-MOCK-GUID-163"
+                          name="field-MOCK-GUID-163"
                         />
                         <label
                           className="title label"
@@ -1164,7 +1164,7 @@ exports[`The identification section renders the Identification component for the
                                   autoComplete={true}
                                   autoCorrect={true}
                                   className=""
-                                  id="first-MOCK-GUID"
+                                  id="first-MOCK-GUID-164"
                                   maxLength="100"
                                   name="first"
                                   onBlur={[Function]}
@@ -1187,7 +1187,7 @@ exports[`The identification section renders the Identification component for the
                                     aria-label="Initial only for null"
                                     checked={false}
                                     className="usa-input-success"
-                                    id="firstInitialOnly-MOCK-GUID"
+                                    id="firstInitialOnly-MOCK-GUID-165"
                                     name="firstInitialOnly"
                                     onBlur={[Function]}
                                     onChange={[Function]}
@@ -1198,7 +1198,7 @@ exports[`The identification section renders the Identification component for the
                                   />
                                   <label
                                     className="checkbox no-toggle"
-                                    htmlFor="firstInitialOnly-MOCK-GUID"
+                                    htmlFor="firstInitialOnly-MOCK-GUID-165"
                                   >
                                     <span>
                                       Initial only
@@ -1222,13 +1222,13 @@ exports[`The identification section renders the Identification component for the
                       <div
                         aria-label="Middle name"
                         className="field required"
-                        data-uuid="field-MOCK-GUID"
+                        data-uuid="field-MOCK-GUID-166"
                       >
                         <a
                           aria-hidden="true"
                           className="anchor"
-                          id="field-MOCK-GUID"
-                          name="field-MOCK-GUID"
+                          id="field-MOCK-GUID-166"
+                          name="field-MOCK-GUID-166"
                         />
                         <label
                           className="title label"
@@ -1289,7 +1289,7 @@ exports[`The identification section renders the Identification component for the
                                   autoComplete={true}
                                   autoCorrect={true}
                                   className=""
-                                  id="middle-MOCK-GUID"
+                                  id="middle-MOCK-GUID-167"
                                   maxLength="100"
                                   name="middle"
                                   onBlur={[Function]}
@@ -1312,7 +1312,7 @@ exports[`The identification section renders the Identification component for the
                                     aria-label="No middle name for null"
                                     checked={false}
                                     className="usa-input-success"
-                                    id="noMiddleName-MOCK-GUID"
+                                    id="noMiddleName-MOCK-GUID-168"
                                     name="noMiddleName"
                                     onBlur={[Function]}
                                     onChange={[Function]}
@@ -1323,7 +1323,7 @@ exports[`The identification section renders the Identification component for the
                                   />
                                   <label
                                     className="checkbox no-toggle"
-                                    htmlFor="noMiddleName-MOCK-GUID"
+                                    htmlFor="noMiddleName-MOCK-GUID-168"
                                   >
                                     <span>
                                       No middle name
@@ -1337,7 +1337,7 @@ exports[`The identification section renders the Identification component for the
                                     aria-label="Initial only for null"
                                     checked={false}
                                     className="usa-input-success"
-                                    id="middleInitialOnly-MOCK-GUID"
+                                    id="middleInitialOnly-MOCK-GUID-169"
                                     name="middleInitialOnly"
                                     onBlur={[Function]}
                                     onChange={[Function]}
@@ -1348,7 +1348,7 @@ exports[`The identification section renders the Identification component for the
                                   />
                                   <label
                                     className="checkbox no-toggle"
-                                    htmlFor="middleInitialOnly-MOCK-GUID"
+                                    htmlFor="middleInitialOnly-MOCK-GUID-169"
                                   >
                                     <span>
                                       Initial only
@@ -1372,13 +1372,13 @@ exports[`The identification section renders the Identification component for the
                       <div
                         aria-label="Last name"
                         className="field required"
-                        data-uuid="field-MOCK-GUID"
+                        data-uuid="field-MOCK-GUID-170"
                       >
                         <a
                           aria-hidden="true"
                           className="anchor"
-                          id="field-MOCK-GUID"
-                          name="field-MOCK-GUID"
+                          id="field-MOCK-GUID-170"
+                          name="field-MOCK-GUID-170"
                         />
                         <label
                           className="title label"
@@ -1439,7 +1439,7 @@ exports[`The identification section renders the Identification component for the
                                   autoComplete={true}
                                   autoCorrect={true}
                                   className=""
-                                  id="last-MOCK-GUID"
+                                  id="last-MOCK-GUID-171"
                                   maxLength="100"
                                   name="last"
                                   onBlur={[Function]}
@@ -1462,7 +1462,7 @@ exports[`The identification section renders the Identification component for the
                                     aria-label="Initial only for null"
                                     checked={false}
                                     className="usa-input-success"
-                                    id="lastInitialOnly-MOCK-GUID"
+                                    id="lastInitialOnly-MOCK-GUID-172"
                                     name="lastInitialOnly"
                                     onBlur={[Function]}
                                     onChange={[Function]}
@@ -1473,7 +1473,7 @@ exports[`The identification section renders the Identification component for the
                                   />
                                   <label
                                     className="checkbox no-toggle"
-                                    htmlFor="lastInitialOnly-MOCK-GUID"
+                                    htmlFor="lastInitialOnly-MOCK-GUID-172"
                                   >
                                     <span>
                                       Initial only
@@ -1497,13 +1497,13 @@ exports[`The identification section renders the Identification component for the
                       <div
                         aria-label="Suffix"
                         className="field"
-                        data-uuid="field-MOCK-GUID"
+                        data-uuid="field-MOCK-GUID-173"
                       >
                         <a
                           aria-hidden="true"
                           className="anchor"
-                          id="field-MOCK-GUID"
-                          name="field-MOCK-GUID"
+                          id="field-MOCK-GUID-173"
+                          name="field-MOCK-GUID-173"
                         />
                         <label
                           className="title label"
@@ -1567,15 +1567,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-175"
                                   >
                                     <input
                                       aria-label="Jr for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-175"
+                                      name="suffix-MOCK-GUID-175"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -1594,15 +1594,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-176"
                                   >
                                     <input
                                       aria-label="Sr for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-176"
+                                      name="suffix-MOCK-GUID-176"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -1621,15 +1621,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-177"
                                   >
                                     <input
                                       aria-label="I for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-177"
+                                      name="suffix-MOCK-GUID-177"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -1648,15 +1648,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-178"
                                   >
                                     <input
                                       aria-label="II for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-178"
+                                      name="suffix-MOCK-GUID-178"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -1675,15 +1675,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-179"
                                   >
                                     <input
                                       aria-label="III for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-179"
+                                      name="suffix-MOCK-GUID-179"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -1702,15 +1702,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-180"
                                   >
                                     <input
                                       aria-label="IV for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-180"
+                                      name="suffix-MOCK-GUID-180"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -1729,15 +1729,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-181"
                                   >
                                     <input
                                       aria-label="V for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-181"
+                                      name="suffix-MOCK-GUID-181"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -1756,15 +1756,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-182"
                                   >
                                     <input
                                       aria-label="VI for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-182"
+                                      name="suffix-MOCK-GUID-182"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -1783,15 +1783,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-183"
                                   >
                                     <input
                                       aria-label="VII for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-183"
+                                      name="suffix-MOCK-GUID-183"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -1810,15 +1810,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-184"
                                   >
                                     <input
                                       aria-label="VIII for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-184"
+                                      name="suffix-MOCK-GUID-184"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -1837,15 +1837,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-185"
                                   >
                                     <input
                                       aria-label="IX for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-185"
+                                      name="suffix-MOCK-GUID-185"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -1864,15 +1864,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-186"
                                   >
                                     <input
                                       aria-label="X for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-186"
+                                      name="suffix-MOCK-GUID-186"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -1891,15 +1891,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-187"
                                   >
                                     <input
                                       aria-label="Other for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-187"
+                                      name="suffix-MOCK-GUID-187"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -2048,13 +2048,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Provide your other names used and the period of time you used them"
               className="field   no-margin-bottom"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-188"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-188"
+                name="field-MOCK-GUID-188"
               />
               <h2
                 className="title h2"
@@ -2126,13 +2126,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Have you used any other names?"
               className="field required  branch"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-189"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-189"
+                name="field-MOCK-GUID-189"
               />
               <h3
                 className="title h3"
@@ -2170,15 +2170,15 @@ exports[`The identification section renders the Identification component for the
                       >
                         <label
                           className=""
-                          htmlFor="has_othernames-MOCK-GUID"
+                          htmlFor="has_othernames-MOCK-GUID-191"
                         >
                           <input
                             aria-label="Yes for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="has_othernames-MOCK-GUID"
-                            name="has_othernames-MOCK-GUID"
+                            id="has_othernames-MOCK-GUID-191"
+                            name="has_othernames-MOCK-GUID-191"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -2197,15 +2197,15 @@ exports[`The identification section renders the Identification component for the
                       >
                         <label
                           className=""
-                          htmlFor="has_othernames-MOCK-GUID"
+                          htmlFor="has_othernames-MOCK-GUID-192"
                         >
                           <input
                             aria-label="No for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="has_othernames-MOCK-GUID"
-                            name="has_othernames-MOCK-GUID"
+                            id="has_othernames-MOCK-GUID-192"
+                            name="has_othernames-MOCK-GUID-192"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -2340,13 +2340,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Provide your identifying information"
               className="field   no-margin-bottom"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-221"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-221"
+                name="field-MOCK-GUID-221"
               />
               <h2
                 className="title h2"
@@ -2388,13 +2388,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Height"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-222"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-222"
+                name="field-MOCK-GUID-222"
               />
               <h3
                 className="title h3"
@@ -2456,7 +2456,7 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="feet-MOCK-GUID"
+                            htmlFor="feet-MOCK-GUID-225"
                           >
                             Feet
                           </label>
@@ -2468,7 +2468,7 @@ exports[`The identification section renders the Identification component for the
                             autoCorrect={true}
                             className=""
                             disabled={false}
-                            id="feet-MOCK-GUID"
+                            id="feet-MOCK-GUID-225"
                             maxLength="1"
                             name="feet"
                             onBlur={[Function]}
@@ -2491,7 +2491,7 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="inches-MOCK-GUID"
+                            htmlFor="inches-MOCK-GUID-227"
                           >
                             Inches
                           </label>
@@ -2503,7 +2503,7 @@ exports[`The identification section renders the Identification component for the
                             autoCorrect={true}
                             className=""
                             disabled={false}
-                            id="inches-MOCK-GUID"
+                            id="inches-MOCK-GUID-227"
                             maxLength="2"
                             name="inches"
                             onBlur={[Function]}
@@ -2535,13 +2535,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Weight"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-228"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-228"
+                name="field-MOCK-GUID-228"
               />
               <h3
                 className="title h3"
@@ -2603,7 +2603,7 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="pounds-MOCK-GUID"
+                            htmlFor="pounds-MOCK-GUID-230"
                           >
                             Pounds
                           </label>
@@ -2615,7 +2615,7 @@ exports[`The identification section renders the Identification component for the
                             autoCorrect={true}
                             className=""
                             disabled={false}
-                            id="pounds-MOCK-GUID"
+                            id="pounds-MOCK-GUID-230"
                             maxLength="3"
                             name="pounds"
                             onBlur={[Function]}
@@ -2647,13 +2647,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Hair color"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-231"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-231"
+                name="field-MOCK-GUID-231"
               />
               <h3
                 className="title h3"
@@ -2716,15 +2716,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-black-MOCK-GUID"
+                            htmlFor="hair-black-MOCK-GUID-233"
                           >
                             <input
                               aria-label="Black for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-black-MOCK-GUID"
-                              name="hair-black-MOCK-GUID"
+                              id="hair-black-MOCK-GUID-233"
+                              name="hair-black-MOCK-GUID-233"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -2758,15 +2758,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-brown-MOCK-GUID"
+                            htmlFor="hair-brown-MOCK-GUID-234"
                           >
                             <input
                               aria-label="Brown for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-brown-MOCK-GUID"
-                              name="hair-brown-MOCK-GUID"
+                              id="hair-brown-MOCK-GUID-234"
+                              name="hair-brown-MOCK-GUID-234"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -2800,15 +2800,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-red-MOCK-GUID"
+                            htmlFor="hair-red-MOCK-GUID-235"
                           >
                             <input
                               aria-label="Red or auburn for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-red-MOCK-GUID"
-                              name="hair-red-MOCK-GUID"
+                              id="hair-red-MOCK-GUID-235"
+                              name="hair-red-MOCK-GUID-235"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -2842,15 +2842,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-blonde-MOCK-GUID"
+                            htmlFor="hair-blonde-MOCK-GUID-236"
                           >
                             <input
                               aria-label="Blonde or strawberry for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-blonde-MOCK-GUID"
-                              name="hair-blonde-MOCK-GUID"
+                              id="hair-blonde-MOCK-GUID-236"
+                              name="hair-blonde-MOCK-GUID-236"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -2884,15 +2884,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-sandy-MOCK-GUID"
+                            htmlFor="hair-sandy-MOCK-GUID-237"
                           >
                             <input
                               aria-label="Sandy for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-sandy-MOCK-GUID"
-                              name="hair-sandy-MOCK-GUID"
+                              id="hair-sandy-MOCK-GUID-237"
+                              name="hair-sandy-MOCK-GUID-237"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -2926,15 +2926,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-gray-MOCK-GUID"
+                            htmlFor="hair-gray-MOCK-GUID-238"
                           >
                             <input
                               aria-label="Gray or partially gray for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-gray-MOCK-GUID"
-                              name="hair-gray-MOCK-GUID"
+                              id="hair-gray-MOCK-GUID-238"
+                              name="hair-gray-MOCK-GUID-238"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -2968,15 +2968,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-white-MOCK-GUID"
+                            htmlFor="hair-white-MOCK-GUID-239"
                           >
                             <input
                               aria-label="White for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-white-MOCK-GUID"
-                              name="hair-white-MOCK-GUID"
+                              id="hair-white-MOCK-GUID-239"
+                              name="hair-white-MOCK-GUID-239"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3010,15 +3010,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-bald-MOCK-GUID"
+                            htmlFor="hair-bald-MOCK-GUID-240"
                           >
                             <input
                               aria-label="Bald for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-bald-MOCK-GUID"
-                              name="hair-bald-MOCK-GUID"
+                              id="hair-bald-MOCK-GUID-240"
+                              name="hair-bald-MOCK-GUID-240"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3060,15 +3060,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-blue-MOCK-GUID"
+                            htmlFor="hair-blue-MOCK-GUID-241"
                           >
                             <input
                               aria-label="Blue for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-blue-MOCK-GUID"
-                              name="hair-blue-MOCK-GUID"
+                              id="hair-blue-MOCK-GUID-241"
+                              name="hair-blue-MOCK-GUID-241"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3102,15 +3102,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-green-MOCK-GUID"
+                            htmlFor="hair-green-MOCK-GUID-242"
                           >
                             <input
                               aria-label="Green for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-green-MOCK-GUID"
-                              name="hair-green-MOCK-GUID"
+                              id="hair-green-MOCK-GUID-242"
+                              name="hair-green-MOCK-GUID-242"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3144,15 +3144,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-orange-MOCK-GUID"
+                            htmlFor="hair-orange-MOCK-GUID-243"
                           >
                             <input
                               aria-label="Orange for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-orange-MOCK-GUID"
-                              name="hair-orange-MOCK-GUID"
+                              id="hair-orange-MOCK-GUID-243"
+                              name="hair-orange-MOCK-GUID-243"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3186,15 +3186,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-pink-MOCK-GUID"
+                            htmlFor="hair-pink-MOCK-GUID-244"
                           >
                             <input
                               aria-label="Pink for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-pink-MOCK-GUID"
-                              name="hair-pink-MOCK-GUID"
+                              id="hair-pink-MOCK-GUID-244"
+                              name="hair-pink-MOCK-GUID-244"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3228,15 +3228,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-purple-MOCK-GUID"
+                            htmlFor="hair-purple-MOCK-GUID-245"
                           >
                             <input
                               aria-label="Purple for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-purple-MOCK-GUID"
-                              name="hair-purple-MOCK-GUID"
+                              id="hair-purple-MOCK-GUID-245"
+                              name="hair-purple-MOCK-GUID-245"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3270,15 +3270,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-unknown-MOCK-GUID"
+                            htmlFor="hair-unknown-MOCK-GUID-246"
                           >
                             <input
                               aria-label="Unspecified or unknown for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-unknown-MOCK-GUID"
-                              name="hair-unknown-MOCK-GUID"
+                              id="hair-unknown-MOCK-GUID-246"
+                              name="hair-unknown-MOCK-GUID-246"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3324,13 +3324,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Eye color"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-247"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-247"
+                name="field-MOCK-GUID-247"
               />
               <h3
                 className="title h3"
@@ -3393,15 +3393,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-brown-MOCK-GUID"
+                            htmlFor="eye-brown-MOCK-GUID-249"
                           >
                             <input
                               aria-label="Brown for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-brown-MOCK-GUID"
-                              name="eye-brown-MOCK-GUID"
+                              id="eye-brown-MOCK-GUID-249"
+                              name="eye-brown-MOCK-GUID-249"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3435,15 +3435,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-hazel-MOCK-GUID"
+                            htmlFor="eye-hazel-MOCK-GUID-250"
                           >
                             <input
                               aria-label="Hazel for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-hazel-MOCK-GUID"
-                              name="eye-hazel-MOCK-GUID"
+                              id="eye-hazel-MOCK-GUID-250"
+                              name="eye-hazel-MOCK-GUID-250"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3477,15 +3477,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-blue-MOCK-GUID"
+                            htmlFor="eye-blue-MOCK-GUID-251"
                           >
                             <input
                               aria-label="Blue for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-blue-MOCK-GUID"
-                              name="eye-blue-MOCK-GUID"
+                              id="eye-blue-MOCK-GUID-251"
+                              name="eye-blue-MOCK-GUID-251"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3519,15 +3519,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-green-MOCK-GUID"
+                            htmlFor="eye-green-MOCK-GUID-252"
                           >
                             <input
                               aria-label="Green for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-green-MOCK-GUID"
-                              name="eye-green-MOCK-GUID"
+                              id="eye-green-MOCK-GUID-252"
+                              name="eye-green-MOCK-GUID-252"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3561,15 +3561,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-gray-MOCK-GUID"
+                            htmlFor="eye-gray-MOCK-GUID-253"
                           >
                             <input
                               aria-label="Gray for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-gray-MOCK-GUID"
-                              name="eye-gray-MOCK-GUID"
+                              id="eye-gray-MOCK-GUID-253"
+                              name="eye-gray-MOCK-GUID-253"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3603,15 +3603,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-maroon-MOCK-GUID"
+                            htmlFor="eye-maroon-MOCK-GUID-254"
                           >
                             <input
                               aria-label="Maroon for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-maroon-MOCK-GUID"
-                              name="eye-maroon-MOCK-GUID"
+                              id="eye-maroon-MOCK-GUID-254"
+                              name="eye-maroon-MOCK-GUID-254"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3645,15 +3645,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-black-MOCK-GUID"
+                            htmlFor="eye-black-MOCK-GUID-255"
                           >
                             <input
                               aria-label="Black for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-black-MOCK-GUID"
-                              name="eye-black-MOCK-GUID"
+                              id="eye-black-MOCK-GUID-255"
+                              name="eye-black-MOCK-GUID-255"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3687,15 +3687,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-multi-MOCK-GUID"
+                            htmlFor="eye-multi-MOCK-GUID-256"
                           >
                             <input
                               aria-label="Multicolored for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-multi-MOCK-GUID"
-                              name="eye-multi-MOCK-GUID"
+                              id="eye-multi-MOCK-GUID-256"
+                              name="eye-multi-MOCK-GUID-256"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3723,15 +3723,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-pink-MOCK-GUID"
+                            htmlFor="eye-pink-MOCK-GUID-257"
                           >
                             <input
                               aria-label="Pink for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-pink-MOCK-GUID"
-                              name="eye-pink-MOCK-GUID"
+                              id="eye-pink-MOCK-GUID-257"
+                              name="eye-pink-MOCK-GUID-257"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3765,15 +3765,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-unknown-MOCK-GUID"
+                            htmlFor="eye-unknown-MOCK-GUID-258"
                           >
                             <input
                               aria-label="Unknown for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-unknown-MOCK-GUID"
-                              name="eye-unknown-MOCK-GUID"
+                              id="eye-unknown-MOCK-GUID-258"
+                              name="eye-unknown-MOCK-GUID-258"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3819,13 +3819,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Select your sex"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-259"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-259"
+                name="field-MOCK-GUID-259"
               />
               <h3
                 className="title h3"
@@ -3888,15 +3888,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="sex-MOCK-GUID"
+                            htmlFor="sex-MOCK-GUID-261"
                           >
                             <input
                               aria-label="Female for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="sex-MOCK-GUID"
-                              name="sex-MOCK-GUID"
+                              id="sex-MOCK-GUID-261"
+                              name="sex-MOCK-GUID-261"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -3929,15 +3929,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="sex-MOCK-GUID"
+                            htmlFor="sex-MOCK-GUID-262"
                           >
                             <input
                               aria-label="Male for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="sex-MOCK-GUID"
-                              name="sex-MOCK-GUID"
+                              id="sex-MOCK-GUID-262"
+                              name="sex-MOCK-GUID-262"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -4112,13 +4112,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Provide your full name"
               className="field"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-263"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-263"
+                name="field-MOCK-GUID-263"
               />
               <h2
                 className="title h2"
@@ -4151,13 +4151,13 @@ exports[`The identification section renders the Identification component for the
                       <div
                         aria-label="First name"
                         className="field required"
-                        data-uuid="field-MOCK-GUID"
+                        data-uuid="field-MOCK-GUID-265"
                       >
                         <a
                           aria-hidden="true"
                           className="anchor"
-                          id="field-MOCK-GUID"
-                          name="field-MOCK-GUID"
+                          id="field-MOCK-GUID-265"
+                          name="field-MOCK-GUID-265"
                         />
                         <label
                           className="title label"
@@ -4218,7 +4218,7 @@ exports[`The identification section renders the Identification component for the
                                   autoComplete={true}
                                   autoCorrect={true}
                                   className=""
-                                  id="first-MOCK-GUID"
+                                  id="first-MOCK-GUID-266"
                                   maxLength="100"
                                   name="first"
                                   onBlur={[Function]}
@@ -4241,7 +4241,7 @@ exports[`The identification section renders the Identification component for the
                                     aria-label="Initial only for null"
                                     checked={false}
                                     className="usa-input-success"
-                                    id="firstInitialOnly-MOCK-GUID"
+                                    id="firstInitialOnly-MOCK-GUID-267"
                                     name="firstInitialOnly"
                                     onBlur={[Function]}
                                     onChange={[Function]}
@@ -4252,7 +4252,7 @@ exports[`The identification section renders the Identification component for the
                                   />
                                   <label
                                     className="checkbox no-toggle"
-                                    htmlFor="firstInitialOnly-MOCK-GUID"
+                                    htmlFor="firstInitialOnly-MOCK-GUID-267"
                                   >
                                     <span>
                                       Initial only
@@ -4276,13 +4276,13 @@ exports[`The identification section renders the Identification component for the
                       <div
                         aria-label="Middle name"
                         className="field required"
-                        data-uuid="field-MOCK-GUID"
+                        data-uuid="field-MOCK-GUID-268"
                       >
                         <a
                           aria-hidden="true"
                           className="anchor"
-                          id="field-MOCK-GUID"
-                          name="field-MOCK-GUID"
+                          id="field-MOCK-GUID-268"
+                          name="field-MOCK-GUID-268"
                         />
                         <label
                           className="title label"
@@ -4343,7 +4343,7 @@ exports[`The identification section renders the Identification component for the
                                   autoComplete={true}
                                   autoCorrect={true}
                                   className=""
-                                  id="middle-MOCK-GUID"
+                                  id="middle-MOCK-GUID-269"
                                   maxLength="100"
                                   name="middle"
                                   onBlur={[Function]}
@@ -4366,7 +4366,7 @@ exports[`The identification section renders the Identification component for the
                                     aria-label="No middle name for null"
                                     checked={false}
                                     className="usa-input-success"
-                                    id="noMiddleName-MOCK-GUID"
+                                    id="noMiddleName-MOCK-GUID-270"
                                     name="noMiddleName"
                                     onBlur={[Function]}
                                     onChange={[Function]}
@@ -4377,7 +4377,7 @@ exports[`The identification section renders the Identification component for the
                                   />
                                   <label
                                     className="checkbox no-toggle"
-                                    htmlFor="noMiddleName-MOCK-GUID"
+                                    htmlFor="noMiddleName-MOCK-GUID-270"
                                   >
                                     <span>
                                       No middle name
@@ -4391,7 +4391,7 @@ exports[`The identification section renders the Identification component for the
                                     aria-label="Initial only for null"
                                     checked={false}
                                     className="usa-input-success"
-                                    id="middleInitialOnly-MOCK-GUID"
+                                    id="middleInitialOnly-MOCK-GUID-271"
                                     name="middleInitialOnly"
                                     onBlur={[Function]}
                                     onChange={[Function]}
@@ -4402,7 +4402,7 @@ exports[`The identification section renders the Identification component for the
                                   />
                                   <label
                                     className="checkbox no-toggle"
-                                    htmlFor="middleInitialOnly-MOCK-GUID"
+                                    htmlFor="middleInitialOnly-MOCK-GUID-271"
                                   >
                                     <span>
                                       Initial only
@@ -4426,13 +4426,13 @@ exports[`The identification section renders the Identification component for the
                       <div
                         aria-label="Last name"
                         className="field required"
-                        data-uuid="field-MOCK-GUID"
+                        data-uuid="field-MOCK-GUID-272"
                       >
                         <a
                           aria-hidden="true"
                           className="anchor"
-                          id="field-MOCK-GUID"
-                          name="field-MOCK-GUID"
+                          id="field-MOCK-GUID-272"
+                          name="field-MOCK-GUID-272"
                         />
                         <label
                           className="title label"
@@ -4493,7 +4493,7 @@ exports[`The identification section renders the Identification component for the
                                   autoComplete={true}
                                   autoCorrect={true}
                                   className=""
-                                  id="last-MOCK-GUID"
+                                  id="last-MOCK-GUID-273"
                                   maxLength="100"
                                   name="last"
                                   onBlur={[Function]}
@@ -4516,7 +4516,7 @@ exports[`The identification section renders the Identification component for the
                                     aria-label="Initial only for null"
                                     checked={false}
                                     className="usa-input-success"
-                                    id="lastInitialOnly-MOCK-GUID"
+                                    id="lastInitialOnly-MOCK-GUID-274"
                                     name="lastInitialOnly"
                                     onBlur={[Function]}
                                     onChange={[Function]}
@@ -4527,7 +4527,7 @@ exports[`The identification section renders the Identification component for the
                                   />
                                   <label
                                     className="checkbox no-toggle"
-                                    htmlFor="lastInitialOnly-MOCK-GUID"
+                                    htmlFor="lastInitialOnly-MOCK-GUID-274"
                                   >
                                     <span>
                                       Initial only
@@ -4551,13 +4551,13 @@ exports[`The identification section renders the Identification component for the
                       <div
                         aria-label="Suffix"
                         className="field"
-                        data-uuid="field-MOCK-GUID"
+                        data-uuid="field-MOCK-GUID-275"
                       >
                         <a
                           aria-hidden="true"
                           className="anchor"
-                          id="field-MOCK-GUID"
-                          name="field-MOCK-GUID"
+                          id="field-MOCK-GUID-275"
+                          name="field-MOCK-GUID-275"
                         />
                         <label
                           className="title label"
@@ -4621,15 +4621,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-277"
                                   >
                                     <input
                                       aria-label="Jr for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-277"
+                                      name="suffix-MOCK-GUID-277"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -4648,15 +4648,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-278"
                                   >
                                     <input
                                       aria-label="Sr for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-278"
+                                      name="suffix-MOCK-GUID-278"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -4675,15 +4675,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-279"
                                   >
                                     <input
                                       aria-label="I for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-279"
+                                      name="suffix-MOCK-GUID-279"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -4702,15 +4702,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-280"
                                   >
                                     <input
                                       aria-label="II for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-280"
+                                      name="suffix-MOCK-GUID-280"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -4729,15 +4729,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-281"
                                   >
                                     <input
                                       aria-label="III for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-281"
+                                      name="suffix-MOCK-GUID-281"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -4756,15 +4756,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-282"
                                   >
                                     <input
                                       aria-label="IV for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-282"
+                                      name="suffix-MOCK-GUID-282"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -4783,15 +4783,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-283"
                                   >
                                     <input
                                       aria-label="V for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-283"
+                                      name="suffix-MOCK-GUID-283"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -4810,15 +4810,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-284"
                                   >
                                     <input
                                       aria-label="VI for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-284"
+                                      name="suffix-MOCK-GUID-284"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -4837,15 +4837,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-285"
                                   >
                                     <input
                                       aria-label="VII for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-285"
+                                      name="suffix-MOCK-GUID-285"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -4864,15 +4864,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-286"
                                   >
                                     <input
                                       aria-label="VIII for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-286"
+                                      name="suffix-MOCK-GUID-286"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -4891,15 +4891,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-287"
                                   >
                                     <input
                                       aria-label="IX for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-287"
+                                      name="suffix-MOCK-GUID-287"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -4918,15 +4918,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-288"
                                   >
                                     <input
                                       aria-label="X for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-288"
+                                      name="suffix-MOCK-GUID-288"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -4945,15 +4945,15 @@ exports[`The identification section renders the Identification component for the
                                 >
                                   <label
                                     className=""
-                                    htmlFor="suffix-MOCK-GUID"
+                                    htmlFor="suffix-MOCK-GUID-289"
                                   >
                                     <input
                                       aria-label="Other for null"
                                       checked={false}
                                       className="usa-input-success"
                                       disabled={false}
-                                      id="suffix-MOCK-GUID"
-                                      name="suffix-MOCK-GUID"
+                                      id="suffix-MOCK-GUID-289"
+                                      name="suffix-MOCK-GUID-289"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onClick={[Function]}
@@ -5033,13 +5033,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Provide your other names used and the period of time you used them"
               className="field   no-margin-bottom"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-290"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-290"
+                name="field-MOCK-GUID-290"
               />
               <h2
                 className="title h2"
@@ -5111,13 +5111,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Have you used any other names?"
               className="field required  branch"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-291"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-291"
+                name="field-MOCK-GUID-291"
               />
               <h3
                 className="title h3"
@@ -5155,15 +5155,15 @@ exports[`The identification section renders the Identification component for the
                       >
                         <label
                           className=""
-                          htmlFor="has_othernames-MOCK-GUID"
+                          htmlFor="has_othernames-MOCK-GUID-293"
                         >
                           <input
                             aria-label="Yes for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="has_othernames-MOCK-GUID"
-                            name="has_othernames-MOCK-GUID"
+                            id="has_othernames-MOCK-GUID-293"
+                            name="has_othernames-MOCK-GUID-293"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -5182,15 +5182,15 @@ exports[`The identification section renders the Identification component for the
                       >
                         <label
                           className=""
-                          htmlFor="has_othernames-MOCK-GUID"
+                          htmlFor="has_othernames-MOCK-GUID-294"
                         >
                           <input
                             aria-label="No for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="has_othernames-MOCK-GUID"
-                            name="has_othernames-MOCK-GUID"
+                            id="has_othernames-MOCK-GUID-294"
+                            name="has_othernames-MOCK-GUID-294"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -5250,13 +5250,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Provide your contact information"
               className="field   no-margin-bottom"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-295"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-295"
+                name="field-MOCK-GUID-295"
               />
               <h2
                 className="title h2"
@@ -5298,13 +5298,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Your email addresses"
               className="field   no-margin-bottom"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-296"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-296"
+                name="field-MOCK-GUID-296"
               />
               <h3
                 className="title h3"
@@ -5407,13 +5407,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Your phone numbers"
               className="field   no-margin-bottom"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-298"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-298"
+                name="field-MOCK-GUID-298"
               />
               <h3
                 className="title h3"
@@ -5529,13 +5529,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Provide your date of birth"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-300"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-300"
+                name="field-MOCK-GUID-300"
               />
               <h2
                 className="title h2"
@@ -5598,7 +5598,7 @@ exports[`The identification section renders the Identification component for the
                           >
                             <label
                               className="usa-input-error-label"
-                              htmlFor="month-MOCK-GUID"
+                              htmlFor="month-MOCK-GUID-303"
                             >
                               Month
                             </label>
@@ -5610,7 +5610,7 @@ exports[`The identification section renders the Identification component for the
                               autoCorrect={true}
                               className=""
                               disabled={false}
-                              id="month-MOCK-GUID"
+                              id="month-MOCK-GUID-303"
                               maxLength="2"
                               name="month"
                               onBlur={[Function]}
@@ -5633,7 +5633,7 @@ exports[`The identification section renders the Identification component for the
                           >
                             <label
                               className="usa-input-error-label"
-                              htmlFor="day-MOCK-GUID"
+                              htmlFor="day-MOCK-GUID-305"
                             >
                               Day
                             </label>
@@ -5645,7 +5645,7 @@ exports[`The identification section renders the Identification component for the
                               autoCorrect={true}
                               className=""
                               disabled={false}
-                              id="day-MOCK-GUID"
+                              id="day-MOCK-GUID-305"
                               maxLength="2"
                               name="day"
                               onBlur={[Function]}
@@ -5668,7 +5668,7 @@ exports[`The identification section renders the Identification component for the
                           >
                             <label
                               className="usa-input-error-label"
-                              htmlFor="year-MOCK-GUID"
+                              htmlFor="year-MOCK-GUID-307"
                             >
                               Year
                             </label>
@@ -5680,7 +5680,7 @@ exports[`The identification section renders the Identification component for the
                               autoCorrect={true}
                               className=""
                               disabled={false}
-                              id="year-MOCK-GUID"
+                              id="year-MOCK-GUID-307"
                               maxLength="4"
                               name="year"
                               onBlur={[Function]}
@@ -5707,7 +5707,7 @@ exports[`The identification section renders the Identification component for the
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="estimated-MOCK-GUID"
+                            id="estimated-MOCK-GUID-308"
                             name="estimated"
                             onBlur={[Function]}
                             onChange={[Function]}
@@ -5718,7 +5718,7 @@ exports[`The identification section renders the Identification component for the
                           />
                           <label
                             className="checkbox no-toggle"
-                            htmlFor="estimated-MOCK-GUID"
+                            htmlFor="estimated-MOCK-GUID-308"
                           >
                             <span>
                               Estimated
@@ -5782,13 +5782,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Provide your place of birth"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-309"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-309"
+                name="field-MOCK-GUID-309"
               />
               <h2
                 className="title h2"
@@ -5835,15 +5835,15 @@ exports[`The identification section renders the Identification component for the
                             >
                               <label
                                 className=""
-                                htmlFor="birthplace-MOCK-GUID"
+                                htmlFor="birthplace-MOCK-GUID-313"
                               >
                                 <input
                                   aria-label="Yes for null"
                                   checked={false}
                                   className="usa-input-success"
                                   disabled={false}
-                                  id="birthplace-MOCK-GUID"
-                                  name="birthplace-MOCK-GUID"
+                                  id="birthplace-MOCK-GUID-313"
+                                  name="birthplace-MOCK-GUID-313"
                                   onBlur={[Function]}
                                   onChange={[Function]}
                                   onClick={[Function]}
@@ -5862,15 +5862,15 @@ exports[`The identification section renders the Identification component for the
                             >
                               <label
                                 className=""
-                                htmlFor="birthplace-MOCK-GUID"
+                                htmlFor="birthplace-MOCK-GUID-314"
                               >
                                 <input
                                   aria-label="No for null"
                                   checked={false}
                                   className="usa-input-success"
                                   disabled={false}
-                                  id="birthplace-MOCK-GUID"
-                                  name="birthplace-MOCK-GUID"
+                                  id="birthplace-MOCK-GUID-314"
+                                  name="birthplace-MOCK-GUID-314"
                                   onBlur={[Function]}
                                   onChange={[Function]}
                                   onClick={[Function]}
@@ -5933,13 +5933,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Provide your U.S. Social Security Number"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-315"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-315"
+                name="field-MOCK-GUID-315"
               />
               <h2
                 className="title h2"
@@ -6004,7 +6004,7 @@ exports[`The identification section renders the Identification component for the
                           autoCorrect={true}
                           className=""
                           disabled={false}
-                          id="first-MOCK-GUID"
+                          id="first-MOCK-GUID-317"
                           maxLength="3"
                           name="first"
                           onBlur={[Function]}
@@ -6032,7 +6032,7 @@ exports[`The identification section renders the Identification component for the
                           autoCorrect={true}
                           className=""
                           disabled={false}
-                          id="middle-MOCK-GUID"
+                          id="middle-MOCK-GUID-318"
                           maxLength="2"
                           name="middle"
                           onBlur={[Function]}
@@ -6060,7 +6060,7 @@ exports[`The identification section renders the Identification component for the
                           autoCorrect={true}
                           className=""
                           disabled={false}
-                          id="last-MOCK-GUID"
+                          id="last-MOCK-GUID-319"
                           maxLength="4"
                           name="last"
                           onBlur={[Function]}
@@ -6087,7 +6087,7 @@ exports[`The identification section renders the Identification component for the
                             aria-label="Not applicable for null"
                             checked={false}
                             className="usa-input-success"
-                            id="notApplicable-MOCK-GUID"
+                            id="notApplicable-MOCK-GUID-320"
                             name="notApplicable"
                             onBlur={[Function]}
                             onChange={[Function]}
@@ -6098,7 +6098,7 @@ exports[`The identification section renders the Identification component for the
                           />
                           <label
                             className="checkbox no-toggle"
-                            htmlFor="notApplicable-MOCK-GUID"
+                            htmlFor="notApplicable-MOCK-GUID-320"
                           >
                             <span>
                               Not applicable
@@ -6152,13 +6152,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Provide your identifying information"
               className="field   no-margin-bottom"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-321"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-321"
+                name="field-MOCK-GUID-321"
               />
               <h2
                 className="title h2"
@@ -6200,13 +6200,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Height"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-322"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-322"
+                name="field-MOCK-GUID-322"
               />
               <h3
                 className="title h3"
@@ -6268,7 +6268,7 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className="usa-input-error-label"
-                            htmlFor="feet-MOCK-GUID"
+                            htmlFor="feet-MOCK-GUID-325"
                           >
                             Feet
                           </label>
@@ -6280,7 +6280,7 @@ exports[`The identification section renders the Identification component for the
                             autoCorrect={true}
                             className=""
                             disabled={false}
-                            id="feet-MOCK-GUID"
+                            id="feet-MOCK-GUID-325"
                             maxLength="1"
                             name="feet"
                             onBlur={[Function]}
@@ -6303,7 +6303,7 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className="usa-input-error-label"
-                            htmlFor="inches-MOCK-GUID"
+                            htmlFor="inches-MOCK-GUID-327"
                           >
                             Inches
                           </label>
@@ -6315,7 +6315,7 @@ exports[`The identification section renders the Identification component for the
                             autoCorrect={true}
                             className=""
                             disabled={false}
-                            id="inches-MOCK-GUID"
+                            id="inches-MOCK-GUID-327"
                             maxLength="2"
                             name="inches"
                             onBlur={[Function]}
@@ -6367,13 +6367,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Weight"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-328"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-328"
+                name="field-MOCK-GUID-328"
               />
               <h3
                 className="title h3"
@@ -6435,7 +6435,7 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className="usa-input-error-label"
-                            htmlFor="pounds-MOCK-GUID"
+                            htmlFor="pounds-MOCK-GUID-330"
                           >
                             Pounds
                           </label>
@@ -6447,7 +6447,7 @@ exports[`The identification section renders the Identification component for the
                             autoCorrect={true}
                             className=""
                             disabled={false}
-                            id="pounds-MOCK-GUID"
+                            id="pounds-MOCK-GUID-330"
                             maxLength="3"
                             name="pounds"
                             onBlur={[Function]}
@@ -6499,13 +6499,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Hair color"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-331"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-331"
+                name="field-MOCK-GUID-331"
               />
               <h3
                 className="title h3"
@@ -6568,15 +6568,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-black-MOCK-GUID"
+                            htmlFor="hair-black-MOCK-GUID-333"
                           >
                             <input
                               aria-label="Black for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-black-MOCK-GUID"
-                              name="hair-black-MOCK-GUID"
+                              id="hair-black-MOCK-GUID-333"
+                              name="hair-black-MOCK-GUID-333"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -6610,15 +6610,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-brown-MOCK-GUID"
+                            htmlFor="hair-brown-MOCK-GUID-334"
                           >
                             <input
                               aria-label="Brown for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-brown-MOCK-GUID"
-                              name="hair-brown-MOCK-GUID"
+                              id="hair-brown-MOCK-GUID-334"
+                              name="hair-brown-MOCK-GUID-334"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -6652,15 +6652,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-red-MOCK-GUID"
+                            htmlFor="hair-red-MOCK-GUID-335"
                           >
                             <input
                               aria-label="Red or auburn for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-red-MOCK-GUID"
-                              name="hair-red-MOCK-GUID"
+                              id="hair-red-MOCK-GUID-335"
+                              name="hair-red-MOCK-GUID-335"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -6694,15 +6694,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-blonde-MOCK-GUID"
+                            htmlFor="hair-blonde-MOCK-GUID-336"
                           >
                             <input
                               aria-label="Blonde or strawberry for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-blonde-MOCK-GUID"
-                              name="hair-blonde-MOCK-GUID"
+                              id="hair-blonde-MOCK-GUID-336"
+                              name="hair-blonde-MOCK-GUID-336"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -6736,15 +6736,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-sandy-MOCK-GUID"
+                            htmlFor="hair-sandy-MOCK-GUID-337"
                           >
                             <input
                               aria-label="Sandy for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-sandy-MOCK-GUID"
-                              name="hair-sandy-MOCK-GUID"
+                              id="hair-sandy-MOCK-GUID-337"
+                              name="hair-sandy-MOCK-GUID-337"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -6778,15 +6778,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-gray-MOCK-GUID"
+                            htmlFor="hair-gray-MOCK-GUID-338"
                           >
                             <input
                               aria-label="Gray or partially gray for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-gray-MOCK-GUID"
-                              name="hair-gray-MOCK-GUID"
+                              id="hair-gray-MOCK-GUID-338"
+                              name="hair-gray-MOCK-GUID-338"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -6820,15 +6820,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-white-MOCK-GUID"
+                            htmlFor="hair-white-MOCK-GUID-339"
                           >
                             <input
                               aria-label="White for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-white-MOCK-GUID"
-                              name="hair-white-MOCK-GUID"
+                              id="hair-white-MOCK-GUID-339"
+                              name="hair-white-MOCK-GUID-339"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -6862,15 +6862,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-bald-MOCK-GUID"
+                            htmlFor="hair-bald-MOCK-GUID-340"
                           >
                             <input
                               aria-label="Bald for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-bald-MOCK-GUID"
-                              name="hair-bald-MOCK-GUID"
+                              id="hair-bald-MOCK-GUID-340"
+                              name="hair-bald-MOCK-GUID-340"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -6912,15 +6912,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-blue-MOCK-GUID"
+                            htmlFor="hair-blue-MOCK-GUID-341"
                           >
                             <input
                               aria-label="Blue for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-blue-MOCK-GUID"
-                              name="hair-blue-MOCK-GUID"
+                              id="hair-blue-MOCK-GUID-341"
+                              name="hair-blue-MOCK-GUID-341"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -6954,15 +6954,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-green-MOCK-GUID"
+                            htmlFor="hair-green-MOCK-GUID-342"
                           >
                             <input
                               aria-label="Green for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-green-MOCK-GUID"
-                              name="hair-green-MOCK-GUID"
+                              id="hair-green-MOCK-GUID-342"
+                              name="hair-green-MOCK-GUID-342"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -6996,15 +6996,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-orange-MOCK-GUID"
+                            htmlFor="hair-orange-MOCK-GUID-343"
                           >
                             <input
                               aria-label="Orange for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-orange-MOCK-GUID"
-                              name="hair-orange-MOCK-GUID"
+                              id="hair-orange-MOCK-GUID-343"
+                              name="hair-orange-MOCK-GUID-343"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7038,15 +7038,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-pink-MOCK-GUID"
+                            htmlFor="hair-pink-MOCK-GUID-344"
                           >
                             <input
                               aria-label="Pink for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-pink-MOCK-GUID"
-                              name="hair-pink-MOCK-GUID"
+                              id="hair-pink-MOCK-GUID-344"
+                              name="hair-pink-MOCK-GUID-344"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7080,15 +7080,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-purple-MOCK-GUID"
+                            htmlFor="hair-purple-MOCK-GUID-345"
                           >
                             <input
                               aria-label="Purple for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-purple-MOCK-GUID"
-                              name="hair-purple-MOCK-GUID"
+                              id="hair-purple-MOCK-GUID-345"
+                              name="hair-purple-MOCK-GUID-345"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7122,15 +7122,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="hair-unknown-MOCK-GUID"
+                            htmlFor="hair-unknown-MOCK-GUID-346"
                           >
                             <input
                               aria-label="Unspecified or unknown for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="hair-unknown-MOCK-GUID"
-                              name="hair-unknown-MOCK-GUID"
+                              id="hair-unknown-MOCK-GUID-346"
+                              name="hair-unknown-MOCK-GUID-346"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7196,13 +7196,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Eye color"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-347"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-347"
+                name="field-MOCK-GUID-347"
               />
               <h3
                 className="title h3"
@@ -7265,15 +7265,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-brown-MOCK-GUID"
+                            htmlFor="eye-brown-MOCK-GUID-349"
                           >
                             <input
                               aria-label="Brown for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-brown-MOCK-GUID"
-                              name="eye-brown-MOCK-GUID"
+                              id="eye-brown-MOCK-GUID-349"
+                              name="eye-brown-MOCK-GUID-349"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7307,15 +7307,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-hazel-MOCK-GUID"
+                            htmlFor="eye-hazel-MOCK-GUID-350"
                           >
                             <input
                               aria-label="Hazel for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-hazel-MOCK-GUID"
-                              name="eye-hazel-MOCK-GUID"
+                              id="eye-hazel-MOCK-GUID-350"
+                              name="eye-hazel-MOCK-GUID-350"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7349,15 +7349,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-blue-MOCK-GUID"
+                            htmlFor="eye-blue-MOCK-GUID-351"
                           >
                             <input
                               aria-label="Blue for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-blue-MOCK-GUID"
-                              name="eye-blue-MOCK-GUID"
+                              id="eye-blue-MOCK-GUID-351"
+                              name="eye-blue-MOCK-GUID-351"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7391,15 +7391,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-green-MOCK-GUID"
+                            htmlFor="eye-green-MOCK-GUID-352"
                           >
                             <input
                               aria-label="Green for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-green-MOCK-GUID"
-                              name="eye-green-MOCK-GUID"
+                              id="eye-green-MOCK-GUID-352"
+                              name="eye-green-MOCK-GUID-352"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7433,15 +7433,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-gray-MOCK-GUID"
+                            htmlFor="eye-gray-MOCK-GUID-353"
                           >
                             <input
                               aria-label="Gray for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-gray-MOCK-GUID"
-                              name="eye-gray-MOCK-GUID"
+                              id="eye-gray-MOCK-GUID-353"
+                              name="eye-gray-MOCK-GUID-353"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7475,15 +7475,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-maroon-MOCK-GUID"
+                            htmlFor="eye-maroon-MOCK-GUID-354"
                           >
                             <input
                               aria-label="Maroon for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-maroon-MOCK-GUID"
-                              name="eye-maroon-MOCK-GUID"
+                              id="eye-maroon-MOCK-GUID-354"
+                              name="eye-maroon-MOCK-GUID-354"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7517,15 +7517,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-black-MOCK-GUID"
+                            htmlFor="eye-black-MOCK-GUID-355"
                           >
                             <input
                               aria-label="Black for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-black-MOCK-GUID"
-                              name="eye-black-MOCK-GUID"
+                              id="eye-black-MOCK-GUID-355"
+                              name="eye-black-MOCK-GUID-355"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7559,15 +7559,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-multi-MOCK-GUID"
+                            htmlFor="eye-multi-MOCK-GUID-356"
                           >
                             <input
                               aria-label="Multicolored for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-multi-MOCK-GUID"
-                              name="eye-multi-MOCK-GUID"
+                              id="eye-multi-MOCK-GUID-356"
+                              name="eye-multi-MOCK-GUID-356"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7595,15 +7595,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-pink-MOCK-GUID"
+                            htmlFor="eye-pink-MOCK-GUID-357"
                           >
                             <input
                               aria-label="Pink for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-pink-MOCK-GUID"
-                              name="eye-pink-MOCK-GUID"
+                              id="eye-pink-MOCK-GUID-357"
+                              name="eye-pink-MOCK-GUID-357"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7637,15 +7637,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="eye-unknown-MOCK-GUID"
+                            htmlFor="eye-unknown-MOCK-GUID-358"
                           >
                             <input
                               aria-label="Unknown for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="eye-unknown-MOCK-GUID"
-                              name="eye-unknown-MOCK-GUID"
+                              id="eye-unknown-MOCK-GUID-358"
+                              name="eye-unknown-MOCK-GUID-358"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7711,13 +7711,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Select your sex"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-359"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-359"
+                name="field-MOCK-GUID-359"
               />
               <h3
                 className="title h3"
@@ -7780,15 +7780,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="sex-MOCK-GUID"
+                            htmlFor="sex-MOCK-GUID-361"
                           >
                             <input
                               aria-label="Female for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="sex-MOCK-GUID"
-                              name="sex-MOCK-GUID"
+                              id="sex-MOCK-GUID-361"
+                              name="sex-MOCK-GUID-361"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7821,15 +7821,15 @@ exports[`The identification section renders the Identification component for the
                         >
                           <label
                             className=""
-                            htmlFor="sex-MOCK-GUID"
+                            htmlFor="sex-MOCK-GUID-362"
                           >
                             <input
                               aria-label="Male for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="sex-MOCK-GUID"
-                              name="sex-MOCK-GUID"
+                              id="sex-MOCK-GUID-362"
+                              name="sex-MOCK-GUID-362"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -7911,13 +7911,13 @@ exports[`The identification section renders the Identification component for the
           <div
             aria-label="Add a comment to clarify any of your responses in the information about you section"
             className="field   section-comment"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-363"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-363"
+              name="field-MOCK-GUID-363"
             />
             <h4
               className="title h4"
@@ -7959,7 +7959,7 @@ exports[`The identification section renders the Identification component for the
                       autoComplete={true}
                       autoCorrect={true}
                       className=""
-                      id="Comments-MOCK-GUID"
+                      id="Comments-MOCK-GUID-364"
                       maxLength={255}
                       name="Comments"
                       onBlur={[Function]}
@@ -8091,13 +8091,13 @@ exports[`The identification section renders the Identification component for the
             <div
               aria-label="Provide your U.S. Social Security Number"
               className="field required"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-215"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-215"
+                name="field-MOCK-GUID-215"
               />
               <h2
                 className="title h2"
@@ -8162,7 +8162,7 @@ exports[`The identification section renders the Identification component for the
                           autoCorrect={true}
                           className=""
                           disabled={false}
-                          id="first-MOCK-GUID"
+                          id="first-MOCK-GUID-217"
                           maxLength="3"
                           name="first"
                           onBlur={[Function]}
@@ -8190,7 +8190,7 @@ exports[`The identification section renders the Identification component for the
                           autoCorrect={true}
                           className=""
                           disabled={false}
-                          id="middle-MOCK-GUID"
+                          id="middle-MOCK-GUID-218"
                           maxLength="2"
                           name="middle"
                           onBlur={[Function]}
@@ -8218,7 +8218,7 @@ exports[`The identification section renders the Identification component for the
                           autoCorrect={true}
                           className=""
                           disabled={false}
-                          id="last-MOCK-GUID"
+                          id="last-MOCK-GUID-219"
                           maxLength="4"
                           name="last"
                           onBlur={[Function]}
@@ -8245,7 +8245,7 @@ exports[`The identification section renders the Identification component for the
                             aria-label="Not applicable for null"
                             checked={false}
                             className="usa-input-success"
-                            id="notApplicable-MOCK-GUID"
+                            id="notApplicable-MOCK-GUID-220"
                             name="notApplicable"
                             onBlur={[Function]}
                             onChange={[Function]}
@@ -8256,7 +8256,7 @@ exports[`The identification section renders the Identification component for the
                           />
                           <label
                             className="checkbox no-toggle"
-                            htmlFor="notApplicable-MOCK-GUID"
+                            htmlFor="notApplicable-MOCK-GUID-220"
                           >
                             <span>
                               Not applicable
@@ -8377,13 +8377,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Provide your full name"
       className="field"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-375"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-375"
+        name="field-MOCK-GUID-375"
       />
       <h2
         className="title h2"
@@ -8416,13 +8416,13 @@ exports[`The identification section renders the IdentificationSections component
               <div
                 aria-label="First name"
                 className="field required"
-                data-uuid="field-MOCK-GUID"
+                data-uuid="field-MOCK-GUID-377"
               >
                 <a
                   aria-hidden="true"
                   className="anchor"
-                  id="field-MOCK-GUID"
-                  name="field-MOCK-GUID"
+                  id="field-MOCK-GUID-377"
+                  name="field-MOCK-GUID-377"
                 />
                 <label
                   className="title label"
@@ -8483,7 +8483,7 @@ exports[`The identification section renders the IdentificationSections component
                           autoComplete={true}
                           autoCorrect={true}
                           className=""
-                          id="first-MOCK-GUID"
+                          id="first-MOCK-GUID-378"
                           maxLength="100"
                           name="first"
                           onBlur={[Function]}
@@ -8506,7 +8506,7 @@ exports[`The identification section renders the IdentificationSections component
                             aria-label="Initial only for null"
                             checked={false}
                             className="usa-input-success"
-                            id="firstInitialOnly-MOCK-GUID"
+                            id="firstInitialOnly-MOCK-GUID-379"
                             name="firstInitialOnly"
                             onBlur={[Function]}
                             onChange={[Function]}
@@ -8517,7 +8517,7 @@ exports[`The identification section renders the IdentificationSections component
                           />
                           <label
                             className="checkbox no-toggle"
-                            htmlFor="firstInitialOnly-MOCK-GUID"
+                            htmlFor="firstInitialOnly-MOCK-GUID-379"
                           >
                             <span>
                               Initial only
@@ -8541,13 +8541,13 @@ exports[`The identification section renders the IdentificationSections component
               <div
                 aria-label="Middle name"
                 className="field required"
-                data-uuid="field-MOCK-GUID"
+                data-uuid="field-MOCK-GUID-380"
               >
                 <a
                   aria-hidden="true"
                   className="anchor"
-                  id="field-MOCK-GUID"
-                  name="field-MOCK-GUID"
+                  id="field-MOCK-GUID-380"
+                  name="field-MOCK-GUID-380"
                 />
                 <label
                   className="title label"
@@ -8608,7 +8608,7 @@ exports[`The identification section renders the IdentificationSections component
                           autoComplete={true}
                           autoCorrect={true}
                           className=""
-                          id="middle-MOCK-GUID"
+                          id="middle-MOCK-GUID-381"
                           maxLength="100"
                           name="middle"
                           onBlur={[Function]}
@@ -8631,7 +8631,7 @@ exports[`The identification section renders the IdentificationSections component
                             aria-label="No middle name for null"
                             checked={false}
                             className="usa-input-success"
-                            id="noMiddleName-MOCK-GUID"
+                            id="noMiddleName-MOCK-GUID-382"
                             name="noMiddleName"
                             onBlur={[Function]}
                             onChange={[Function]}
@@ -8642,7 +8642,7 @@ exports[`The identification section renders the IdentificationSections component
                           />
                           <label
                             className="checkbox no-toggle"
-                            htmlFor="noMiddleName-MOCK-GUID"
+                            htmlFor="noMiddleName-MOCK-GUID-382"
                           >
                             <span>
                               No middle name
@@ -8656,7 +8656,7 @@ exports[`The identification section renders the IdentificationSections component
                             aria-label="Initial only for null"
                             checked={false}
                             className="usa-input-success"
-                            id="middleInitialOnly-MOCK-GUID"
+                            id="middleInitialOnly-MOCK-GUID-383"
                             name="middleInitialOnly"
                             onBlur={[Function]}
                             onChange={[Function]}
@@ -8667,7 +8667,7 @@ exports[`The identification section renders the IdentificationSections component
                           />
                           <label
                             className="checkbox no-toggle"
-                            htmlFor="middleInitialOnly-MOCK-GUID"
+                            htmlFor="middleInitialOnly-MOCK-GUID-383"
                           >
                             <span>
                               Initial only
@@ -8691,13 +8691,13 @@ exports[`The identification section renders the IdentificationSections component
               <div
                 aria-label="Last name"
                 className="field required"
-                data-uuid="field-MOCK-GUID"
+                data-uuid="field-MOCK-GUID-384"
               >
                 <a
                   aria-hidden="true"
                   className="anchor"
-                  id="field-MOCK-GUID"
-                  name="field-MOCK-GUID"
+                  id="field-MOCK-GUID-384"
+                  name="field-MOCK-GUID-384"
                 />
                 <label
                   className="title label"
@@ -8758,7 +8758,7 @@ exports[`The identification section renders the IdentificationSections component
                           autoComplete={true}
                           autoCorrect={true}
                           className=""
-                          id="last-MOCK-GUID"
+                          id="last-MOCK-GUID-385"
                           maxLength="100"
                           name="last"
                           onBlur={[Function]}
@@ -8781,7 +8781,7 @@ exports[`The identification section renders the IdentificationSections component
                             aria-label="Initial only for null"
                             checked={false}
                             className="usa-input-success"
-                            id="lastInitialOnly-MOCK-GUID"
+                            id="lastInitialOnly-MOCK-GUID-386"
                             name="lastInitialOnly"
                             onBlur={[Function]}
                             onChange={[Function]}
@@ -8792,7 +8792,7 @@ exports[`The identification section renders the IdentificationSections component
                           />
                           <label
                             className="checkbox no-toggle"
-                            htmlFor="lastInitialOnly-MOCK-GUID"
+                            htmlFor="lastInitialOnly-MOCK-GUID-386"
                           >
                             <span>
                               Initial only
@@ -8816,13 +8816,13 @@ exports[`The identification section renders the IdentificationSections component
               <div
                 aria-label="Suffix"
                 className="field"
-                data-uuid="field-MOCK-GUID"
+                data-uuid="field-MOCK-GUID-387"
               >
                 <a
                   aria-hidden="true"
                   className="anchor"
-                  id="field-MOCK-GUID"
-                  name="field-MOCK-GUID"
+                  id="field-MOCK-GUID-387"
+                  name="field-MOCK-GUID-387"
                 />
                 <label
                   className="title label"
@@ -8886,15 +8886,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-MOCK-GUID"
+                            htmlFor="suffix-MOCK-GUID-389"
                           >
                             <input
                               aria-label="Jr for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-MOCK-GUID"
-                              name="suffix-MOCK-GUID"
+                              id="suffix-MOCK-GUID-389"
+                              name="suffix-MOCK-GUID-389"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -8913,15 +8913,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-MOCK-GUID"
+                            htmlFor="suffix-MOCK-GUID-390"
                           >
                             <input
                               aria-label="Sr for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-MOCK-GUID"
-                              name="suffix-MOCK-GUID"
+                              id="suffix-MOCK-GUID-390"
+                              name="suffix-MOCK-GUID-390"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -8940,15 +8940,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-MOCK-GUID"
+                            htmlFor="suffix-MOCK-GUID-391"
                           >
                             <input
                               aria-label="I for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-MOCK-GUID"
-                              name="suffix-MOCK-GUID"
+                              id="suffix-MOCK-GUID-391"
+                              name="suffix-MOCK-GUID-391"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -8967,15 +8967,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-MOCK-GUID"
+                            htmlFor="suffix-MOCK-GUID-392"
                           >
                             <input
                               aria-label="II for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-MOCK-GUID"
-                              name="suffix-MOCK-GUID"
+                              id="suffix-MOCK-GUID-392"
+                              name="suffix-MOCK-GUID-392"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -8994,15 +8994,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-MOCK-GUID"
+                            htmlFor="suffix-MOCK-GUID-393"
                           >
                             <input
                               aria-label="III for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-MOCK-GUID"
-                              name="suffix-MOCK-GUID"
+                              id="suffix-MOCK-GUID-393"
+                              name="suffix-MOCK-GUID-393"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -9021,15 +9021,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-MOCK-GUID"
+                            htmlFor="suffix-MOCK-GUID-394"
                           >
                             <input
                               aria-label="IV for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-MOCK-GUID"
-                              name="suffix-MOCK-GUID"
+                              id="suffix-MOCK-GUID-394"
+                              name="suffix-MOCK-GUID-394"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -9048,15 +9048,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-MOCK-GUID"
+                            htmlFor="suffix-MOCK-GUID-395"
                           >
                             <input
                               aria-label="V for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-MOCK-GUID"
-                              name="suffix-MOCK-GUID"
+                              id="suffix-MOCK-GUID-395"
+                              name="suffix-MOCK-GUID-395"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -9075,15 +9075,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-MOCK-GUID"
+                            htmlFor="suffix-MOCK-GUID-396"
                           >
                             <input
                               aria-label="VI for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-MOCK-GUID"
-                              name="suffix-MOCK-GUID"
+                              id="suffix-MOCK-GUID-396"
+                              name="suffix-MOCK-GUID-396"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -9102,15 +9102,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-MOCK-GUID"
+                            htmlFor="suffix-MOCK-GUID-397"
                           >
                             <input
                               aria-label="VII for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-MOCK-GUID"
-                              name="suffix-MOCK-GUID"
+                              id="suffix-MOCK-GUID-397"
+                              name="suffix-MOCK-GUID-397"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -9129,15 +9129,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-MOCK-GUID"
+                            htmlFor="suffix-MOCK-GUID-398"
                           >
                             <input
                               aria-label="VIII for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-MOCK-GUID"
-                              name="suffix-MOCK-GUID"
+                              id="suffix-MOCK-GUID-398"
+                              name="suffix-MOCK-GUID-398"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -9156,15 +9156,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-MOCK-GUID"
+                            htmlFor="suffix-MOCK-GUID-399"
                           >
                             <input
                               aria-label="IX for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-MOCK-GUID"
-                              name="suffix-MOCK-GUID"
+                              id="suffix-MOCK-GUID-399"
+                              name="suffix-MOCK-GUID-399"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -9183,15 +9183,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-MOCK-GUID"
+                            htmlFor="suffix-MOCK-GUID-400"
                           >
                             <input
                               aria-label="X for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-MOCK-GUID"
-                              name="suffix-MOCK-GUID"
+                              id="suffix-MOCK-GUID-400"
+                              name="suffix-MOCK-GUID-400"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -9210,15 +9210,15 @@ exports[`The identification section renders the IdentificationSections component
                         >
                           <label
                             className=""
-                            htmlFor="suffix-MOCK-GUID"
+                            htmlFor="suffix-MOCK-GUID-401"
                           >
                             <input
                               aria-label="Other for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="suffix-MOCK-GUID"
-                              name="suffix-MOCK-GUID"
+                              id="suffix-MOCK-GUID-401"
+                              name="suffix-MOCK-GUID-401"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -9298,13 +9298,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Provide your other names used and the period of time you used them"
       className="field   no-margin-bottom"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-402"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-402"
+        name="field-MOCK-GUID-402"
       />
       <h2
         className="title h2"
@@ -9376,13 +9376,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Have you used any other names?"
       className="field required  branch"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-403"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-403"
+        name="field-MOCK-GUID-403"
       />
       <h3
         className="title h3"
@@ -9420,15 +9420,15 @@ exports[`The identification section renders the IdentificationSections component
               >
                 <label
                   className=""
-                  htmlFor="has_othernames-MOCK-GUID"
+                  htmlFor="has_othernames-MOCK-GUID-405"
                 >
                   <input
                     aria-label="Yes for null"
                     checked={false}
                     className="usa-input-success"
                     disabled={false}
-                    id="has_othernames-MOCK-GUID"
-                    name="has_othernames-MOCK-GUID"
+                    id="has_othernames-MOCK-GUID-405"
+                    name="has_othernames-MOCK-GUID-405"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onClick={[Function]}
@@ -9447,15 +9447,15 @@ exports[`The identification section renders the IdentificationSections component
               >
                 <label
                   className=""
-                  htmlFor="has_othernames-MOCK-GUID"
+                  htmlFor="has_othernames-MOCK-GUID-406"
                 >
                   <input
                     aria-label="No for null"
                     checked={false}
                     className="usa-input-success"
                     disabled={false}
-                    id="has_othernames-MOCK-GUID"
-                    name="has_othernames-MOCK-GUID"
+                    id="has_othernames-MOCK-GUID-406"
+                    name="has_othernames-MOCK-GUID-406"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onClick={[Function]}
@@ -9515,13 +9515,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Provide your contact information"
       className="field   no-margin-bottom"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-407"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-407"
+        name="field-MOCK-GUID-407"
       />
       <h2
         className="title h2"
@@ -9563,13 +9563,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Your email addresses"
       className="field   no-margin-bottom"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-408"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-408"
+        name="field-MOCK-GUID-408"
       />
       <h3
         className="title h3"
@@ -9672,13 +9672,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Your phone numbers"
       className="field   no-margin-bottom"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-410"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-410"
+        name="field-MOCK-GUID-410"
       />
       <h3
         className="title h3"
@@ -9794,13 +9794,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Provide your date of birth"
       className="field required"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-412"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-412"
+        name="field-MOCK-GUID-412"
       />
       <h2
         className="title h2"
@@ -9863,7 +9863,7 @@ exports[`The identification section renders the IdentificationSections component
                   >
                     <label
                       className="usa-input-error-label"
-                      htmlFor="month-MOCK-GUID"
+                      htmlFor="month-MOCK-GUID-415"
                     >
                       Month
                     </label>
@@ -9875,7 +9875,7 @@ exports[`The identification section renders the IdentificationSections component
                       autoCorrect={true}
                       className=""
                       disabled={false}
-                      id="month-MOCK-GUID"
+                      id="month-MOCK-GUID-415"
                       maxLength="2"
                       name="month"
                       onBlur={[Function]}
@@ -9898,7 +9898,7 @@ exports[`The identification section renders the IdentificationSections component
                   >
                     <label
                       className="usa-input-error-label"
-                      htmlFor="day-MOCK-GUID"
+                      htmlFor="day-MOCK-GUID-417"
                     >
                       Day
                     </label>
@@ -9910,7 +9910,7 @@ exports[`The identification section renders the IdentificationSections component
                       autoCorrect={true}
                       className=""
                       disabled={false}
-                      id="day-MOCK-GUID"
+                      id="day-MOCK-GUID-417"
                       maxLength="2"
                       name="day"
                       onBlur={[Function]}
@@ -9933,7 +9933,7 @@ exports[`The identification section renders the IdentificationSections component
                   >
                     <label
                       className="usa-input-error-label"
-                      htmlFor="year-MOCK-GUID"
+                      htmlFor="year-MOCK-GUID-419"
                     >
                       Year
                     </label>
@@ -9945,7 +9945,7 @@ exports[`The identification section renders the IdentificationSections component
                       autoCorrect={true}
                       className=""
                       disabled={false}
-                      id="year-MOCK-GUID"
+                      id="year-MOCK-GUID-419"
                       maxLength="4"
                       name="year"
                       onBlur={[Function]}
@@ -9972,7 +9972,7 @@ exports[`The identification section renders the IdentificationSections component
                     checked={false}
                     className="usa-input-success"
                     disabled={false}
-                    id="estimated-MOCK-GUID"
+                    id="estimated-MOCK-GUID-420"
                     name="estimated"
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -9983,7 +9983,7 @@ exports[`The identification section renders the IdentificationSections component
                   />
                   <label
                     className="checkbox no-toggle"
-                    htmlFor="estimated-MOCK-GUID"
+                    htmlFor="estimated-MOCK-GUID-420"
                   >
                     <span>
                       Estimated
@@ -10047,13 +10047,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Provide your place of birth"
       className="field required"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-421"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-421"
+        name="field-MOCK-GUID-421"
       />
       <h2
         className="title h2"
@@ -10100,15 +10100,15 @@ exports[`The identification section renders the IdentificationSections component
                     >
                       <label
                         className=""
-                        htmlFor="birthplace-MOCK-GUID"
+                        htmlFor="birthplace-MOCK-GUID-425"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="birthplace-MOCK-GUID"
-                          name="birthplace-MOCK-GUID"
+                          id="birthplace-MOCK-GUID-425"
+                          name="birthplace-MOCK-GUID-425"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -10127,15 +10127,15 @@ exports[`The identification section renders the IdentificationSections component
                     >
                       <label
                         className=""
-                        htmlFor="birthplace-MOCK-GUID"
+                        htmlFor="birthplace-MOCK-GUID-426"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="birthplace-MOCK-GUID"
-                          name="birthplace-MOCK-GUID"
+                          id="birthplace-MOCK-GUID-426"
+                          name="birthplace-MOCK-GUID-426"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -10198,13 +10198,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Provide your U.S. Social Security Number"
       className="field required"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-427"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-427"
+        name="field-MOCK-GUID-427"
       />
       <h2
         className="title h2"
@@ -10269,7 +10269,7 @@ exports[`The identification section renders the IdentificationSections component
                   autoCorrect={true}
                   className=""
                   disabled={false}
-                  id="first-MOCK-GUID"
+                  id="first-MOCK-GUID-429"
                   maxLength="3"
                   name="first"
                   onBlur={[Function]}
@@ -10297,7 +10297,7 @@ exports[`The identification section renders the IdentificationSections component
                   autoCorrect={true}
                   className=""
                   disabled={false}
-                  id="middle-MOCK-GUID"
+                  id="middle-MOCK-GUID-430"
                   maxLength="2"
                   name="middle"
                   onBlur={[Function]}
@@ -10325,7 +10325,7 @@ exports[`The identification section renders the IdentificationSections component
                   autoCorrect={true}
                   className=""
                   disabled={false}
-                  id="last-MOCK-GUID"
+                  id="last-MOCK-GUID-431"
                   maxLength="4"
                   name="last"
                   onBlur={[Function]}
@@ -10352,7 +10352,7 @@ exports[`The identification section renders the IdentificationSections component
                     aria-label="Not applicable for null"
                     checked={false}
                     className="usa-input-success"
-                    id="notApplicable-MOCK-GUID"
+                    id="notApplicable-MOCK-GUID-432"
                     name="notApplicable"
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -10363,7 +10363,7 @@ exports[`The identification section renders the IdentificationSections component
                   />
                   <label
                     className="checkbox no-toggle"
-                    htmlFor="notApplicable-MOCK-GUID"
+                    htmlFor="notApplicable-MOCK-GUID-432"
                   >
                     <span>
                       Not applicable
@@ -10417,13 +10417,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Provide your identifying information"
       className="field   no-margin-bottom"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-433"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-433"
+        name="field-MOCK-GUID-433"
       />
       <h2
         className="title h2"
@@ -10465,13 +10465,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Height"
       className="field required"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-434"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-434"
+        name="field-MOCK-GUID-434"
       />
       <h3
         className="title h3"
@@ -10533,7 +10533,7 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className="usa-input-error-label"
-                    htmlFor="feet-MOCK-GUID"
+                    htmlFor="feet-MOCK-GUID-437"
                   >
                     Feet
                   </label>
@@ -10545,7 +10545,7 @@ exports[`The identification section renders the IdentificationSections component
                     autoCorrect={true}
                     className=""
                     disabled={false}
-                    id="feet-MOCK-GUID"
+                    id="feet-MOCK-GUID-437"
                     maxLength="1"
                     name="feet"
                     onBlur={[Function]}
@@ -10568,7 +10568,7 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className="usa-input-error-label"
-                    htmlFor="inches-MOCK-GUID"
+                    htmlFor="inches-MOCK-GUID-439"
                   >
                     Inches
                   </label>
@@ -10580,7 +10580,7 @@ exports[`The identification section renders the IdentificationSections component
                     autoCorrect={true}
                     className=""
                     disabled={false}
-                    id="inches-MOCK-GUID"
+                    id="inches-MOCK-GUID-439"
                     maxLength="2"
                     name="inches"
                     onBlur={[Function]}
@@ -10632,13 +10632,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Weight"
       className="field required"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-440"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-440"
+        name="field-MOCK-GUID-440"
       />
       <h3
         className="title h3"
@@ -10700,7 +10700,7 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className="usa-input-error-label"
-                    htmlFor="pounds-MOCK-GUID"
+                    htmlFor="pounds-MOCK-GUID-442"
                   >
                     Pounds
                   </label>
@@ -10712,7 +10712,7 @@ exports[`The identification section renders the IdentificationSections component
                     autoCorrect={true}
                     className=""
                     disabled={false}
-                    id="pounds-MOCK-GUID"
+                    id="pounds-MOCK-GUID-442"
                     maxLength="3"
                     name="pounds"
                     onBlur={[Function]}
@@ -10764,13 +10764,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Hair color"
       className="field required"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-443"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-443"
+        name="field-MOCK-GUID-443"
       />
       <h3
         className="title h3"
@@ -10833,15 +10833,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-black-MOCK-GUID"
+                    htmlFor="hair-black-MOCK-GUID-445"
                   >
                     <input
                       aria-label="Black for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-black-MOCK-GUID"
-                      name="hair-black-MOCK-GUID"
+                      id="hair-black-MOCK-GUID-445"
+                      name="hair-black-MOCK-GUID-445"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -10875,15 +10875,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-brown-MOCK-GUID"
+                    htmlFor="hair-brown-MOCK-GUID-446"
                   >
                     <input
                       aria-label="Brown for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-brown-MOCK-GUID"
-                      name="hair-brown-MOCK-GUID"
+                      id="hair-brown-MOCK-GUID-446"
+                      name="hair-brown-MOCK-GUID-446"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -10917,15 +10917,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-red-MOCK-GUID"
+                    htmlFor="hair-red-MOCK-GUID-447"
                   >
                     <input
                       aria-label="Red or auburn for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-red-MOCK-GUID"
-                      name="hair-red-MOCK-GUID"
+                      id="hair-red-MOCK-GUID-447"
+                      name="hair-red-MOCK-GUID-447"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -10959,15 +10959,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-blonde-MOCK-GUID"
+                    htmlFor="hair-blonde-MOCK-GUID-448"
                   >
                     <input
                       aria-label="Blonde or strawberry for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-blonde-MOCK-GUID"
-                      name="hair-blonde-MOCK-GUID"
+                      id="hair-blonde-MOCK-GUID-448"
+                      name="hair-blonde-MOCK-GUID-448"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11001,15 +11001,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-sandy-MOCK-GUID"
+                    htmlFor="hair-sandy-MOCK-GUID-449"
                   >
                     <input
                       aria-label="Sandy for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-sandy-MOCK-GUID"
-                      name="hair-sandy-MOCK-GUID"
+                      id="hair-sandy-MOCK-GUID-449"
+                      name="hair-sandy-MOCK-GUID-449"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11043,15 +11043,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-gray-MOCK-GUID"
+                    htmlFor="hair-gray-MOCK-GUID-450"
                   >
                     <input
                       aria-label="Gray or partially gray for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-gray-MOCK-GUID"
-                      name="hair-gray-MOCK-GUID"
+                      id="hair-gray-MOCK-GUID-450"
+                      name="hair-gray-MOCK-GUID-450"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11085,15 +11085,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-white-MOCK-GUID"
+                    htmlFor="hair-white-MOCK-GUID-451"
                   >
                     <input
                       aria-label="White for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-white-MOCK-GUID"
-                      name="hair-white-MOCK-GUID"
+                      id="hair-white-MOCK-GUID-451"
+                      name="hair-white-MOCK-GUID-451"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11127,15 +11127,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-bald-MOCK-GUID"
+                    htmlFor="hair-bald-MOCK-GUID-452"
                   >
                     <input
                       aria-label="Bald for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-bald-MOCK-GUID"
-                      name="hair-bald-MOCK-GUID"
+                      id="hair-bald-MOCK-GUID-452"
+                      name="hair-bald-MOCK-GUID-452"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11177,15 +11177,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-blue-MOCK-GUID"
+                    htmlFor="hair-blue-MOCK-GUID-453"
                   >
                     <input
                       aria-label="Blue for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-blue-MOCK-GUID"
-                      name="hair-blue-MOCK-GUID"
+                      id="hair-blue-MOCK-GUID-453"
+                      name="hair-blue-MOCK-GUID-453"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11219,15 +11219,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-green-MOCK-GUID"
+                    htmlFor="hair-green-MOCK-GUID-454"
                   >
                     <input
                       aria-label="Green for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-green-MOCK-GUID"
-                      name="hair-green-MOCK-GUID"
+                      id="hair-green-MOCK-GUID-454"
+                      name="hair-green-MOCK-GUID-454"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11261,15 +11261,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-orange-MOCK-GUID"
+                    htmlFor="hair-orange-MOCK-GUID-455"
                   >
                     <input
                       aria-label="Orange for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-orange-MOCK-GUID"
-                      name="hair-orange-MOCK-GUID"
+                      id="hair-orange-MOCK-GUID-455"
+                      name="hair-orange-MOCK-GUID-455"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11303,15 +11303,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-pink-MOCK-GUID"
+                    htmlFor="hair-pink-MOCK-GUID-456"
                   >
                     <input
                       aria-label="Pink for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-pink-MOCK-GUID"
-                      name="hair-pink-MOCK-GUID"
+                      id="hair-pink-MOCK-GUID-456"
+                      name="hair-pink-MOCK-GUID-456"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11345,15 +11345,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-purple-MOCK-GUID"
+                    htmlFor="hair-purple-MOCK-GUID-457"
                   >
                     <input
                       aria-label="Purple for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-purple-MOCK-GUID"
-                      name="hair-purple-MOCK-GUID"
+                      id="hair-purple-MOCK-GUID-457"
+                      name="hair-purple-MOCK-GUID-457"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11387,15 +11387,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="hair-unknown-MOCK-GUID"
+                    htmlFor="hair-unknown-MOCK-GUID-458"
                   >
                     <input
                       aria-label="Unspecified or unknown for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="hair-unknown-MOCK-GUID"
-                      name="hair-unknown-MOCK-GUID"
+                      id="hair-unknown-MOCK-GUID-458"
+                      name="hair-unknown-MOCK-GUID-458"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11461,13 +11461,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Eye color"
       className="field required"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-459"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-459"
+        name="field-MOCK-GUID-459"
       />
       <h3
         className="title h3"
@@ -11530,15 +11530,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-brown-MOCK-GUID"
+                    htmlFor="eye-brown-MOCK-GUID-461"
                   >
                     <input
                       aria-label="Brown for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-brown-MOCK-GUID"
-                      name="eye-brown-MOCK-GUID"
+                      id="eye-brown-MOCK-GUID-461"
+                      name="eye-brown-MOCK-GUID-461"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11572,15 +11572,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-hazel-MOCK-GUID"
+                    htmlFor="eye-hazel-MOCK-GUID-462"
                   >
                     <input
                       aria-label="Hazel for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-hazel-MOCK-GUID"
-                      name="eye-hazel-MOCK-GUID"
+                      id="eye-hazel-MOCK-GUID-462"
+                      name="eye-hazel-MOCK-GUID-462"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11614,15 +11614,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-blue-MOCK-GUID"
+                    htmlFor="eye-blue-MOCK-GUID-463"
                   >
                     <input
                       aria-label="Blue for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-blue-MOCK-GUID"
-                      name="eye-blue-MOCK-GUID"
+                      id="eye-blue-MOCK-GUID-463"
+                      name="eye-blue-MOCK-GUID-463"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11656,15 +11656,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-green-MOCK-GUID"
+                    htmlFor="eye-green-MOCK-GUID-464"
                   >
                     <input
                       aria-label="Green for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-green-MOCK-GUID"
-                      name="eye-green-MOCK-GUID"
+                      id="eye-green-MOCK-GUID-464"
+                      name="eye-green-MOCK-GUID-464"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11698,15 +11698,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-gray-MOCK-GUID"
+                    htmlFor="eye-gray-MOCK-GUID-465"
                   >
                     <input
                       aria-label="Gray for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-gray-MOCK-GUID"
-                      name="eye-gray-MOCK-GUID"
+                      id="eye-gray-MOCK-GUID-465"
+                      name="eye-gray-MOCK-GUID-465"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11740,15 +11740,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-maroon-MOCK-GUID"
+                    htmlFor="eye-maroon-MOCK-GUID-466"
                   >
                     <input
                       aria-label="Maroon for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-maroon-MOCK-GUID"
-                      name="eye-maroon-MOCK-GUID"
+                      id="eye-maroon-MOCK-GUID-466"
+                      name="eye-maroon-MOCK-GUID-466"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11782,15 +11782,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-black-MOCK-GUID"
+                    htmlFor="eye-black-MOCK-GUID-467"
                   >
                     <input
                       aria-label="Black for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-black-MOCK-GUID"
-                      name="eye-black-MOCK-GUID"
+                      id="eye-black-MOCK-GUID-467"
+                      name="eye-black-MOCK-GUID-467"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11824,15 +11824,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-multi-MOCK-GUID"
+                    htmlFor="eye-multi-MOCK-GUID-468"
                   >
                     <input
                       aria-label="Multicolored for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-multi-MOCK-GUID"
-                      name="eye-multi-MOCK-GUID"
+                      id="eye-multi-MOCK-GUID-468"
+                      name="eye-multi-MOCK-GUID-468"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11860,15 +11860,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-pink-MOCK-GUID"
+                    htmlFor="eye-pink-MOCK-GUID-469"
                   >
                     <input
                       aria-label="Pink for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-pink-MOCK-GUID"
-                      name="eye-pink-MOCK-GUID"
+                      id="eye-pink-MOCK-GUID-469"
+                      name="eye-pink-MOCK-GUID-469"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11902,15 +11902,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="eye-unknown-MOCK-GUID"
+                    htmlFor="eye-unknown-MOCK-GUID-470"
                   >
                     <input
                       aria-label="Unknown for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="eye-unknown-MOCK-GUID"
-                      name="eye-unknown-MOCK-GUID"
+                      id="eye-unknown-MOCK-GUID-470"
+                      name="eye-unknown-MOCK-GUID-470"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -11976,13 +11976,13 @@ exports[`The identification section renders the IdentificationSections component
     <div
       aria-label="Select your sex"
       className="field required"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-471"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-471"
+        name="field-MOCK-GUID-471"
       />
       <h3
         className="title h3"
@@ -12045,15 +12045,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="sex-MOCK-GUID"
+                    htmlFor="sex-MOCK-GUID-473"
                   >
                     <input
                       aria-label="Female for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="sex-MOCK-GUID"
-                      name="sex-MOCK-GUID"
+                      id="sex-MOCK-GUID-473"
+                      name="sex-MOCK-GUID-473"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -12086,15 +12086,15 @@ exports[`The identification section renders the IdentificationSections component
                 >
                   <label
                     className=""
-                    htmlFor="sex-MOCK-GUID"
+                    htmlFor="sex-MOCK-GUID-474"
                   >
                     <input
                       aria-label="Male for null"
                       checked={false}
                       className="usa-input-success"
                       disabled={false}
-                      id="sex-MOCK-GUID"
-                      name="sex-MOCK-GUID"
+                      id="sex-MOCK-GUID-474"
+                      name="sex-MOCK-GUID-474"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}
@@ -12176,13 +12176,13 @@ exports[`The identification section renders the IdentificationSections component
   <div
     aria-label="Add a comment to clarify any of your responses in the information about you section"
     className="field   section-comment"
-    data-uuid="field-MOCK-GUID"
+    data-uuid="field-MOCK-GUID-475"
   >
     <a
       aria-hidden="true"
       className="anchor"
-      id="field-MOCK-GUID"
-      name="field-MOCK-GUID"
+      id="field-MOCK-GUID-475"
+      name="field-MOCK-GUID-475"
     />
     <h4
       className="title h4"
@@ -12224,7 +12224,7 @@ exports[`The identification section renders the IdentificationSections component
               autoComplete={true}
               autoCorrect={true}
               className=""
-              id="Comments-MOCK-GUID"
+              id="Comments-MOCK-GUID-476"
               maxLength={255}
               name="Comments"
               onBlur={[Function]}

--- a/src/components/Section/Package/Attachments.test.jsx
+++ b/src/components/Section/Package/Attachments.test.jsx
@@ -5,14 +5,6 @@ import { mount } from 'enzyme'
 import { api } from '../../../services'
 import Attachments from './Attachments'
 
-// give a fake GUID so the field IDs don't differ between snapshots
-// https://github.com/facebook/jest/issues/936#issuecomment-404246102
-jest.mock('../../Form/ValidationElement/helpers', () =>
-  Object.assign(require.requireActual('../../Form/ValidationElement/helpers'), {
-    newGuid: jest.fn().mockReturnValue('MOCK-GUID')
-  })
-)
-
 describe('The attachments component', () => {
   beforeEach(() => {
     const mock = new MockAdapter(api.proxy)

--- a/src/components/Section/Package/Print.test.jsx
+++ b/src/components/Section/Package/Print.test.jsx
@@ -12,14 +12,6 @@ const applicationState = {
   Application: {}
 }
 
-// give a fake GUID so the field IDs don't differ between snapshots
-// https://github.com/facebook/jest/issues/936#issuecomment-404246102
-jest.mock('../../Form/ValidationElement/helpers', () =>
-  Object.assign(require.requireActual('../../Form/ValidationElement/helpers'), {
-    newGuid: jest.fn().mockReturnValue('MOCK-GUID')
-  })
-)
-
 describe('The print section', () => {
   // Setup
   window.token = 'fake-token'

--- a/src/components/Section/Package/__snapshots__/Attachments.test.jsx.snap
+++ b/src/components/Section/Package/__snapshots__/Attachments.test.jsx.snap
@@ -7,13 +7,13 @@ exports[`The attachments component renders properly 1`] = `
   <div
     aria-label="Specify your attachment method"
     className="field   attachment-type"
-    data-uuid="field-MOCK-GUID"
+    data-uuid="field-MOCK-GUID-34"
   >
     <a
       aria-hidden="true"
       className="anchor"
-      id="field-MOCK-GUID"
-      name="field-MOCK-GUID"
+      id="field-MOCK-GUID-34"
+      name="field-MOCK-GUID-34"
     />
     <h3
       className="title h3"
@@ -77,15 +77,15 @@ exports[`The attachments component renders properly 1`] = `
             >
               <label
                 className="checked"
-                htmlFor="attachment-type-upload-MOCK-GUID"
+                htmlFor="attachment-type-upload-MOCK-GUID-36"
               >
                 <input
                   aria-label="[object Object] for null"
                   checked={true}
                   className="usa-input-success selected"
                   disabled={false}
-                  id="attachment-type-upload-MOCK-GUID"
-                  name="attachment-type-upload-MOCK-GUID"
+                  id="attachment-type-upload-MOCK-GUID-36"
+                  name="attachment-type-upload-MOCK-GUID-36"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onClick={[Function]}
@@ -117,15 +117,15 @@ exports[`The attachments component renders properly 1`] = `
             >
               <label
                 className=""
-                htmlFor="attachment-type-fax-MOCK-GUID"
+                htmlFor="attachment-type-fax-MOCK-GUID-37"
               >
                 <input
                   aria-label="[object Object] for null"
                   checked={false}
                   className="usa-input-success"
                   disabled={false}
-                  id="attachment-type-fax-MOCK-GUID"
-                  name="attachment-type-fax-MOCK-GUID"
+                  id="attachment-type-fax-MOCK-GUID-37"
+                  name="attachment-type-fax-MOCK-GUID-37"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onClick={[Function]}
@@ -157,15 +157,15 @@ exports[`The attachments component renders properly 1`] = `
             >
               <label
                 className=""
-                htmlFor="attachment-type-other-MOCK-GUID"
+                htmlFor="attachment-type-other-MOCK-GUID-38"
               >
                 <input
                   aria-label="[object Object] for null"
                   checked={false}
                   className="usa-input-success"
                   disabled={false}
-                  id="attachment-type-other-MOCK-GUID"
-                  name="attachment-type-other-MOCK-GUID"
+                  id="attachment-type-other-MOCK-GUID-38"
+                  name="attachment-type-other-MOCK-GUID-38"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onClick={[Function]}
@@ -210,13 +210,13 @@ exports[`The attachments component renders properly 1`] = `
     <div
       aria-label="Upload file to e-QIP directly"
       className="field   upload-area"
-      data-uuid="field-MOCK-GUID"
+      data-uuid="field-MOCK-GUID-39"
     >
       <a
         aria-hidden="true"
         className="anchor"
-        id="field-MOCK-GUID"
-        name="field-MOCK-GUID"
+        id="field-MOCK-GUID-39"
+        name="field-MOCK-GUID-39"
       />
       <h3
         className="title h3"
@@ -264,7 +264,7 @@ exports[`The attachments component renders properly 1`] = `
             >
               <label
                 className=""
-                htmlFor="UploadDescription-MOCK-GUID"
+                htmlFor="UploadDescription-MOCK-GUID-40"
               >
                 Description
               </label>
@@ -275,7 +275,7 @@ exports[`The attachments component renders properly 1`] = `
                 autoComplete={true}
                 autoCorrect={true}
                 className=""
-                id="UploadDescription-MOCK-GUID"
+                id="UploadDescription-MOCK-GUID-40"
                 maxLength={255}
                 name="UploadDescription"
                 onBlur={[Function]}

--- a/src/components/Section/Package/__snapshots__/Print.test.jsx.snap
+++ b/src/components/Section/Package/__snapshots__/Print.test.jsx.snap
@@ -74,13 +74,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Provide your full name"
             className="field"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-996"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-996"
+              name="field-MOCK-GUID-996"
             />
             <h2
               className="title h2"
@@ -113,13 +113,13 @@ exports[`The print section renders properly 1`] = `
                     <div
                       aria-label="First name"
                       className="field required"
-                      data-uuid="field-MOCK-GUID"
+                      data-uuid="field-MOCK-GUID-998"
                     >
                       <a
                         aria-hidden="true"
                         className="anchor"
-                        id="field-MOCK-GUID"
-                        name="field-MOCK-GUID"
+                        id="field-MOCK-GUID-998"
+                        name="field-MOCK-GUID-998"
                       />
                       <label
                         className="title label"
@@ -180,7 +180,7 @@ exports[`The print section renders properly 1`] = `
                                 autoComplete={true}
                                 autoCorrect={true}
                                 className=""
-                                id="first-MOCK-GUID"
+                                id="first-MOCK-GUID-999"
                                 maxLength="100"
                                 name="first"
                                 onBlur={[Function]}
@@ -203,7 +203,7 @@ exports[`The print section renders properly 1`] = `
                                   aria-label="Initial only for null"
                                   checked={false}
                                   className="usa-input-success"
-                                  id="firstInitialOnly-MOCK-GUID"
+                                  id="firstInitialOnly-MOCK-GUID-1000"
                                   name="firstInitialOnly"
                                   onBlur={[Function]}
                                   onChange={[Function]}
@@ -214,7 +214,7 @@ exports[`The print section renders properly 1`] = `
                                 />
                                 <label
                                   className="checkbox no-toggle"
-                                  htmlFor="firstInitialOnly-MOCK-GUID"
+                                  htmlFor="firstInitialOnly-MOCK-GUID-1000"
                                 >
                                   <span>
                                     Initial only
@@ -238,13 +238,13 @@ exports[`The print section renders properly 1`] = `
                     <div
                       aria-label="Middle name"
                       className="field required"
-                      data-uuid="field-MOCK-GUID"
+                      data-uuid="field-MOCK-GUID-1001"
                     >
                       <a
                         aria-hidden="true"
                         className="anchor"
-                        id="field-MOCK-GUID"
-                        name="field-MOCK-GUID"
+                        id="field-MOCK-GUID-1001"
+                        name="field-MOCK-GUID-1001"
                       />
                       <label
                         className="title label"
@@ -305,7 +305,7 @@ exports[`The print section renders properly 1`] = `
                                 autoComplete={true}
                                 autoCorrect={true}
                                 className=""
-                                id="middle-MOCK-GUID"
+                                id="middle-MOCK-GUID-1002"
                                 maxLength="100"
                                 name="middle"
                                 onBlur={[Function]}
@@ -328,7 +328,7 @@ exports[`The print section renders properly 1`] = `
                                   aria-label="No middle name for null"
                                   checked={false}
                                   className="usa-input-success"
-                                  id="noMiddleName-MOCK-GUID"
+                                  id="noMiddleName-MOCK-GUID-1003"
                                   name="noMiddleName"
                                   onBlur={[Function]}
                                   onChange={[Function]}
@@ -339,7 +339,7 @@ exports[`The print section renders properly 1`] = `
                                 />
                                 <label
                                   className="checkbox no-toggle"
-                                  htmlFor="noMiddleName-MOCK-GUID"
+                                  htmlFor="noMiddleName-MOCK-GUID-1003"
                                 >
                                   <span>
                                     No middle name
@@ -353,7 +353,7 @@ exports[`The print section renders properly 1`] = `
                                   aria-label="Initial only for null"
                                   checked={false}
                                   className="usa-input-success"
-                                  id="middleInitialOnly-MOCK-GUID"
+                                  id="middleInitialOnly-MOCK-GUID-1004"
                                   name="middleInitialOnly"
                                   onBlur={[Function]}
                                   onChange={[Function]}
@@ -364,7 +364,7 @@ exports[`The print section renders properly 1`] = `
                                 />
                                 <label
                                   className="checkbox no-toggle"
-                                  htmlFor="middleInitialOnly-MOCK-GUID"
+                                  htmlFor="middleInitialOnly-MOCK-GUID-1004"
                                 >
                                   <span>
                                     Initial only
@@ -388,13 +388,13 @@ exports[`The print section renders properly 1`] = `
                     <div
                       aria-label="Last name"
                       className="field required"
-                      data-uuid="field-MOCK-GUID"
+                      data-uuid="field-MOCK-GUID-1005"
                     >
                       <a
                         aria-hidden="true"
                         className="anchor"
-                        id="field-MOCK-GUID"
-                        name="field-MOCK-GUID"
+                        id="field-MOCK-GUID-1005"
+                        name="field-MOCK-GUID-1005"
                       />
                       <label
                         className="title label"
@@ -455,7 +455,7 @@ exports[`The print section renders properly 1`] = `
                                 autoComplete={true}
                                 autoCorrect={true}
                                 className=""
-                                id="last-MOCK-GUID"
+                                id="last-MOCK-GUID-1006"
                                 maxLength="100"
                                 name="last"
                                 onBlur={[Function]}
@@ -478,7 +478,7 @@ exports[`The print section renders properly 1`] = `
                                   aria-label="Initial only for null"
                                   checked={false}
                                   className="usa-input-success"
-                                  id="lastInitialOnly-MOCK-GUID"
+                                  id="lastInitialOnly-MOCK-GUID-1007"
                                   name="lastInitialOnly"
                                   onBlur={[Function]}
                                   onChange={[Function]}
@@ -489,7 +489,7 @@ exports[`The print section renders properly 1`] = `
                                 />
                                 <label
                                   className="checkbox no-toggle"
-                                  htmlFor="lastInitialOnly-MOCK-GUID"
+                                  htmlFor="lastInitialOnly-MOCK-GUID-1007"
                                 >
                                   <span>
                                     Initial only
@@ -513,13 +513,13 @@ exports[`The print section renders properly 1`] = `
                     <div
                       aria-label="Suffix"
                       className="field"
-                      data-uuid="field-MOCK-GUID"
+                      data-uuid="field-MOCK-GUID-1008"
                     >
                       <a
                         aria-hidden="true"
                         className="anchor"
-                        id="field-MOCK-GUID"
-                        name="field-MOCK-GUID"
+                        id="field-MOCK-GUID-1008"
+                        name="field-MOCK-GUID-1008"
                       />
                       <label
                         className="title label"
@@ -583,15 +583,15 @@ exports[`The print section renders properly 1`] = `
                               >
                                 <label
                                   className=""
-                                  htmlFor="suffix-MOCK-GUID"
+                                  htmlFor="suffix-MOCK-GUID-1010"
                                 >
                                   <input
                                     aria-label="Jr for null"
                                     checked={false}
                                     className="usa-input-success"
                                     disabled={false}
-                                    id="suffix-MOCK-GUID"
-                                    name="suffix-MOCK-GUID"
+                                    id="suffix-MOCK-GUID-1010"
+                                    name="suffix-MOCK-GUID-1010"
                                     onBlur={[Function]}
                                     onChange={[Function]}
                                     onClick={[Function]}
@@ -610,15 +610,15 @@ exports[`The print section renders properly 1`] = `
                               >
                                 <label
                                   className=""
-                                  htmlFor="suffix-MOCK-GUID"
+                                  htmlFor="suffix-MOCK-GUID-1011"
                                 >
                                   <input
                                     aria-label="Sr for null"
                                     checked={false}
                                     className="usa-input-success"
                                     disabled={false}
-                                    id="suffix-MOCK-GUID"
-                                    name="suffix-MOCK-GUID"
+                                    id="suffix-MOCK-GUID-1011"
+                                    name="suffix-MOCK-GUID-1011"
                                     onBlur={[Function]}
                                     onChange={[Function]}
                                     onClick={[Function]}
@@ -637,15 +637,15 @@ exports[`The print section renders properly 1`] = `
                               >
                                 <label
                                   className=""
-                                  htmlFor="suffix-MOCK-GUID"
+                                  htmlFor="suffix-MOCK-GUID-1012"
                                 >
                                   <input
                                     aria-label="I for null"
                                     checked={false}
                                     className="usa-input-success"
                                     disabled={false}
-                                    id="suffix-MOCK-GUID"
-                                    name="suffix-MOCK-GUID"
+                                    id="suffix-MOCK-GUID-1012"
+                                    name="suffix-MOCK-GUID-1012"
                                     onBlur={[Function]}
                                     onChange={[Function]}
                                     onClick={[Function]}
@@ -664,15 +664,15 @@ exports[`The print section renders properly 1`] = `
                               >
                                 <label
                                   className=""
-                                  htmlFor="suffix-MOCK-GUID"
+                                  htmlFor="suffix-MOCK-GUID-1013"
                                 >
                                   <input
                                     aria-label="II for null"
                                     checked={false}
                                     className="usa-input-success"
                                     disabled={false}
-                                    id="suffix-MOCK-GUID"
-                                    name="suffix-MOCK-GUID"
+                                    id="suffix-MOCK-GUID-1013"
+                                    name="suffix-MOCK-GUID-1013"
                                     onBlur={[Function]}
                                     onChange={[Function]}
                                     onClick={[Function]}
@@ -691,15 +691,15 @@ exports[`The print section renders properly 1`] = `
                               >
                                 <label
                                   className=""
-                                  htmlFor="suffix-MOCK-GUID"
+                                  htmlFor="suffix-MOCK-GUID-1014"
                                 >
                                   <input
                                     aria-label="III for null"
                                     checked={false}
                                     className="usa-input-success"
                                     disabled={false}
-                                    id="suffix-MOCK-GUID"
-                                    name="suffix-MOCK-GUID"
+                                    id="suffix-MOCK-GUID-1014"
+                                    name="suffix-MOCK-GUID-1014"
                                     onBlur={[Function]}
                                     onChange={[Function]}
                                     onClick={[Function]}
@@ -718,15 +718,15 @@ exports[`The print section renders properly 1`] = `
                               >
                                 <label
                                   className=""
-                                  htmlFor="suffix-MOCK-GUID"
+                                  htmlFor="suffix-MOCK-GUID-1015"
                                 >
                                   <input
                                     aria-label="IV for null"
                                     checked={false}
                                     className="usa-input-success"
                                     disabled={false}
-                                    id="suffix-MOCK-GUID"
-                                    name="suffix-MOCK-GUID"
+                                    id="suffix-MOCK-GUID-1015"
+                                    name="suffix-MOCK-GUID-1015"
                                     onBlur={[Function]}
                                     onChange={[Function]}
                                     onClick={[Function]}
@@ -745,15 +745,15 @@ exports[`The print section renders properly 1`] = `
                               >
                                 <label
                                   className=""
-                                  htmlFor="suffix-MOCK-GUID"
+                                  htmlFor="suffix-MOCK-GUID-1016"
                                 >
                                   <input
                                     aria-label="V for null"
                                     checked={false}
                                     className="usa-input-success"
                                     disabled={false}
-                                    id="suffix-MOCK-GUID"
-                                    name="suffix-MOCK-GUID"
+                                    id="suffix-MOCK-GUID-1016"
+                                    name="suffix-MOCK-GUID-1016"
                                     onBlur={[Function]}
                                     onChange={[Function]}
                                     onClick={[Function]}
@@ -772,15 +772,15 @@ exports[`The print section renders properly 1`] = `
                               >
                                 <label
                                   className=""
-                                  htmlFor="suffix-MOCK-GUID"
+                                  htmlFor="suffix-MOCK-GUID-1017"
                                 >
                                   <input
                                     aria-label="VI for null"
                                     checked={false}
                                     className="usa-input-success"
                                     disabled={false}
-                                    id="suffix-MOCK-GUID"
-                                    name="suffix-MOCK-GUID"
+                                    id="suffix-MOCK-GUID-1017"
+                                    name="suffix-MOCK-GUID-1017"
                                     onBlur={[Function]}
                                     onChange={[Function]}
                                     onClick={[Function]}
@@ -799,15 +799,15 @@ exports[`The print section renders properly 1`] = `
                               >
                                 <label
                                   className=""
-                                  htmlFor="suffix-MOCK-GUID"
+                                  htmlFor="suffix-MOCK-GUID-1018"
                                 >
                                   <input
                                     aria-label="VII for null"
                                     checked={false}
                                     className="usa-input-success"
                                     disabled={false}
-                                    id="suffix-MOCK-GUID"
-                                    name="suffix-MOCK-GUID"
+                                    id="suffix-MOCK-GUID-1018"
+                                    name="suffix-MOCK-GUID-1018"
                                     onBlur={[Function]}
                                     onChange={[Function]}
                                     onClick={[Function]}
@@ -826,15 +826,15 @@ exports[`The print section renders properly 1`] = `
                               >
                                 <label
                                   className=""
-                                  htmlFor="suffix-MOCK-GUID"
+                                  htmlFor="suffix-MOCK-GUID-1019"
                                 >
                                   <input
                                     aria-label="VIII for null"
                                     checked={false}
                                     className="usa-input-success"
                                     disabled={false}
-                                    id="suffix-MOCK-GUID"
-                                    name="suffix-MOCK-GUID"
+                                    id="suffix-MOCK-GUID-1019"
+                                    name="suffix-MOCK-GUID-1019"
                                     onBlur={[Function]}
                                     onChange={[Function]}
                                     onClick={[Function]}
@@ -853,15 +853,15 @@ exports[`The print section renders properly 1`] = `
                               >
                                 <label
                                   className=""
-                                  htmlFor="suffix-MOCK-GUID"
+                                  htmlFor="suffix-MOCK-GUID-1020"
                                 >
                                   <input
                                     aria-label="IX for null"
                                     checked={false}
                                     className="usa-input-success"
                                     disabled={false}
-                                    id="suffix-MOCK-GUID"
-                                    name="suffix-MOCK-GUID"
+                                    id="suffix-MOCK-GUID-1020"
+                                    name="suffix-MOCK-GUID-1020"
                                     onBlur={[Function]}
                                     onChange={[Function]}
                                     onClick={[Function]}
@@ -880,15 +880,15 @@ exports[`The print section renders properly 1`] = `
                               >
                                 <label
                                   className=""
-                                  htmlFor="suffix-MOCK-GUID"
+                                  htmlFor="suffix-MOCK-GUID-1021"
                                 >
                                   <input
                                     aria-label="X for null"
                                     checked={false}
                                     className="usa-input-success"
                                     disabled={false}
-                                    id="suffix-MOCK-GUID"
-                                    name="suffix-MOCK-GUID"
+                                    id="suffix-MOCK-GUID-1021"
+                                    name="suffix-MOCK-GUID-1021"
                                     onBlur={[Function]}
                                     onChange={[Function]}
                                     onClick={[Function]}
@@ -907,15 +907,15 @@ exports[`The print section renders properly 1`] = `
                               >
                                 <label
                                   className=""
-                                  htmlFor="suffix-MOCK-GUID"
+                                  htmlFor="suffix-MOCK-GUID-1022"
                                 >
                                   <input
                                     aria-label="Other for null"
                                     checked={false}
                                     className="usa-input-success"
                                     disabled={false}
-                                    id="suffix-MOCK-GUID"
-                                    name="suffix-MOCK-GUID"
+                                    id="suffix-MOCK-GUID-1022"
+                                    name="suffix-MOCK-GUID-1022"
                                     onBlur={[Function]}
                                     onChange={[Function]}
                                     onClick={[Function]}
@@ -995,13 +995,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Provide your other names used and the period of time you used them"
             className="field   no-margin-bottom"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1023"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1023"
+              name="field-MOCK-GUID-1023"
             />
             <h2
               className="title h2"
@@ -1073,13 +1073,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you used any other names?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1024"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1024"
+              name="field-MOCK-GUID-1024"
             />
             <h3
               className="title h3"
@@ -1117,15 +1117,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_othernames-MOCK-GUID"
+                        htmlFor="has_othernames-MOCK-GUID-1026"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_othernames-MOCK-GUID"
-                          name="has_othernames-MOCK-GUID"
+                          id="has_othernames-MOCK-GUID-1026"
+                          name="has_othernames-MOCK-GUID-1026"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -1144,15 +1144,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_othernames-MOCK-GUID"
+                        htmlFor="has_othernames-MOCK-GUID-1027"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_othernames-MOCK-GUID"
-                          name="has_othernames-MOCK-GUID"
+                          id="has_othernames-MOCK-GUID-1027"
+                          name="has_othernames-MOCK-GUID-1027"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -1212,13 +1212,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Provide your contact information"
             className="field   no-margin-bottom"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1028"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1028"
+              name="field-MOCK-GUID-1028"
             />
             <h2
               className="title h2"
@@ -1260,13 +1260,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Your email addresses"
             className="field   no-margin-bottom"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1029"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1029"
+              name="field-MOCK-GUID-1029"
             />
             <h3
               className="title h3"
@@ -1369,13 +1369,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Your phone numbers"
             className="field   no-margin-bottom"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1031"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1031"
+              name="field-MOCK-GUID-1031"
             />
             <h3
               className="title h3"
@@ -1491,13 +1491,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Provide your date of birth"
             className="field required"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1033"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1033"
+              name="field-MOCK-GUID-1033"
             />
             <h2
               className="title h2"
@@ -1560,7 +1560,7 @@ exports[`The print section renders properly 1`] = `
                         >
                           <label
                             className="usa-input-error-label"
-                            htmlFor="month-MOCK-GUID"
+                            htmlFor="month-MOCK-GUID-1036"
                           >
                             Month
                           </label>
@@ -1572,7 +1572,7 @@ exports[`The print section renders properly 1`] = `
                             autoCorrect={true}
                             className=""
                             disabled={false}
-                            id="month-MOCK-GUID"
+                            id="month-MOCK-GUID-1036"
                             maxLength="2"
                             name="month"
                             onBlur={[Function]}
@@ -1595,7 +1595,7 @@ exports[`The print section renders properly 1`] = `
                         >
                           <label
                             className="usa-input-error-label"
-                            htmlFor="day-MOCK-GUID"
+                            htmlFor="day-MOCK-GUID-1038"
                           >
                             Day
                           </label>
@@ -1607,7 +1607,7 @@ exports[`The print section renders properly 1`] = `
                             autoCorrect={true}
                             className=""
                             disabled={false}
-                            id="day-MOCK-GUID"
+                            id="day-MOCK-GUID-1038"
                             maxLength="2"
                             name="day"
                             onBlur={[Function]}
@@ -1630,7 +1630,7 @@ exports[`The print section renders properly 1`] = `
                         >
                           <label
                             className="usa-input-error-label"
-                            htmlFor="year-MOCK-GUID"
+                            htmlFor="year-MOCK-GUID-1040"
                           >
                             Year
                           </label>
@@ -1642,7 +1642,7 @@ exports[`The print section renders properly 1`] = `
                             autoCorrect={true}
                             className=""
                             disabled={false}
-                            id="year-MOCK-GUID"
+                            id="year-MOCK-GUID-1040"
                             maxLength="4"
                             name="year"
                             onBlur={[Function]}
@@ -1669,7 +1669,7 @@ exports[`The print section renders properly 1`] = `
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="estimated-MOCK-GUID"
+                          id="estimated-MOCK-GUID-1041"
                           name="estimated"
                           onBlur={[Function]}
                           onChange={[Function]}
@@ -1680,7 +1680,7 @@ exports[`The print section renders properly 1`] = `
                         />
                         <label
                           className="checkbox no-toggle"
-                          htmlFor="estimated-MOCK-GUID"
+                          htmlFor="estimated-MOCK-GUID-1041"
                         >
                           <span>
                             Estimated
@@ -1744,13 +1744,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Provide your place of birth"
             className="field required"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1042"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1042"
+              name="field-MOCK-GUID-1042"
             />
             <h2
               className="title h2"
@@ -1797,15 +1797,15 @@ exports[`The print section renders properly 1`] = `
                           >
                             <label
                               className=""
-                              htmlFor="birthplace-MOCK-GUID"
+                              htmlFor="birthplace-MOCK-GUID-1046"
                             >
                               <input
                                 aria-label="Yes for null"
                                 checked={false}
                                 className="usa-input-success"
                                 disabled={false}
-                                id="birthplace-MOCK-GUID"
-                                name="birthplace-MOCK-GUID"
+                                id="birthplace-MOCK-GUID-1046"
+                                name="birthplace-MOCK-GUID-1046"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 onClick={[Function]}
@@ -1824,15 +1824,15 @@ exports[`The print section renders properly 1`] = `
                           >
                             <label
                               className=""
-                              htmlFor="birthplace-MOCK-GUID"
+                              htmlFor="birthplace-MOCK-GUID-1047"
                             >
                               <input
                                 aria-label="No for null"
                                 checked={false}
                                 className="usa-input-success"
                                 disabled={false}
-                                id="birthplace-MOCK-GUID"
-                                name="birthplace-MOCK-GUID"
+                                id="birthplace-MOCK-GUID-1047"
+                                name="birthplace-MOCK-GUID-1047"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 onClick={[Function]}
@@ -1895,13 +1895,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Provide your U.S. Social Security Number"
             className="field required"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1048"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1048"
+              name="field-MOCK-GUID-1048"
             />
             <h2
               className="title h2"
@@ -1966,7 +1966,7 @@ exports[`The print section renders properly 1`] = `
                         autoCorrect={true}
                         className=""
                         disabled={false}
-                        id="first-MOCK-GUID"
+                        id="first-MOCK-GUID-1050"
                         maxLength="3"
                         name="first"
                         onBlur={[Function]}
@@ -1994,7 +1994,7 @@ exports[`The print section renders properly 1`] = `
                         autoCorrect={true}
                         className=""
                         disabled={false}
-                        id="middle-MOCK-GUID"
+                        id="middle-MOCK-GUID-1051"
                         maxLength="2"
                         name="middle"
                         onBlur={[Function]}
@@ -2022,7 +2022,7 @@ exports[`The print section renders properly 1`] = `
                         autoCorrect={true}
                         className=""
                         disabled={false}
-                        id="last-MOCK-GUID"
+                        id="last-MOCK-GUID-1052"
                         maxLength="4"
                         name="last"
                         onBlur={[Function]}
@@ -2049,7 +2049,7 @@ exports[`The print section renders properly 1`] = `
                           aria-label="Not applicable for null"
                           checked={false}
                           className="usa-input-success"
-                          id="notApplicable-MOCK-GUID"
+                          id="notApplicable-MOCK-GUID-1053"
                           name="notApplicable"
                           onBlur={[Function]}
                           onChange={[Function]}
@@ -2060,7 +2060,7 @@ exports[`The print section renders properly 1`] = `
                         />
                         <label
                           className="checkbox no-toggle"
-                          htmlFor="notApplicable-MOCK-GUID"
+                          htmlFor="notApplicable-MOCK-GUID-1053"
                         >
                           <span>
                             Not applicable
@@ -2114,13 +2114,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Provide your identifying information"
             className="field   no-margin-bottom"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1054"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1054"
+              name="field-MOCK-GUID-1054"
             />
             <h2
               className="title h2"
@@ -2162,13 +2162,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Height"
             className="field required"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1055"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1055"
+              name="field-MOCK-GUID-1055"
             />
             <h3
               className="title h3"
@@ -2230,7 +2230,7 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className="usa-input-error-label"
-                          htmlFor="feet-MOCK-GUID"
+                          htmlFor="feet-MOCK-GUID-1058"
                         >
                           Feet
                         </label>
@@ -2242,7 +2242,7 @@ exports[`The print section renders properly 1`] = `
                           autoCorrect={true}
                           className=""
                           disabled={false}
-                          id="feet-MOCK-GUID"
+                          id="feet-MOCK-GUID-1058"
                           maxLength="1"
                           name="feet"
                           onBlur={[Function]}
@@ -2265,7 +2265,7 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className="usa-input-error-label"
-                          htmlFor="inches-MOCK-GUID"
+                          htmlFor="inches-MOCK-GUID-1060"
                         >
                           Inches
                         </label>
@@ -2277,7 +2277,7 @@ exports[`The print section renders properly 1`] = `
                           autoCorrect={true}
                           className=""
                           disabled={false}
-                          id="inches-MOCK-GUID"
+                          id="inches-MOCK-GUID-1060"
                           maxLength="2"
                           name="inches"
                           onBlur={[Function]}
@@ -2329,13 +2329,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Weight"
             className="field required"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1061"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1061"
+              name="field-MOCK-GUID-1061"
             />
             <h3
               className="title h3"
@@ -2397,7 +2397,7 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className="usa-input-error-label"
-                          htmlFor="pounds-MOCK-GUID"
+                          htmlFor="pounds-MOCK-GUID-1063"
                         >
                           Pounds
                         </label>
@@ -2409,7 +2409,7 @@ exports[`The print section renders properly 1`] = `
                           autoCorrect={true}
                           className=""
                           disabled={false}
-                          id="pounds-MOCK-GUID"
+                          id="pounds-MOCK-GUID-1063"
                           maxLength="3"
                           name="pounds"
                           onBlur={[Function]}
@@ -2461,13 +2461,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Hair color"
             className="field required"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1064"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1064"
+              name="field-MOCK-GUID-1064"
             />
             <h3
               className="title h3"
@@ -2530,15 +2530,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="hair-black-MOCK-GUID"
+                          htmlFor="hair-black-MOCK-GUID-1066"
                         >
                           <input
                             aria-label="Black for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="hair-black-MOCK-GUID"
-                            name="hair-black-MOCK-GUID"
+                            id="hair-black-MOCK-GUID-1066"
+                            name="hair-black-MOCK-GUID-1066"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -2572,15 +2572,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="hair-brown-MOCK-GUID"
+                          htmlFor="hair-brown-MOCK-GUID-1067"
                         >
                           <input
                             aria-label="Brown for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="hair-brown-MOCK-GUID"
-                            name="hair-brown-MOCK-GUID"
+                            id="hair-brown-MOCK-GUID-1067"
+                            name="hair-brown-MOCK-GUID-1067"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -2614,15 +2614,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="hair-red-MOCK-GUID"
+                          htmlFor="hair-red-MOCK-GUID-1068"
                         >
                           <input
                             aria-label="Red or auburn for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="hair-red-MOCK-GUID"
-                            name="hair-red-MOCK-GUID"
+                            id="hair-red-MOCK-GUID-1068"
+                            name="hair-red-MOCK-GUID-1068"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -2656,15 +2656,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="hair-blonde-MOCK-GUID"
+                          htmlFor="hair-blonde-MOCK-GUID-1069"
                         >
                           <input
                             aria-label="Blonde or strawberry for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="hair-blonde-MOCK-GUID"
-                            name="hair-blonde-MOCK-GUID"
+                            id="hair-blonde-MOCK-GUID-1069"
+                            name="hair-blonde-MOCK-GUID-1069"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -2698,15 +2698,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="hair-sandy-MOCK-GUID"
+                          htmlFor="hair-sandy-MOCK-GUID-1070"
                         >
                           <input
                             aria-label="Sandy for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="hair-sandy-MOCK-GUID"
-                            name="hair-sandy-MOCK-GUID"
+                            id="hair-sandy-MOCK-GUID-1070"
+                            name="hair-sandy-MOCK-GUID-1070"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -2740,15 +2740,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="hair-gray-MOCK-GUID"
+                          htmlFor="hair-gray-MOCK-GUID-1071"
                         >
                           <input
                             aria-label="Gray or partially gray for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="hair-gray-MOCK-GUID"
-                            name="hair-gray-MOCK-GUID"
+                            id="hair-gray-MOCK-GUID-1071"
+                            name="hair-gray-MOCK-GUID-1071"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -2782,15 +2782,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="hair-white-MOCK-GUID"
+                          htmlFor="hair-white-MOCK-GUID-1072"
                         >
                           <input
                             aria-label="White for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="hair-white-MOCK-GUID"
-                            name="hair-white-MOCK-GUID"
+                            id="hair-white-MOCK-GUID-1072"
+                            name="hair-white-MOCK-GUID-1072"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -2824,15 +2824,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="hair-bald-MOCK-GUID"
+                          htmlFor="hair-bald-MOCK-GUID-1073"
                         >
                           <input
                             aria-label="Bald for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="hair-bald-MOCK-GUID"
-                            name="hair-bald-MOCK-GUID"
+                            id="hair-bald-MOCK-GUID-1073"
+                            name="hair-bald-MOCK-GUID-1073"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -2874,15 +2874,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="hair-blue-MOCK-GUID"
+                          htmlFor="hair-blue-MOCK-GUID-1074"
                         >
                           <input
                             aria-label="Blue for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="hair-blue-MOCK-GUID"
-                            name="hair-blue-MOCK-GUID"
+                            id="hair-blue-MOCK-GUID-1074"
+                            name="hair-blue-MOCK-GUID-1074"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -2916,15 +2916,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="hair-green-MOCK-GUID"
+                          htmlFor="hair-green-MOCK-GUID-1075"
                         >
                           <input
                             aria-label="Green for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="hair-green-MOCK-GUID"
-                            name="hair-green-MOCK-GUID"
+                            id="hair-green-MOCK-GUID-1075"
+                            name="hair-green-MOCK-GUID-1075"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -2958,15 +2958,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="hair-orange-MOCK-GUID"
+                          htmlFor="hair-orange-MOCK-GUID-1076"
                         >
                           <input
                             aria-label="Orange for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="hair-orange-MOCK-GUID"
-                            name="hair-orange-MOCK-GUID"
+                            id="hair-orange-MOCK-GUID-1076"
+                            name="hair-orange-MOCK-GUID-1076"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3000,15 +3000,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="hair-pink-MOCK-GUID"
+                          htmlFor="hair-pink-MOCK-GUID-1077"
                         >
                           <input
                             aria-label="Pink for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="hair-pink-MOCK-GUID"
-                            name="hair-pink-MOCK-GUID"
+                            id="hair-pink-MOCK-GUID-1077"
+                            name="hair-pink-MOCK-GUID-1077"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3042,15 +3042,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="hair-purple-MOCK-GUID"
+                          htmlFor="hair-purple-MOCK-GUID-1078"
                         >
                           <input
                             aria-label="Purple for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="hair-purple-MOCK-GUID"
-                            name="hair-purple-MOCK-GUID"
+                            id="hair-purple-MOCK-GUID-1078"
+                            name="hair-purple-MOCK-GUID-1078"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3084,15 +3084,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="hair-unknown-MOCK-GUID"
+                          htmlFor="hair-unknown-MOCK-GUID-1079"
                         >
                           <input
                             aria-label="Unspecified or unknown for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="hair-unknown-MOCK-GUID"
-                            name="hair-unknown-MOCK-GUID"
+                            id="hair-unknown-MOCK-GUID-1079"
+                            name="hair-unknown-MOCK-GUID-1079"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3158,13 +3158,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Eye color"
             className="field required"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1080"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1080"
+              name="field-MOCK-GUID-1080"
             />
             <h3
               className="title h3"
@@ -3227,15 +3227,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="eye-brown-MOCK-GUID"
+                          htmlFor="eye-brown-MOCK-GUID-1082"
                         >
                           <input
                             aria-label="Brown for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="eye-brown-MOCK-GUID"
-                            name="eye-brown-MOCK-GUID"
+                            id="eye-brown-MOCK-GUID-1082"
+                            name="eye-brown-MOCK-GUID-1082"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3269,15 +3269,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="eye-hazel-MOCK-GUID"
+                          htmlFor="eye-hazel-MOCK-GUID-1083"
                         >
                           <input
                             aria-label="Hazel for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="eye-hazel-MOCK-GUID"
-                            name="eye-hazel-MOCK-GUID"
+                            id="eye-hazel-MOCK-GUID-1083"
+                            name="eye-hazel-MOCK-GUID-1083"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3311,15 +3311,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="eye-blue-MOCK-GUID"
+                          htmlFor="eye-blue-MOCK-GUID-1084"
                         >
                           <input
                             aria-label="Blue for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="eye-blue-MOCK-GUID"
-                            name="eye-blue-MOCK-GUID"
+                            id="eye-blue-MOCK-GUID-1084"
+                            name="eye-blue-MOCK-GUID-1084"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3353,15 +3353,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="eye-green-MOCK-GUID"
+                          htmlFor="eye-green-MOCK-GUID-1085"
                         >
                           <input
                             aria-label="Green for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="eye-green-MOCK-GUID"
-                            name="eye-green-MOCK-GUID"
+                            id="eye-green-MOCK-GUID-1085"
+                            name="eye-green-MOCK-GUID-1085"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3395,15 +3395,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="eye-gray-MOCK-GUID"
+                          htmlFor="eye-gray-MOCK-GUID-1086"
                         >
                           <input
                             aria-label="Gray for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="eye-gray-MOCK-GUID"
-                            name="eye-gray-MOCK-GUID"
+                            id="eye-gray-MOCK-GUID-1086"
+                            name="eye-gray-MOCK-GUID-1086"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3437,15 +3437,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="eye-maroon-MOCK-GUID"
+                          htmlFor="eye-maroon-MOCK-GUID-1087"
                         >
                           <input
                             aria-label="Maroon for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="eye-maroon-MOCK-GUID"
-                            name="eye-maroon-MOCK-GUID"
+                            id="eye-maroon-MOCK-GUID-1087"
+                            name="eye-maroon-MOCK-GUID-1087"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3479,15 +3479,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="eye-black-MOCK-GUID"
+                          htmlFor="eye-black-MOCK-GUID-1088"
                         >
                           <input
                             aria-label="Black for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="eye-black-MOCK-GUID"
-                            name="eye-black-MOCK-GUID"
+                            id="eye-black-MOCK-GUID-1088"
+                            name="eye-black-MOCK-GUID-1088"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3521,15 +3521,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="eye-multi-MOCK-GUID"
+                          htmlFor="eye-multi-MOCK-GUID-1089"
                         >
                           <input
                             aria-label="Multicolored for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="eye-multi-MOCK-GUID"
-                            name="eye-multi-MOCK-GUID"
+                            id="eye-multi-MOCK-GUID-1089"
+                            name="eye-multi-MOCK-GUID-1089"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3557,15 +3557,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="eye-pink-MOCK-GUID"
+                          htmlFor="eye-pink-MOCK-GUID-1090"
                         >
                           <input
                             aria-label="Pink for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="eye-pink-MOCK-GUID"
-                            name="eye-pink-MOCK-GUID"
+                            id="eye-pink-MOCK-GUID-1090"
+                            name="eye-pink-MOCK-GUID-1090"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3599,15 +3599,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="eye-unknown-MOCK-GUID"
+                          htmlFor="eye-unknown-MOCK-GUID-1091"
                         >
                           <input
                             aria-label="Unknown for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="eye-unknown-MOCK-GUID"
-                            name="eye-unknown-MOCK-GUID"
+                            id="eye-unknown-MOCK-GUID-1091"
+                            name="eye-unknown-MOCK-GUID-1091"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3673,13 +3673,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Select your sex"
             className="field required"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1092"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1092"
+              name="field-MOCK-GUID-1092"
             />
             <h3
               className="title h3"
@@ -3742,15 +3742,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="sex-MOCK-GUID"
+                          htmlFor="sex-MOCK-GUID-1094"
                         >
                           <input
                             aria-label="Female for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="sex-MOCK-GUID"
-                            name="sex-MOCK-GUID"
+                            id="sex-MOCK-GUID-1094"
+                            name="sex-MOCK-GUID-1094"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3783,15 +3783,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="sex-MOCK-GUID"
+                          htmlFor="sex-MOCK-GUID-1095"
                         >
                           <input
                             aria-label="Male for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="sex-MOCK-GUID"
-                            name="sex-MOCK-GUID"
+                            id="sex-MOCK-GUID-1095"
+                            name="sex-MOCK-GUID-1095"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -3873,13 +3873,13 @@ exports[`The print section renders properly 1`] = `
         <div
           aria-label="Add a comment to clarify any of your responses in the information about you section"
           className="field   section-comment"
-          data-uuid="field-MOCK-GUID"
+          data-uuid="field-MOCK-GUID-1096"
         >
           <a
             aria-hidden="true"
             className="anchor"
-            id="field-MOCK-GUID"
-            name="field-MOCK-GUID"
+            id="field-MOCK-GUID-1096"
+            name="field-MOCK-GUID-1096"
           />
           <h4
             className="title h4"
@@ -3921,7 +3921,7 @@ exports[`The print section renders properly 1`] = `
                     autoComplete={true}
                     autoCorrect={true}
                     className=""
-                    id="Comments-MOCK-GUID"
+                    id="Comments-MOCK-GUID-1097"
                     maxLength={255}
                     name="Comments"
                     onBlur={[Function]}
@@ -3982,13 +3982,13 @@ exports[`The print section renders properly 1`] = `
             <div
               aria-label="Do you have an additional residence to report?"
               className="field required  branch addendum"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-1099"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-1099"
+                name="field-MOCK-GUID-1099"
               />
               <h3
                 className="title h3"
@@ -4026,15 +4026,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="radio_input-MOCK-GUID"
+                          htmlFor="radio_input-MOCK-GUID-1101"
                         >
                           <input
                             aria-label="Yes for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="radio_input-MOCK-GUID"
-                            name="radio_input-MOCK-GUID"
+                            id="radio_input-MOCK-GUID-1101"
+                            name="radio_input-MOCK-GUID-1101"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -4053,15 +4053,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="radio_input-MOCK-GUID"
+                          htmlFor="radio_input-MOCK-GUID-1102"
                         >
                           <input
                             aria-label="No for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="radio_input-MOCK-GUID"
-                            name="radio_input-MOCK-GUID"
+                            id="radio_input-MOCK-GUID-1102"
+                            name="radio_input-MOCK-GUID-1102"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -4135,13 +4135,13 @@ exports[`The print section renders properly 1`] = `
             <div
               aria-label="Do you have an additional employment activity to enter?"
               className="field required  branch addendum no-margin-bottom"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-1104"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-1104"
+                name="field-MOCK-GUID-1104"
               />
               <h3
                 className="title h3"
@@ -4179,15 +4179,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="radio_input-MOCK-GUID"
+                          htmlFor="radio_input-MOCK-GUID-1106"
                         >
                           <input
                             aria-label="Yes for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="radio_input-MOCK-GUID"
-                            name="radio_input-MOCK-GUID"
+                            id="radio_input-MOCK-GUID-1106"
+                            name="radio_input-MOCK-GUID-1106"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -4206,15 +4206,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="radio_input-MOCK-GUID"
+                          htmlFor="radio_input-MOCK-GUID-1107"
                         >
                           <input
                             aria-label="No for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="radio_input-MOCK-GUID"
-                            name="radio_input-MOCK-GUID"
+                            id="radio_input-MOCK-GUID-1107"
+                            name="radio_input-MOCK-GUID-1107"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -4269,13 +4269,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have any of the following happened to you in the last seven (7) years at employment activities that you have not previously listed?"
             className="field required  branch employment-record"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1108"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1108"
+              name="field-MOCK-GUID-1108"
             />
             <h3
               className="title h3"
@@ -4354,15 +4354,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="radio_input-MOCK-GUID"
+                        htmlFor="radio_input-MOCK-GUID-1110"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="radio_input-MOCK-GUID"
-                          name="radio_input-MOCK-GUID"
+                          id="radio_input-MOCK-GUID-1110"
+                          name="radio_input-MOCK-GUID-1110"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -4381,15 +4381,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="radio_input-MOCK-GUID"
+                        htmlFor="radio_input-MOCK-GUID-1111"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="radio_input-MOCK-GUID"
-                          name="radio_input-MOCK-GUID"
+                          id="radio_input-MOCK-GUID-1111"
+                          name="radio_input-MOCK-GUID-1111"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -4449,13 +4449,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1112"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1112"
+              name="field-MOCK-GUID-1112"
             />
             <h2
               className="title h2"
@@ -4517,15 +4517,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_federalservice-MOCK-GUID"
+                        htmlFor="has_federalservice-MOCK-GUID-1114"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_federalservice-MOCK-GUID"
-                          name="has_federalservice-MOCK-GUID"
+                          id="has_federalservice-MOCK-GUID-1114"
+                          name="has_federalservice-MOCK-GUID-1114"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -4544,15 +4544,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_federalservice-MOCK-GUID"
+                        htmlFor="has_federalservice-MOCK-GUID-1115"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_federalservice-MOCK-GUID"
-                          name="has_federalservice-MOCK-GUID"
+                          id="has_federalservice-MOCK-GUID-1115"
+                          name="has_federalservice-MOCK-GUID-1115"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -4607,13 +4607,13 @@ exports[`The print section renders properly 1`] = `
         <div
           aria-label="Add a comment to clarify any of your responses in the your history section"
           className="field   section-comment"
-          data-uuid="field-MOCK-GUID"
+          data-uuid="field-MOCK-GUID-1116"
         >
           <a
             aria-hidden="true"
             className="anchor"
-            id="field-MOCK-GUID"
-            name="field-MOCK-GUID"
+            id="field-MOCK-GUID-1116"
+            name="field-MOCK-GUID-1116"
           />
           <h4
             className="title h4"
@@ -4655,7 +4655,7 @@ exports[`The print section renders properly 1`] = `
                     autoComplete={true}
                     autoCorrect={true}
                     className=""
-                    id="Comments-MOCK-GUID"
+                    id="Comments-MOCK-GUID-1117"
                     maxLength={255}
                     name="Comments"
                     onBlur={[Function]}
@@ -4700,13 +4700,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Provide your current marital/relationship status with regard to civil marriage, legally recognized civil union, or legally recognized domestic partnership."
             className="field required"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1118"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1118"
+              name="field-MOCK-GUID-1118"
             />
             <h3
               className="title h3"
@@ -4741,15 +4741,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="status-MOCK-GUID-status-MOCK-GUID"
+                        htmlFor="status-MOCK-GUID-1119-status-MOCK-GUID-1120"
                       >
                         <input
                           aria-label="[object Object] for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="status-MOCK-GUID-status-MOCK-GUID"
-                          name="status-MOCK-GUID-status-MOCK-GUID"
+                          id="status-MOCK-GUID-1119-status-MOCK-GUID-1120"
+                          name="status-MOCK-GUID-1119-status-MOCK-GUID-1120"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -4772,15 +4772,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="status-MOCK-GUID-status-MOCK-GUID"
+                        htmlFor="status-MOCK-GUID-1119-status-MOCK-GUID-1121"
                       >
                         <input
                           aria-label="[object Object] for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="status-MOCK-GUID-status-MOCK-GUID"
-                          name="status-MOCK-GUID-status-MOCK-GUID"
+                          id="status-MOCK-GUID-1119-status-MOCK-GUID-1121"
+                          name="status-MOCK-GUID-1119-status-MOCK-GUID-1121"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -4803,15 +4803,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="status-MOCK-GUID-status-MOCK-GUID"
+                        htmlFor="status-MOCK-GUID-1119-status-MOCK-GUID-1122"
                       >
                         <input
                           aria-label="[object Object] for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="status-MOCK-GUID-status-MOCK-GUID"
-                          name="status-MOCK-GUID-status-MOCK-GUID"
+                          id="status-MOCK-GUID-1119-status-MOCK-GUID-1122"
+                          name="status-MOCK-GUID-1119-status-MOCK-GUID-1122"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -4834,15 +4834,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="status-MOCK-GUID-status-MOCK-GUID"
+                        htmlFor="status-MOCK-GUID-1119-status-MOCK-GUID-1123"
                       >
                         <input
                           aria-label="[object Object] for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="status-MOCK-GUID-status-MOCK-GUID"
-                          name="status-MOCK-GUID-status-MOCK-GUID"
+                          id="status-MOCK-GUID-1119-status-MOCK-GUID-1123"
+                          name="status-MOCK-GUID-1119-status-MOCK-GUID-1123"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -4865,15 +4865,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="status-MOCK-GUID-status-MOCK-GUID"
+                        htmlFor="status-MOCK-GUID-1119-status-MOCK-GUID-1124"
                       >
                         <input
                           aria-label="[object Object] for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="status-MOCK-GUID-status-MOCK-GUID"
-                          name="status-MOCK-GUID-status-MOCK-GUID"
+                          id="status-MOCK-GUID-1119-status-MOCK-GUID-1124"
+                          name="status-MOCK-GUID-1119-status-MOCK-GUID-1124"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -4896,15 +4896,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="status-MOCK-GUID-status-MOCK-GUID"
+                        htmlFor="status-MOCK-GUID-1119-status-MOCK-GUID-1125"
                       >
                         <input
                           aria-label="[object Object] for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="status-MOCK-GUID-status-MOCK-GUID"
-                          name="status-MOCK-GUID-status-MOCK-GUID"
+                          id="status-MOCK-GUID-1119-status-MOCK-GUID-1125"
+                          name="status-MOCK-GUID-1119-status-MOCK-GUID-1125"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -4927,15 +4927,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="status-MOCK-GUID-status-MOCK-GUID"
+                        htmlFor="status-MOCK-GUID-1119-status-MOCK-GUID-1126"
                       >
                         <input
                           aria-label="[object Object] for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="status-MOCK-GUID-status-MOCK-GUID"
-                          name="status-MOCK-GUID-status-MOCK-GUID"
+                          id="status-MOCK-GUID-1119-status-MOCK-GUID-1126"
+                          name="status-MOCK-GUID-1119-status-MOCK-GUID-1126"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -4999,13 +4999,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Do you presently reside with a person, other than a spouse or legally recognized civil union/domestic partner, with whom you share bonds of affection, obligation, or other commitment, as opposed to a person with whom you live for reasons of convenience?"
             className="field required  branch has-cohabitant"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1127"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1127"
+              name="field-MOCK-GUID-1127"
             />
             <h3
               className="title h3"
@@ -5067,15 +5067,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="hasCohabitant-MOCK-GUID"
+                        htmlFor="hasCohabitant-MOCK-GUID-1129"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="hasCohabitant-MOCK-GUID"
-                          name="hasCohabitant-MOCK-GUID"
+                          id="hasCohabitant-MOCK-GUID-1129"
+                          name="hasCohabitant-MOCK-GUID-1129"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -5094,15 +5094,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="hasCohabitant-MOCK-GUID"
+                        htmlFor="hasCohabitant-MOCK-GUID-1130"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="hasCohabitant-MOCK-GUID"
-                          name="hasCohabitant-MOCK-GUID"
+                          id="hasCohabitant-MOCK-GUID-1130"
+                          name="hasCohabitant-MOCK-GUID-1130"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -5273,13 +5273,13 @@ exports[`The print section renders properly 1`] = `
             <div
               aria-label="Do you have an additional person who knows you well to list?"
               className="field required  branch addendum"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-1132"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-1132"
+                name="field-MOCK-GUID-1132"
               />
               <h3
                 className="title h3"
@@ -5317,15 +5317,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="radio_input-MOCK-GUID"
+                          htmlFor="radio_input-MOCK-GUID-1134"
                         >
                           <input
                             aria-label="Yes for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="radio_input-MOCK-GUID"
-                            name="radio_input-MOCK-GUID"
+                            id="radio_input-MOCK-GUID-1134"
+                            name="radio_input-MOCK-GUID-1134"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -5344,15 +5344,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="radio_input-MOCK-GUID"
+                          htmlFor="radio_input-MOCK-GUID-1135"
                         >
                           <input
                             aria-label="No for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="radio_input-MOCK-GUID"
-                            name="radio_input-MOCK-GUID"
+                            id="radio_input-MOCK-GUID-1135"
+                            name="radio_input-MOCK-GUID-1135"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -5413,13 +5413,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Add each relative applicable to you, regardless if they are living or deceased."
             className="field   no-margin-bottom"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1136"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1136"
+              name="field-MOCK-GUID-1136"
             />
             <h2
               className="title h2"
@@ -5483,13 +5483,13 @@ exports[`The print section renders properly 1`] = `
             <div
               aria-label="Do you have an additional relative to enter?"
               className="field required  branch addendum"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-1138"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-1138"
+                name="field-MOCK-GUID-1138"
               />
               <h3
                 className="title h3"
@@ -5527,15 +5527,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="radio_input-MOCK-GUID"
+                          htmlFor="radio_input-MOCK-GUID-1140"
                         >
                           <input
                             aria-label="Yes for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="radio_input-MOCK-GUID"
-                            name="radio_input-MOCK-GUID"
+                            id="radio_input-MOCK-GUID-1140"
+                            name="radio_input-MOCK-GUID-1140"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -5554,15 +5554,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="radio_input-MOCK-GUID"
+                          htmlFor="radio_input-MOCK-GUID-1141"
                         >
                           <input
                             aria-label="No for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="radio_input-MOCK-GUID"
-                            name="radio_input-MOCK-GUID"
+                            id="radio_input-MOCK-GUID-1141"
+                            name="radio_input-MOCK-GUID-1141"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -5618,13 +5618,13 @@ exports[`The print section renders properly 1`] = `
         <div
           aria-label="Add a comment to clarify any of your responses in the relationships section"
           className="field   section-comment"
-          data-uuid="field-MOCK-GUID"
+          data-uuid="field-MOCK-GUID-1142"
         >
           <a
             aria-hidden="true"
             className="anchor"
-            id="field-MOCK-GUID"
-            name="field-MOCK-GUID"
+            id="field-MOCK-GUID-1142"
+            name="field-MOCK-GUID-1142"
           />
           <h4
             className="title h4"
@@ -5666,7 +5666,7 @@ exports[`The print section renders properly 1`] = `
                     autoComplete={true}
                     autoCorrect={true}
                     className=""
-                    id="Comments-MOCK-GUID"
+                    id="Comments-MOCK-GUID-1143"
                     maxLength={255}
                     name="Comments"
                     onBlur={[Function]}
@@ -5711,13 +5711,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Citizenship status"
             className="field   no-margin-bottom"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1144"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1144"
+              name="field-MOCK-GUID-1144"
             />
             <h2
               className="title h2"
@@ -5759,13 +5759,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Provide your current citizenship status"
             className="field required"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1145"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1145"
+              name="field-MOCK-GUID-1145"
             />
             <h3
               className="title h3"
@@ -5800,15 +5800,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="citizenship-status-citizen-MOCK-GUID"
+                        htmlFor="citizenship-status-citizen-MOCK-GUID-1147"
                       >
                         <input
                           aria-label="[object Object] for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="citizenship-status-citizen-MOCK-GUID"
-                          name="citizenship-status-citizen-MOCK-GUID"
+                          id="citizenship-status-citizen-MOCK-GUID-1147"
+                          name="citizenship-status-citizen-MOCK-GUID-1147"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -5831,15 +5831,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="citizenship-status-foreignborn-MOCK-GUID"
+                        htmlFor="citizenship-status-foreignborn-MOCK-GUID-1148"
                       >
                         <input
                           aria-label="[object Object] for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="citizenship-status-foreignborn-MOCK-GUID"
-                          name="citizenship-status-foreignborn-MOCK-GUID"
+                          id="citizenship-status-foreignborn-MOCK-GUID-1148"
+                          name="citizenship-status-foreignborn-MOCK-GUID-1148"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -5862,15 +5862,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="citizenship-status-naturalized-MOCK-GUID"
+                        htmlFor="citizenship-status-naturalized-MOCK-GUID-1149"
                       >
                         <input
                           aria-label="[object Object] for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="citizenship-status-naturalized-MOCK-GUID"
-                          name="citizenship-status-naturalized-MOCK-GUID"
+                          id="citizenship-status-naturalized-MOCK-GUID-1149"
+                          name="citizenship-status-naturalized-MOCK-GUID-1149"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -5893,15 +5893,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="citizenship-status-derived-MOCK-GUID"
+                        htmlFor="citizenship-status-derived-MOCK-GUID-1150"
                       >
                         <input
                           aria-label="[object Object] for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="citizenship-status-derived-MOCK-GUID"
-                          name="citizenship-status-derived-MOCK-GUID"
+                          id="citizenship-status-derived-MOCK-GUID-1150"
+                          name="citizenship-status-derived-MOCK-GUID-1150"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -5924,15 +5924,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="citizenship-status-notcitizen-MOCK-GUID"
+                        htmlFor="citizenship-status-notcitizen-MOCK-GUID-1151"
                       >
                         <input
                           aria-label="[object Object] for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="citizenship-status-notcitizen-MOCK-GUID"
-                          name="citizenship-status-notcitizen-MOCK-GUID"
+                          id="citizenship-status-notcitizen-MOCK-GUID-1151"
+                          name="citizenship-status-notcitizen-MOCK-GUID-1151"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -5996,13 +5996,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Dual/multiple citizenship"
             className="field   no-margin-bottom"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1152"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1152"
+              name="field-MOCK-GUID-1152"
             />
             <h2
               className="title h2"
@@ -6044,13 +6044,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Do you now or have you EVER held dual/multiple citizenships?"
             className="field required  branch has-multiple"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1153"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1153"
+              name="field-MOCK-GUID-1153"
             />
             <h3
               className="title h3"
@@ -6088,15 +6088,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_multiple-MOCK-GUID"
+                        htmlFor="has_multiple-MOCK-GUID-1155"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_multiple-MOCK-GUID"
-                          name="has_multiple-MOCK-GUID"
+                          id="has_multiple-MOCK-GUID-1155"
+                          name="has_multiple-MOCK-GUID-1155"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -6115,15 +6115,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_multiple-MOCK-GUID"
+                        htmlFor="has_multiple-MOCK-GUID-1156"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_multiple-MOCK-GUID"
-                          name="has_multiple-MOCK-GUID"
+                          id="has_multiple-MOCK-GUID-1156"
+                          name="has_multiple-MOCK-GUID-1156"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -6183,13 +6183,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Foreign passport information"
             className="field   no-margin-bottom"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1157"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1157"
+              name="field-MOCK-GUID-1157"
             />
             <h2
               className="title h2"
@@ -6235,13 +6235,13 @@ exports[`The print section renders properly 1`] = `
               <div
                 aria-label="Have you EVER been issued a passport (or identity card for travel) by a country other than the U.S.?"
                 className="field required  branch"
-                data-uuid="field-MOCK-GUID"
+                data-uuid="field-MOCK-GUID-1158"
               >
                 <a
                   aria-hidden="true"
                   className="anchor"
-                  id="field-MOCK-GUID"
-                  name="field-MOCK-GUID"
+                  id="field-MOCK-GUID-1158"
+                  name="field-MOCK-GUID-1158"
                 />
                 <h3
                   className="title h3"
@@ -6279,15 +6279,15 @@ exports[`The print section renders properly 1`] = `
                         >
                           <label
                             className=""
-                            htmlFor="branchcollection-MOCK-GUID"
+                            htmlFor="branchcollection-MOCK-GUID-1160"
                           >
                             <input
                               aria-label="Yes for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="branchcollection-MOCK-GUID"
-                              name="branchcollection-MOCK-GUID"
+                              id="branchcollection-MOCK-GUID-1160"
+                              name="branchcollection-MOCK-GUID-1160"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -6306,15 +6306,15 @@ exports[`The print section renders properly 1`] = `
                         >
                           <label
                             className=""
-                            htmlFor="branchcollection-MOCK-GUID"
+                            htmlFor="branchcollection-MOCK-GUID-1161"
                           >
                             <input
                               aria-label="No for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="branchcollection-MOCK-GUID"
-                              name="branchcollection-MOCK-GUID"
+                              id="branchcollection-MOCK-GUID-1161"
+                              name="branchcollection-MOCK-GUID-1161"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -6371,13 +6371,13 @@ exports[`The print section renders properly 1`] = `
         <div
           aria-label="Add a comment to clarify any of your responses in the citizenship section"
           className="field   section-comment"
-          data-uuid="field-MOCK-GUID"
+          data-uuid="field-MOCK-GUID-1162"
         >
           <a
             aria-hidden="true"
             className="anchor"
-            id="field-MOCK-GUID"
-            name="field-MOCK-GUID"
+            id="field-MOCK-GUID-1162"
+            name="field-MOCK-GUID-1162"
           />
           <h4
             className="title h4"
@@ -6419,7 +6419,7 @@ exports[`The print section renders properly 1`] = `
                     autoComplete={true}
                     autoCorrect={true}
                     className=""
-                    id="Comments-MOCK-GUID"
+                    id="Comments-MOCK-GUID-1163"
                     maxLength={255}
                     name="Comments"
                     onBlur={[Function]}
@@ -6465,13 +6465,13 @@ exports[`The print section renders properly 1`] = `
             <div
               aria-label="Were you born a male after December 31, 1959?"
               className="field required  branch born"
-              data-uuid="field-MOCK-GUID"
+              data-uuid="field-MOCK-GUID-1164"
             >
               <a
                 aria-hidden="true"
                 className="anchor"
-                id="field-MOCK-GUID"
-                name="field-MOCK-GUID"
+                id="field-MOCK-GUID-1164"
+                name="field-MOCK-GUID-1164"
               />
               <h2
                 className="title h2"
@@ -6533,15 +6533,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="was_bornafter-MOCK-GUID"
+                          htmlFor="was_bornafter-MOCK-GUID-1166"
                         >
                           <input
                             aria-label="Yes for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="was_bornafter-MOCK-GUID"
-                            name="was_bornafter-MOCK-GUID"
+                            id="was_bornafter-MOCK-GUID-1166"
+                            name="was_bornafter-MOCK-GUID-1166"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -6560,15 +6560,15 @@ exports[`The print section renders properly 1`] = `
                       >
                         <label
                           className=""
-                          htmlFor="was_bornafter-MOCK-GUID"
+                          htmlFor="was_bornafter-MOCK-GUID-1167"
                         >
                           <input
                             aria-label="No for null"
                             checked={false}
                             className="usa-input-success"
                             disabled={false}
-                            id="was_bornafter-MOCK-GUID"
-                            name="was_bornafter-MOCK-GUID"
+                            id="was_bornafter-MOCK-GUID-1167"
+                            name="was_bornafter-MOCK-GUID-1167"
                             onBlur={[Function]}
                             onChange={[Function]}
                             onClick={[Function]}
@@ -6629,13 +6629,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you ever served in the U.S. Military?"
             className="field required  branch served"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1168"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1168"
+              name="field-MOCK-GUID-1168"
             />
             <h2
               className="title h2"
@@ -6697,15 +6697,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_served-MOCK-GUID"
+                        htmlFor="has_served-MOCK-GUID-1170"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_served-MOCK-GUID"
-                          name="has_served-MOCK-GUID"
+                          id="has_served-MOCK-GUID-1170"
+                          name="has_served-MOCK-GUID-1170"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -6724,15 +6724,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_served-MOCK-GUID"
+                        htmlFor="has_served-MOCK-GUID-1171"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_served-MOCK-GUID"
-                          name="has_served-MOCK-GUID"
+                          id="has_served-MOCK-GUID-1171"
+                          name="has_served-MOCK-GUID-1171"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -6794,13 +6794,13 @@ exports[`The print section renders properly 1`] = `
               <div
                 aria-label="Have you ever served, as a civilian or military member in a foreign country's military, intelligence, diplomatic, security forces, militia, other defense force, or government agency?"
                 className="field required  branch"
-                data-uuid="field-MOCK-GUID"
+                data-uuid="field-MOCK-GUID-1172"
               >
                 <a
                   aria-hidden="true"
                   className="anchor"
-                  id="field-MOCK-GUID"
-                  name="field-MOCK-GUID"
+                  id="field-MOCK-GUID-1172"
+                  name="field-MOCK-GUID-1172"
                 />
                 <h2
                   className="title h2"
@@ -6838,15 +6838,15 @@ exports[`The print section renders properly 1`] = `
                         >
                           <label
                             className=""
-                            htmlFor="has_foreign-MOCK-GUID"
+                            htmlFor="has_foreign-MOCK-GUID-1174"
                           >
                             <input
                               aria-label="Yes for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="has_foreign-MOCK-GUID"
-                              name="has_foreign-MOCK-GUID"
+                              id="has_foreign-MOCK-GUID-1174"
+                              name="has_foreign-MOCK-GUID-1174"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -6865,15 +6865,15 @@ exports[`The print section renders properly 1`] = `
                         >
                           <label
                             className=""
-                            htmlFor="has_foreign-MOCK-GUID"
+                            htmlFor="has_foreign-MOCK-GUID-1175"
                           >
                             <input
                               aria-label="No for null"
                               checked={false}
                               className="usa-input-success"
                               disabled={false}
-                              id="has_foreign-MOCK-GUID"
-                              name="has_foreign-MOCK-GUID"
+                              id="has_foreign-MOCK-GUID-1175"
+                              name="has_foreign-MOCK-GUID-1175"
                               onBlur={[Function]}
                               onChange={[Function]}
                               onClick={[Function]}
@@ -6930,13 +6930,13 @@ exports[`The print section renders properly 1`] = `
         <div
           aria-label="Add a comment to clarify any of your responses in the military history section"
           className="field   section-comment"
-          data-uuid="field-MOCK-GUID"
+          data-uuid="field-MOCK-GUID-1176"
         >
           <a
             aria-hidden="true"
             className="anchor"
-            id="field-MOCK-GUID"
-            name="field-MOCK-GUID"
+            id="field-MOCK-GUID-1176"
+            name="field-MOCK-GUID-1176"
           />
           <h4
             className="title h4"
@@ -6978,7 +6978,7 @@ exports[`The print section renders properly 1`] = `
                     autoComplete={true}
                     autoCorrect={true}
                     className=""
-                    id="Comments-MOCK-GUID"
+                    id="Comments-MOCK-GUID-1177"
                     maxLength={255}
                     name="Comments"
                     onBlur={[Function]}
@@ -7023,13 +7023,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="U.S. passport information"
             className="field   no-margin-bottom"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1178"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1178"
+              name="field-MOCK-GUID-1178"
             />
             <h2
               className="title h2"
@@ -7084,13 +7084,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Do you possess a U.S. passport (current or expired)?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1179"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1179"
+              name="field-MOCK-GUID-1179"
             />
             <h3
               className="title h3"
@@ -7128,15 +7128,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_passport-MOCK-GUID"
+                        htmlFor="has_passport-MOCK-GUID-1181"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_passport-MOCK-GUID"
-                          name="has_passport-MOCK-GUID"
+                          id="has_passport-MOCK-GUID-1181"
+                          name="has_passport-MOCK-GUID-1181"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -7155,15 +7155,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_passport-MOCK-GUID"
+                        htmlFor="has_passport-MOCK-GUID-1182"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_passport-MOCK-GUID"
-                          name="has_passport-MOCK-GUID"
+                          id="has_passport-MOCK-GUID-1182"
+                          name="has_passport-MOCK-GUID-1182"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -7228,13 +7228,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Do you have, or have you had, close and/or continuing contact with a foreign national within the last seven (7) years with whom you, or your spouse, or legally recognized civil union/domestic partner, or cohabitant are bound by affection, influence, common interests, and/or obligation?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1183"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1183"
+              name="field-MOCK-GUID-1183"
             />
             <h2
               className="title h2"
@@ -7278,15 +7278,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_contacts-MOCK-GUID"
+                        htmlFor="has_foreign_contacts-MOCK-GUID-1185"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_contacts-MOCK-GUID"
-                          name="has_foreign_contacts-MOCK-GUID"
+                          id="has_foreign_contacts-MOCK-GUID-1185"
+                          name="has_foreign_contacts-MOCK-GUID-1185"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -7305,15 +7305,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_contacts-MOCK-GUID"
+                        htmlFor="has_foreign_contacts-MOCK-GUID-1186"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_contacts-MOCK-GUID"
-                          name="has_foreign_contacts-MOCK-GUID"
+                          id="has_foreign_contacts-MOCK-GUID-1186"
+                          name="has_foreign_contacts-MOCK-GUID-1186"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -7373,13 +7373,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children EVER had any foreign financial interests in which you or they have direct control or direct ownership?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1187"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1187"
+              name="field-MOCK-GUID-1187"
             />
             <h2
               className="title h2"
@@ -7454,15 +7454,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_interests-MOCK-GUID"
+                        htmlFor="has_interests-MOCK-GUID-1189"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_interests-MOCK-GUID"
-                          name="has_interests-MOCK-GUID"
+                          id="has_interests-MOCK-GUID-1189"
+                          name="has_interests-MOCK-GUID-1189"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -7481,15 +7481,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_interests-MOCK-GUID"
+                        htmlFor="has_interests-MOCK-GUID-1190"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_interests-MOCK-GUID"
-                          name="has_interests-MOCK-GUID"
+                          id="has_interests-MOCK-GUID-1190"
+                          name="has_interests-MOCK-GUID-1190"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -7549,13 +7549,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children EVER had any foreign financial interests that someone controlled on your behalf?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1191"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1191"
+              name="field-MOCK-GUID-1191"
             />
             <h2
               className="title h2"
@@ -7617,15 +7617,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_interests-MOCK-GUID"
+                        htmlFor="has_interests-MOCK-GUID-1193"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_interests-MOCK-GUID"
-                          name="has_interests-MOCK-GUID"
+                          id="has_interests-MOCK-GUID-1193"
+                          name="has_interests-MOCK-GUID-1193"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -7644,15 +7644,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_interests-MOCK-GUID"
+                        htmlFor="has_interests-MOCK-GUID-1194"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_interests-MOCK-GUID"
-                          name="has_interests-MOCK-GUID"
+                          id="has_interests-MOCK-GUID-1194"
+                          name="has_interests-MOCK-GUID-1194"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -7712,13 +7712,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children EVER owned, or do you anticipate owning, or plan to purchase real estate in a foreign country?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1195"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1195"
+              name="field-MOCK-GUID-1195"
             />
             <h2
               className="title h2"
@@ -7756,15 +7756,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_interests-MOCK-GUID"
+                        htmlFor="has_interests-MOCK-GUID-1197"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_interests-MOCK-GUID"
-                          name="has_interests-MOCK-GUID"
+                          id="has_interests-MOCK-GUID-1197"
+                          name="has_interests-MOCK-GUID-1197"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -7783,15 +7783,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_interests-MOCK-GUID"
+                        htmlFor="has_interests-MOCK-GUID-1198"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_interests-MOCK-GUID"
-                          name="has_interests-MOCK-GUID"
+                          id="has_interests-MOCK-GUID-1198"
+                          name="has_interests-MOCK-GUID-1198"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -7851,13 +7851,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="As a U.S. citizen, have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children received in the last seven (7) years, or are eligible to receive in the future, any educational, medical, retirement, social welfare, or other such benefit from a foreign country?"
             className="field required  branch has-benefits"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1199"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1199"
+              name="field-MOCK-GUID-1199"
             />
             <h2
               className="title h2"
@@ -7895,15 +7895,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_benefit-MOCK-GUID"
+                        htmlFor="has_benefit-MOCK-GUID-1201"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_benefit-MOCK-GUID"
-                          name="has_benefit-MOCK-GUID"
+                          id="has_benefit-MOCK-GUID-1201"
+                          name="has_benefit-MOCK-GUID-1201"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -7922,15 +7922,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_benefit-MOCK-GUID"
+                        htmlFor="has_benefit-MOCK-GUID-1202"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_benefit-MOCK-GUID"
-                          name="has_benefit-MOCK-GUID"
+                          id="has_benefit-MOCK-GUID-1202"
+                          name="has_benefit-MOCK-GUID-1202"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -7990,13 +7990,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER provided financial support for any foreign national?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1203"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1203"
+              name="field-MOCK-GUID-1203"
             />
             <h2
               className="title h2"
@@ -8034,15 +8034,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_support-MOCK-GUID"
+                        htmlFor="has_foreign_support-MOCK-GUID-1205"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_support-MOCK-GUID"
-                          name="has_foreign_support-MOCK-GUID"
+                          id="has_foreign_support-MOCK-GUID-1205"
+                          name="has_foreign_support-MOCK-GUID-1205"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -8061,15 +8061,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_support-MOCK-GUID"
+                        htmlFor="has_foreign_support-MOCK-GUID-1206"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_support-MOCK-GUID"
-                          name="has_foreign_support-MOCK-GUID"
+                          id="has_foreign_support-MOCK-GUID-1206"
+                          name="has_foreign_support-MOCK-GUID-1206"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -8129,13 +8129,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you in the last seven (7) years provided advice or support to any individual associated with a foreign business or other foreign organization that you have not previously listed as a former employer?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1207"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1207"
+              name="field-MOCK-GUID-1207"
             />
             <h2
               className="title h2"
@@ -8183,15 +8183,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_advice-MOCK-GUID"
+                        htmlFor="has_foreign_advice-MOCK-GUID-1209"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_advice-MOCK-GUID"
-                          name="has_foreign_advice-MOCK-GUID"
+                          id="has_foreign_advice-MOCK-GUID-1209"
+                          name="has_foreign_advice-MOCK-GUID-1209"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -8210,15 +8210,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_advice-MOCK-GUID"
+                        htmlFor="has_foreign_advice-MOCK-GUID-1210"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_advice-MOCK-GUID"
-                          name="has_foreign_advice-MOCK-GUID"
+                          id="has_foreign_advice-MOCK-GUID-1210"
+                          name="has_foreign_advice-MOCK-GUID-1210"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -8278,13 +8278,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or any member of your immediate family in the last seven (7) years been asked to provide advice or serve as a consultant, even informally, by any foreign government official or agency?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1211"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1211"
+              name="field-MOCK-GUID-1211"
             />
             <h2
               className="title h2"
@@ -8337,15 +8337,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_family-MOCK-GUID"
+                        htmlFor="has_foreign_family-MOCK-GUID-1213"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_family-MOCK-GUID"
-                          name="has_foreign_family-MOCK-GUID"
+                          id="has_foreign_family-MOCK-GUID-1213"
+                          name="has_foreign_family-MOCK-GUID-1213"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -8364,15 +8364,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_family-MOCK-GUID"
+                        htmlFor="has_foreign_family-MOCK-GUID-1214"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_family-MOCK-GUID"
-                          name="has_foreign_family-MOCK-GUID"
+                          id="has_foreign_family-MOCK-GUID-1214"
+                          name="has_foreign_family-MOCK-GUID-1214"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -8432,13 +8432,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Has any foreign national in the last seven (7) years offered you a job, asked you to work as a consultant, or consider employment with them?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1215"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1215"
+              name="field-MOCK-GUID-1215"
             />
             <h2
               className="title h2"
@@ -8476,15 +8476,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_employment-MOCK-GUID"
+                        htmlFor="has_foreign_employment-MOCK-GUID-1217"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_employment-MOCK-GUID"
-                          name="has_foreign_employment-MOCK-GUID"
+                          id="has_foreign_employment-MOCK-GUID-1217"
+                          name="has_foreign_employment-MOCK-GUID-1217"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -8503,15 +8503,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_employment-MOCK-GUID"
+                        htmlFor="has_foreign_employment-MOCK-GUID-1218"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_employment-MOCK-GUID"
-                          name="has_foreign_employment-MOCK-GUID"
+                          id="has_foreign_employment-MOCK-GUID-1218"
+                          name="has_foreign_employment-MOCK-GUID-1218"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -8571,13 +8571,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you in the last seven (7) years been involved in any other type of business venture with a foreign national not described above?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1219"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1219"
+              name="field-MOCK-GUID-1219"
             />
             <h2
               className="title h2"
@@ -8621,15 +8621,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_ventures-MOCK-GUID"
+                        htmlFor="has_foreign_ventures-MOCK-GUID-1221"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_ventures-MOCK-GUID"
-                          name="has_foreign_ventures-MOCK-GUID"
+                          id="has_foreign_ventures-MOCK-GUID-1221"
+                          name="has_foreign_ventures-MOCK-GUID-1221"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -8648,15 +8648,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_ventures-MOCK-GUID"
+                        htmlFor="has_foreign_ventures-MOCK-GUID-1222"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_ventures-MOCK-GUID"
-                          name="has_foreign_ventures-MOCK-GUID"
+                          id="has_foreign_ventures-MOCK-GUID-1222"
+                          name="has_foreign_ventures-MOCK-GUID-1222"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -8716,13 +8716,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you in the last seven (7) years attended or participated in any conferences, trade shows, seminars, or meetings outside the U.S.?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1223"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1223"
+              name="field-MOCK-GUID-1223"
             />
             <h2
               className="title h2"
@@ -8766,15 +8766,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_conferences-MOCK-GUID"
+                        htmlFor="has_foreign_conferences-MOCK-GUID-1225"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_conferences-MOCK-GUID"
-                          name="has_foreign_conferences-MOCK-GUID"
+                          id="has_foreign_conferences-MOCK-GUID-1225"
+                          name="has_foreign_conferences-MOCK-GUID-1225"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -8793,15 +8793,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_conferences-MOCK-GUID"
+                        htmlFor="has_foreign_conferences-MOCK-GUID-1226"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_conferences-MOCK-GUID"
-                          name="has_foreign_conferences-MOCK-GUID"
+                          id="has_foreign_conferences-MOCK-GUID-1226"
+                          name="has_foreign_conferences-MOCK-GUID-1226"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -8866,13 +8866,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you or any member of your immediate family in the last seven (7) years had any contact with a foreign government, its establishment or its representatives, whether inside or outside the U.S.?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1227"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1227"
+              name="field-MOCK-GUID-1227"
             />
             <h2
               className="title h2"
@@ -8921,15 +8921,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_contact-MOCK-GUID"
+                        htmlFor="has_foreign_contact-MOCK-GUID-1229"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_contact-MOCK-GUID"
-                          name="has_foreign_contact-MOCK-GUID"
+                          id="has_foreign_contact-MOCK-GUID-1229"
+                          name="has_foreign_contact-MOCK-GUID-1229"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -8948,15 +8948,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_contact-MOCK-GUID"
+                        htmlFor="has_foreign_contact-MOCK-GUID-1230"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_contact-MOCK-GUID"
-                          name="has_foreign_contact-MOCK-GUID"
+                          id="has_foreign_contact-MOCK-GUID-1230"
+                          name="has_foreign_contact-MOCK-GUID-1230"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -9016,13 +9016,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you in the last seven (7) years sponsored any foreign national to come to the U.S. as a student, for work, or for permanent residence?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1231"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1231"
+              name="field-MOCK-GUID-1231"
             />
             <h2
               className="title h2"
@@ -9084,15 +9084,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_sponsorship-MOCK-GUID"
+                        htmlFor="has_foreign_sponsorship-MOCK-GUID-1233"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_sponsorship-MOCK-GUID"
-                          name="has_foreign_sponsorship-MOCK-GUID"
+                          id="has_foreign_sponsorship-MOCK-GUID-1233"
+                          name="has_foreign_sponsorship-MOCK-GUID-1233"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -9111,15 +9111,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_sponsorship-MOCK-GUID"
+                        htmlFor="has_foreign_sponsorship-MOCK-GUID-1234"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_sponsorship-MOCK-GUID"
-                          name="has_foreign_sponsorship-MOCK-GUID"
+                          id="has_foreign_sponsorship-MOCK-GUID-1234"
+                          name="has_foreign_sponsorship-MOCK-GUID-1234"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -9179,13 +9179,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER held political office in a foreign country?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1235"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1235"
+              name="field-MOCK-GUID-1235"
             />
             <h2
               className="title h2"
@@ -9223,15 +9223,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_political-MOCK-GUID"
+                        htmlFor="has_foreign_political-MOCK-GUID-1237"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_political-MOCK-GUID"
-                          name="has_foreign_political-MOCK-GUID"
+                          id="has_foreign_political-MOCK-GUID-1237"
+                          name="has_foreign_political-MOCK-GUID-1237"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -9250,15 +9250,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_political-MOCK-GUID"
+                        htmlFor="has_foreign_political-MOCK-GUID-1238"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_political-MOCK-GUID"
-                          name="has_foreign_political-MOCK-GUID"
+                          id="has_foreign_political-MOCK-GUID-1238"
+                          name="has_foreign_political-MOCK-GUID-1238"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -9318,13 +9318,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER voted in the election of a foreign country?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1239"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1239"
+              name="field-MOCK-GUID-1239"
             />
             <h2
               className="title h2"
@@ -9362,15 +9362,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_voting-MOCK-GUID"
+                        htmlFor="has_foreign_voting-MOCK-GUID-1241"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_voting-MOCK-GUID"
-                          name="has_foreign_voting-MOCK-GUID"
+                          id="has_foreign_voting-MOCK-GUID-1241"
+                          name="has_foreign_voting-MOCK-GUID-1241"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -9389,15 +9389,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_voting-MOCK-GUID"
+                        htmlFor="has_foreign_voting-MOCK-GUID-1242"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_voting-MOCK-GUID"
-                          name="has_foreign_voting-MOCK-GUID"
+                          id="has_foreign_voting-MOCK-GUID-1242"
+                          name="has_foreign_voting-MOCK-GUID-1242"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -9457,13 +9457,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you traveled outside the U.S. in the last past seven (7) years?"
             className="field required  branch foreign-travel-outside"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1243"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1243"
+              name="field-MOCK-GUID-1243"
             />
             <h2
               className="title h2"
@@ -9501,15 +9501,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_travel_outside-MOCK-GUID"
+                        htmlFor="has_foreign_travel_outside-MOCK-GUID-1245"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_travel_outside-MOCK-GUID"
-                          name="has_foreign_travel_outside-MOCK-GUID"
+                          id="has_foreign_travel_outside-MOCK-GUID-1245"
+                          name="has_foreign_travel_outside-MOCK-GUID-1245"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -9528,15 +9528,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_foreign_travel_outside-MOCK-GUID"
+                        htmlFor="has_foreign_travel_outside-MOCK-GUID-1246"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_foreign_travel_outside-MOCK-GUID"
-                          name="has_foreign_travel_outside-MOCK-GUID"
+                          id="has_foreign_travel_outside-MOCK-GUID-1246"
+                          name="has_foreign_travel_outside-MOCK-GUID-1246"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -9591,13 +9591,13 @@ exports[`The print section renders properly 1`] = `
         <div
           aria-label="Add a comment to clarify any of your responses in the foreign associations section"
           className="field   section-comment"
-          data-uuid="field-MOCK-GUID"
+          data-uuid="field-MOCK-GUID-1247"
         >
           <a
             aria-hidden="true"
             className="anchor"
-            id="field-MOCK-GUID"
-            name="field-MOCK-GUID"
+            id="field-MOCK-GUID-1247"
+            name="field-MOCK-GUID-1247"
           />
           <h4
             className="title h4"
@@ -9639,7 +9639,7 @@ exports[`The print section renders properly 1`] = `
                     autoComplete={true}
                     autoCorrect={true}
                     className=""
-                    id="Comments-MOCK-GUID"
+                    id="Comments-MOCK-GUID-1248"
                     maxLength={255}
                     name="Comments"
                     onBlur={[Function]}
@@ -9684,13 +9684,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="In the last seven (7) years have you filed a petition under any chapter of the bankruptcy code?"
             className="field required  branch bankruptcy-branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1249"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1249"
+              name="field-MOCK-GUID-1249"
             />
             <h2
               className="title h2"
@@ -9752,15 +9752,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_bankruptcydebt-MOCK-GUID"
+                        htmlFor="has_bankruptcydebt-MOCK-GUID-1251"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_bankruptcydebt-MOCK-GUID"
-                          name="has_bankruptcydebt-MOCK-GUID"
+                          id="has_bankruptcydebt-MOCK-GUID-1251"
+                          name="has_bankruptcydebt-MOCK-GUID-1251"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -9779,15 +9779,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_bankruptcydebt-MOCK-GUID"
+                        htmlFor="has_bankruptcydebt-MOCK-GUID-1252"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_bankruptcydebt-MOCK-GUID"
-                          name="has_bankruptcydebt-MOCK-GUID"
+                          id="has_bankruptcydebt-MOCK-GUID-1252"
+                          name="has_bankruptcydebt-MOCK-GUID-1252"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -9847,13 +9847,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you ever experienced financial problems due to gambling?"
             className="field required  branch has-gambling-debt"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1253"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1253"
+              name="field-MOCK-GUID-1253"
             />
             <h2
               className="title h2"
@@ -9891,15 +9891,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_gamblingdebt-MOCK-GUID"
+                        htmlFor="has_gamblingdebt-MOCK-GUID-1255"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_gamblingdebt-MOCK-GUID"
-                          name="has_gamblingdebt-MOCK-GUID"
+                          id="has_gamblingdebt-MOCK-GUID-1255"
+                          name="has_gamblingdebt-MOCK-GUID-1255"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -9918,15 +9918,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_gamblingdebt-MOCK-GUID"
+                        htmlFor="has_gamblingdebt-MOCK-GUID-1256"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_gamblingdebt-MOCK-GUID"
-                          name="has_gamblingdebt-MOCK-GUID"
+                          id="has_gamblingdebt-MOCK-GUID-1256"
+                          name="has_gamblingdebt-MOCK-GUID-1256"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -9986,13 +9986,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="In the last seven (7) years have you failed to file or pay Federal, state, or other taxes when required by law or ordinance?"
             className="field required  branch taxes-branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1257"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1257"
+              name="field-MOCK-GUID-1257"
             />
             <h2
               className="title h2"
@@ -10030,15 +10030,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_taxes-MOCK-GUID"
+                        htmlFor="has_taxes-MOCK-GUID-1259"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_taxes-MOCK-GUID"
-                          name="has_taxes-MOCK-GUID"
+                          id="has_taxes-MOCK-GUID-1259"
+                          name="has_taxes-MOCK-GUID-1259"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -10057,15 +10057,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_taxes-MOCK-GUID"
+                        htmlFor="has_taxes-MOCK-GUID-1260"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_taxes-MOCK-GUID"
-                          name="has_taxes-MOCK-GUID"
+                          id="has_taxes-MOCK-GUID-1260"
+                          name="has_taxes-MOCK-GUID-1260"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -10125,13 +10125,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="In the last seven (7) years have you been counseled, warned, or disciplined for violating the terms of agreement for your travel or credit card provided by your employer?"
             className="field required  branch card-branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1261"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1261"
+              name="field-MOCK-GUID-1261"
             />
             <h2
               className="title h2"
@@ -10169,15 +10169,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_cardabuse-MOCK-GUID"
+                        htmlFor="has_cardabuse-MOCK-GUID-1263"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_cardabuse-MOCK-GUID"
-                          name="has_cardabuse-MOCK-GUID"
+                          id="has_cardabuse-MOCK-GUID-1263"
+                          name="has_cardabuse-MOCK-GUID-1263"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -10196,15 +10196,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_cardabuse-MOCK-GUID"
+                        htmlFor="has_cardabuse-MOCK-GUID-1264"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_cardabuse-MOCK-GUID"
-                          name="has_cardabuse-MOCK-GUID"
+                          id="has_cardabuse-MOCK-GUID-1264"
+                          name="has_cardabuse-MOCK-GUID-1264"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -10264,13 +10264,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Are you currently utilizing, or seeking assistance from, a credit counseling service or other similar resource to resolve your financial difficulties?"
             className="field required  branch credit-branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1265"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1265"
+              name="field-MOCK-GUID-1265"
             />
             <h2
               className="title h2"
@@ -10308,15 +10308,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_credit-MOCK-GUID"
+                        htmlFor="has_credit-MOCK-GUID-1267"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_credit-MOCK-GUID"
-                          name="has_credit-MOCK-GUID"
+                          id="has_credit-MOCK-GUID-1267"
+                          name="has_credit-MOCK-GUID-1267"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -10335,15 +10335,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_credit-MOCK-GUID"
+                        htmlFor="has_credit-MOCK-GUID-1268"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_credit-MOCK-GUID"
-                          name="has_credit-MOCK-GUID"
+                          id="has_credit-MOCK-GUID-1268"
+                          name="has_credit-MOCK-GUID-1268"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -10403,13 +10403,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Other than previously listed, have any of the following happened to you?"
             className="field required  branch delinquent-branch eapp-field-wrap"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1269"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1269"
+              name="field-MOCK-GUID-1269"
             />
             <h2
               className="title h2"
@@ -10492,15 +10492,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_delinquent-MOCK-GUID"
+                        htmlFor="has_delinquent-MOCK-GUID-1271"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_delinquent-MOCK-GUID"
-                          name="has_delinquent-MOCK-GUID"
+                          id="has_delinquent-MOCK-GUID-1271"
+                          name="has_delinquent-MOCK-GUID-1271"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -10519,15 +10519,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_delinquent-MOCK-GUID"
+                        htmlFor="has_delinquent-MOCK-GUID-1272"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_delinquent-MOCK-GUID"
-                          name="has_delinquent-MOCK-GUID"
+                          id="has_delinquent-MOCK-GUID-1272"
+                          name="has_delinquent-MOCK-GUID-1272"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -10587,13 +10587,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Other than previously listed, have any of the following happened?"
             className="field required  branch nonpayment-branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1273"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1273"
+              name="field-MOCK-GUID-1273"
             />
             <h2
               className="title h2"
@@ -10711,15 +10711,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_nonpayment-MOCK-GUID"
+                        htmlFor="has_nonpayment-MOCK-GUID-1275"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_nonpayment-MOCK-GUID"
-                          name="has_nonpayment-MOCK-GUID"
+                          id="has_nonpayment-MOCK-GUID-1275"
+                          name="has_nonpayment-MOCK-GUID-1275"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -10738,15 +10738,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_nonpayment-MOCK-GUID"
+                        htmlFor="has_nonpayment-MOCK-GUID-1276"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_nonpayment-MOCK-GUID"
-                          name="has_nonpayment-MOCK-GUID"
+                          id="has_nonpayment-MOCK-GUID-1276"
+                          name="has_nonpayment-MOCK-GUID-1276"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -10801,13 +10801,13 @@ exports[`The print section renders properly 1`] = `
         <div
           aria-label="Add a comment to clarify any of your responses in the financial record section"
           className="field   section-comment"
-          data-uuid="field-MOCK-GUID"
+          data-uuid="field-MOCK-GUID-1277"
         >
           <a
             aria-hidden="true"
             className="anchor"
-            id="field-MOCK-GUID"
-            name="field-MOCK-GUID"
+            id="field-MOCK-GUID-1277"
+            name="field-MOCK-GUID-1277"
           />
           <h4
             className="title h4"
@@ -10849,7 +10849,7 @@ exports[`The print section renders properly 1`] = `
                     autoComplete={true}
                     autoCorrect={true}
                     className=""
-                    id="Comments-MOCK-GUID"
+                    id="Comments-MOCK-GUID-1278"
                     maxLength={255}
                     name="Comments"
                     onBlur={[Function]}
@@ -10899,13 +10899,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="In the last seven (7) years, have you illegally used any drugs or controlled substances?"
             className="field required  branch used-drugs"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1279"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1279"
+              name="field-MOCK-GUID-1279"
             />
             <h2
               className="title h2"
@@ -10949,15 +10949,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="UsedDrugs-MOCK-GUID"
+                        htmlFor="UsedDrugs-MOCK-GUID-1281"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="UsedDrugs-MOCK-GUID"
-                          name="UsedDrugs-MOCK-GUID"
+                          id="UsedDrugs-MOCK-GUID-1281"
+                          name="UsedDrugs-MOCK-GUID-1281"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -10976,15 +10976,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="UsedDrugs-MOCK-GUID"
+                        htmlFor="UsedDrugs-MOCK-GUID-1282"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="UsedDrugs-MOCK-GUID"
-                          name="UsedDrugs-MOCK-GUID"
+                          id="UsedDrugs-MOCK-GUID-1282"
+                          name="UsedDrugs-MOCK-GUID-1282"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -11044,13 +11044,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="In the last seven (7) years, have you been involved in the illegal purchase, manufacture, cultivation, trafficking, production, transfer, shipping, receiving, handling or sale of any drug or controlled substance?"
             className="field required  branch involved"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1283"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1283"
+              name="field-MOCK-GUID-1283"
             />
             <h2
               className="title h2"
@@ -11088,15 +11088,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="Involved-MOCK-GUID"
+                        htmlFor="Involved-MOCK-GUID-1285"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="Involved-MOCK-GUID"
-                          name="Involved-MOCK-GUID"
+                          id="Involved-MOCK-GUID-1285"
+                          name="Involved-MOCK-GUID-1285"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -11115,15 +11115,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="Involved-MOCK-GUID"
+                        htmlFor="Involved-MOCK-GUID-1286"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="Involved-MOCK-GUID"
-                          name="Involved-MOCK-GUID"
+                          id="Involved-MOCK-GUID-1286"
+                          name="Involved-MOCK-GUID-1286"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -11183,13 +11183,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER illegally used or otherwise been illegally involved with a drug or controlled substance while possessing a security clearance other than previously listed?"
             className="field required  branch used-drugs"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1287"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1287"
+              name="field-MOCK-GUID-1287"
             />
             <h2
               className="title h2"
@@ -11227,15 +11227,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="UsedDrugs-MOCK-GUID"
+                        htmlFor="UsedDrugs-MOCK-GUID-1289"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="UsedDrugs-MOCK-GUID"
-                          name="UsedDrugs-MOCK-GUID"
+                          id="UsedDrugs-MOCK-GUID-1289"
+                          name="UsedDrugs-MOCK-GUID-1289"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -11254,15 +11254,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="UsedDrugs-MOCK-GUID"
+                        htmlFor="UsedDrugs-MOCK-GUID-1290"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="UsedDrugs-MOCK-GUID"
-                          name="UsedDrugs-MOCK-GUID"
+                          id="UsedDrugs-MOCK-GUID-1290"
+                          name="UsedDrugs-MOCK-GUID-1290"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -11322,13 +11322,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER illegally used or otherwise been involved with a drug or controlled substance while employed as a law enforcement officer, prosecutor, or courtroom official; or while in a position directly and immediately affecting the public safety other than previously listed?"
             className="field required  branch used-drugs"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1291"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1291"
+              name="field-MOCK-GUID-1291"
             />
             <h2
               className="title h2"
@@ -11366,15 +11366,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="UsedDrugs-MOCK-GUID"
+                        htmlFor="UsedDrugs-MOCK-GUID-1293"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="UsedDrugs-MOCK-GUID"
-                          name="UsedDrugs-MOCK-GUID"
+                          id="UsedDrugs-MOCK-GUID-1293"
+                          name="UsedDrugs-MOCK-GUID-1293"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -11393,15 +11393,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="UsedDrugs-MOCK-GUID"
+                        htmlFor="UsedDrugs-MOCK-GUID-1294"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="UsedDrugs-MOCK-GUID"
-                          name="UsedDrugs-MOCK-GUID"
+                          id="UsedDrugs-MOCK-GUID-1294"
+                          name="UsedDrugs-MOCK-GUID-1294"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -11461,13 +11461,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="In the last seven (7) years have you intentionally engaged in the misuse of prescription drugs, regardless of whether or not the drugs were prescribed for you or someone else?"
             className="field required  branch misused"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1295"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1295"
+              name="field-MOCK-GUID-1295"
             />
             <h2
               className="title h2"
@@ -11505,15 +11505,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="Misused-MOCK-GUID"
+                        htmlFor="Misused-MOCK-GUID-1297"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="Misused-MOCK-GUID"
-                          name="Misused-MOCK-GUID"
+                          id="Misused-MOCK-GUID-1297"
+                          name="Misused-MOCK-GUID-1297"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -11532,15 +11532,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="Misused-MOCK-GUID"
+                        htmlFor="Misused-MOCK-GUID-1298"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="Misused-MOCK-GUID"
-                          name="Misused-MOCK-GUID"
+                          id="Misused-MOCK-GUID-1298"
+                          name="Misused-MOCK-GUID-1298"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -11600,13 +11600,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER been ordered, advised, or asked to seek counseling or treatment as a result of your illegal use of drugs or controlled substances?"
             className="field required  branch treatment-ordered"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1299"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1299"
+              name="field-MOCK-GUID-1299"
             />
             <h2
               className="title h2"
@@ -11644,15 +11644,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="TreatmentOrdered-MOCK-GUID"
+                        htmlFor="TreatmentOrdered-MOCK-GUID-1301"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="TreatmentOrdered-MOCK-GUID"
-                          name="TreatmentOrdered-MOCK-GUID"
+                          id="TreatmentOrdered-MOCK-GUID-1301"
+                          name="TreatmentOrdered-MOCK-GUID-1301"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -11671,15 +11671,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="TreatmentOrdered-MOCK-GUID"
+                        htmlFor="TreatmentOrdered-MOCK-GUID-1302"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="TreatmentOrdered-MOCK-GUID"
-                          name="TreatmentOrdered-MOCK-GUID"
+                          id="TreatmentOrdered-MOCK-GUID-1302"
+                          name="TreatmentOrdered-MOCK-GUID-1302"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -11739,13 +11739,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER voluntarily sought counseling or treatment as a result of your use of a drug or controlled substance?"
             className="field required  branch treatment-voluntary"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1303"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1303"
+              name="field-MOCK-GUID-1303"
             />
             <h2
               className="title h2"
@@ -11783,15 +11783,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="TreatmentVoluntary-MOCK-GUID"
+                        htmlFor="TreatmentVoluntary-MOCK-GUID-1305"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="TreatmentVoluntary-MOCK-GUID"
-                          name="TreatmentVoluntary-MOCK-GUID"
+                          id="TreatmentVoluntary-MOCK-GUID-1305"
+                          name="TreatmentVoluntary-MOCK-GUID-1305"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -11810,15 +11810,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="TreatmentVoluntary-MOCK-GUID"
+                        htmlFor="TreatmentVoluntary-MOCK-GUID-1306"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="TreatmentVoluntary-MOCK-GUID"
-                          name="TreatmentVoluntary-MOCK-GUID"
+                          id="TreatmentVoluntary-MOCK-GUID-1306"
+                          name="TreatmentVoluntary-MOCK-GUID-1306"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -11878,13 +11878,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="In the last seven (7) years has your use of alcohol had a negative impact on your work performance, your professional or personal relationships, your finances, or resulted in intervention by law enforcement/public safety personnel?"
             className="field required  branch has-impacts"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1307"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1307"
+              name="field-MOCK-GUID-1307"
             />
             <h2
               className="title h2"
@@ -11922,15 +11922,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_impacts-MOCK-GUID"
+                        htmlFor="has_impacts-MOCK-GUID-1309"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_impacts-MOCK-GUID"
-                          name="has_impacts-MOCK-GUID"
+                          id="has_impacts-MOCK-GUID-1309"
+                          name="has_impacts-MOCK-GUID-1309"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -11949,15 +11949,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_impacts-MOCK-GUID"
+                        htmlFor="has_impacts-MOCK-GUID-1310"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_impacts-MOCK-GUID"
-                          name="has_impacts-MOCK-GUID"
+                          id="has_impacts-MOCK-GUID-1310"
+                          name="has_impacts-MOCK-GUID-1310"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -12017,13 +12017,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER been ordered, advised, or asked to seek counseling or treatment as a result of your use of alcohol?"
             className="field required  branch has-been-ordered"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1311"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1311"
+              name="field-MOCK-GUID-1311"
             />
             <h2
               className="title h2"
@@ -12061,15 +12061,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="HasBeenOrdered-MOCK-GUID"
+                        htmlFor="HasBeenOrdered-MOCK-GUID-1313"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="HasBeenOrdered-MOCK-GUID"
-                          name="HasBeenOrdered-MOCK-GUID"
+                          id="HasBeenOrdered-MOCK-GUID-1313"
+                          name="HasBeenOrdered-MOCK-GUID-1313"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -12088,15 +12088,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="HasBeenOrdered-MOCK-GUID"
+                        htmlFor="HasBeenOrdered-MOCK-GUID-1314"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="HasBeenOrdered-MOCK-GUID"
-                          name="HasBeenOrdered-MOCK-GUID"
+                          id="HasBeenOrdered-MOCK-GUID-1314"
+                          name="HasBeenOrdered-MOCK-GUID-1314"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -12156,13 +12156,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER voluntarily sought counseling or treatment as a result of your use of alcohol?"
             className="field required  branch sought-treatment"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1315"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1315"
+              name="field-MOCK-GUID-1315"
             />
             <h2
               className="title h2"
@@ -12200,15 +12200,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="SoughtTreatment-MOCK-GUID"
+                        htmlFor="SoughtTreatment-MOCK-GUID-1317"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="SoughtTreatment-MOCK-GUID"
-                          name="SoughtTreatment-MOCK-GUID"
+                          id="SoughtTreatment-MOCK-GUID-1317"
+                          name="SoughtTreatment-MOCK-GUID-1317"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -12227,15 +12227,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="SoughtTreatment-MOCK-GUID"
+                        htmlFor="SoughtTreatment-MOCK-GUID-1318"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="SoughtTreatment-MOCK-GUID"
-                          name="SoughtTreatment-MOCK-GUID"
+                          id="SoughtTreatment-MOCK-GUID-1318"
+                          name="SoughtTreatment-MOCK-GUID-1318"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -12295,13 +12295,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER received counseling or treatment as a result of your use of alcohol in addition to what you have already listed on this form?"
             className="field required  branch received-treatment"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1319"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1319"
+              name="field-MOCK-GUID-1319"
             />
             <h2
               className="title h2"
@@ -12339,15 +12339,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="ReceivedTreatment-MOCK-GUID"
+                        htmlFor="ReceivedTreatment-MOCK-GUID-1321"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="ReceivedTreatment-MOCK-GUID"
-                          name="ReceivedTreatment-MOCK-GUID"
+                          id="ReceivedTreatment-MOCK-GUID-1321"
+                          name="ReceivedTreatment-MOCK-GUID-1321"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -12366,15 +12366,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="ReceivedTreatment-MOCK-GUID"
+                        htmlFor="ReceivedTreatment-MOCK-GUID-1322"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="ReceivedTreatment-MOCK-GUID"
-                          name="ReceivedTreatment-MOCK-GUID"
+                          id="ReceivedTreatment-MOCK-GUID-1322"
+                          name="ReceivedTreatment-MOCK-GUID-1322"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -12429,13 +12429,13 @@ exports[`The print section renders properly 1`] = `
         <div
           aria-label="Add a comment to clarify any of your responses in the substance use section"
           className="field   section-comment"
-          data-uuid="field-MOCK-GUID"
+          data-uuid="field-MOCK-GUID-1323"
         >
           <a
             aria-hidden="true"
             className="anchor"
-            id="field-MOCK-GUID"
-            name="field-MOCK-GUID"
+            id="field-MOCK-GUID-1323"
+            name="field-MOCK-GUID-1323"
           />
           <h4
             className="title h4"
@@ -12477,7 +12477,7 @@ exports[`The print section renders properly 1`] = `
                     autoComplete={true}
                     autoCorrect={true}
                     className=""
-                    id="Comments-MOCK-GUID"
+                    id="Comments-MOCK-GUID-1324"
                     maxLength={255}
                     name="Comments"
                     onBlur={[Function]}
@@ -12517,13 +12517,13 @@ exports[`The print section renders properly 1`] = `
         <div
           aria-label="Police record"
           className="field   no-margin-bottom"
-          data-uuid="field-MOCK-GUID"
+          data-uuid="field-MOCK-GUID-1325"
         >
           <a
             aria-hidden="true"
             className="anchor"
-            id="field-MOCK-GUID"
-            name="field-MOCK-GUID"
+            id="field-MOCK-GUID-1325"
+            name="field-MOCK-GUID-1325"
           />
           <h2
             className="title h2"
@@ -12588,13 +12588,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have any of the following happened?"
             className="field required  branch has-offenses"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1326"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1326"
+              name="field-MOCK-GUID-1326"
             />
             <h2
               className="title h2"
@@ -12682,15 +12682,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_offenses-MOCK-GUID"
+                        htmlFor="has_offenses-MOCK-GUID-1328"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_offenses-MOCK-GUID"
-                          name="has_offenses-MOCK-GUID"
+                          id="has_offenses-MOCK-GUID-1328"
+                          name="has_offenses-MOCK-GUID-1328"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -12709,15 +12709,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_offenses-MOCK-GUID"
+                        htmlFor="has_offenses-MOCK-GUID-1329"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_offenses-MOCK-GUID"
-                          name="has_offenses-MOCK-GUID"
+                          id="has_offenses-MOCK-GUID-1329"
+                          name="has_offenses-MOCK-GUID-1329"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -12777,13 +12777,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Other than those offenses already listed, have you EVER had the following happen to you?"
             className="field required  branch has-otheroffenses"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1330"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1330"
+              name="field-MOCK-GUID-1330"
             />
             <h2
               className="title h2"
@@ -12874,15 +12874,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_otheroffenses-MOCK-GUID"
+                        htmlFor="has_otheroffenses-MOCK-GUID-1332"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_otheroffenses-MOCK-GUID"
-                          name="has_otheroffenses-MOCK-GUID"
+                          id="has_otheroffenses-MOCK-GUID-1332"
+                          name="has_otheroffenses-MOCK-GUID-1332"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -12901,15 +12901,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_otheroffenses-MOCK-GUID"
+                        htmlFor="has_otheroffenses-MOCK-GUID-1333"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_otheroffenses-MOCK-GUID"
-                          name="has_otheroffenses-MOCK-GUID"
+                          id="has_otheroffenses-MOCK-GUID-1333"
+                          name="has_otheroffenses-MOCK-GUID-1333"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -12969,13 +12969,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Is there currently a domestic violence protective order or restraining order issued against you?"
             className="field required  branch has-domestic-violence"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1334"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1334"
+              name="field-MOCK-GUID-1334"
             />
             <h2
               className="title h2"
@@ -13013,15 +13013,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_domestic_violence-MOCK-GUID"
+                        htmlFor="has_domestic_violence-MOCK-GUID-1336"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_domestic_violence-MOCK-GUID"
-                          name="has_domestic_violence-MOCK-GUID"
+                          id="has_domestic_violence-MOCK-GUID-1336"
+                          name="has_domestic_violence-MOCK-GUID-1336"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -13040,15 +13040,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_domestic_violence-MOCK-GUID"
+                        htmlFor="has_domestic_violence-MOCK-GUID-1337"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_domestic_violence-MOCK-GUID"
-                          name="has_domestic_violence-MOCK-GUID"
+                          id="has_domestic_violence-MOCK-GUID-1337"
+                          name="has_domestic_violence-MOCK-GUID-1337"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -13108,13 +13108,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Has the U.S. Government (or a foreign government) EVER investigated your background and/or granted you a security clearance eligibility/access?"
             className="field required  branch legal-investigations-history-has-history"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1338"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1338"
+              name="field-MOCK-GUID-1338"
             />
             <h2
               className="title h2"
@@ -13152,15 +13152,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_history-MOCK-GUID"
+                        htmlFor="has_history-MOCK-GUID-1340"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_history-MOCK-GUID"
-                          name="has_history-MOCK-GUID"
+                          id="has_history-MOCK-GUID-1340"
+                          name="has_history-MOCK-GUID-1340"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -13179,15 +13179,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_history-MOCK-GUID"
+                        htmlFor="has_history-MOCK-GUID-1341"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_history-MOCK-GUID"
-                          name="has_history-MOCK-GUID"
+                          id="has_history-MOCK-GUID-1341"
+                          name="has_history-MOCK-GUID-1341"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -13247,13 +13247,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER had a security clearance eligibility/access authorization denied, suspended, or revoked?"
             className="field required  branch legal-investigations-revoked-has-revocations"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1342"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1342"
+              name="field-MOCK-GUID-1342"
             />
             <h2
               className="title h2"
@@ -13297,15 +13297,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_revoked-MOCK-GUID"
+                        htmlFor="has_revoked-MOCK-GUID-1344"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_revoked-MOCK-GUID"
-                          name="has_revoked-MOCK-GUID"
+                          id="has_revoked-MOCK-GUID-1344"
+                          name="has_revoked-MOCK-GUID-1344"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -13324,15 +13324,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_revoked-MOCK-GUID"
+                        htmlFor="has_revoked-MOCK-GUID-1345"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_revoked-MOCK-GUID"
-                          name="has_revoked-MOCK-GUID"
+                          id="has_revoked-MOCK-GUID-1345"
+                          name="has_revoked-MOCK-GUID-1345"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -13392,13 +13392,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER been debarred from government employment?"
             className="field required  branch legal-investigations-debarred-has-debarment"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1346"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1346"
+              name="field-MOCK-GUID-1346"
             />
             <h2
               className="title h2"
@@ -13436,15 +13436,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_debarred-MOCK-GUID"
+                        htmlFor="has_debarred-MOCK-GUID-1348"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_debarred-MOCK-GUID"
-                          name="has_debarred-MOCK-GUID"
+                          id="has_debarred-MOCK-GUID-1348"
+                          name="has_debarred-MOCK-GUID-1348"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -13463,15 +13463,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_debarred-MOCK-GUID"
+                        htmlFor="has_debarred-MOCK-GUID-1349"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_debarred-MOCK-GUID"
-                          name="has_debarred-MOCK-GUID"
+                          id="has_debarred-MOCK-GUID-1349"
+                          name="has_debarred-MOCK-GUID-1349"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -13531,13 +13531,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="In the last ten (10) years, have you been a party to any public record civil court action not listed elsewhere on this form?"
             className="field required  branch has-court-actions"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1350"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1350"
+              name="field-MOCK-GUID-1350"
             />
             <h2
               className="title h2"
@@ -13575,15 +13575,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="HasCourtActions-MOCK-GUID"
+                        htmlFor="HasCourtActions-MOCK-GUID-1352"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="HasCourtActions-MOCK-GUID"
-                          name="HasCourtActions-MOCK-GUID"
+                          id="HasCourtActions-MOCK-GUID-1352"
+                          name="HasCourtActions-MOCK-GUID-1352"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -13602,15 +13602,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="HasCourtActions-MOCK-GUID"
+                        htmlFor="HasCourtActions-MOCK-GUID-1353"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="HasCourtActions-MOCK-GUID"
-                          name="HasCourtActions-MOCK-GUID"
+                          id="HasCourtActions-MOCK-GUID-1353"
+                          name="HasCourtActions-MOCK-GUID-1353"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -13680,13 +13680,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="In the last seven (7) years have you illegally or without proper authorization accessed or attempted to access any information technology system?"
             className="field required  branch legal-technology-unauthorized-has-unauthorized"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1354"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1354"
+              name="field-MOCK-GUID-1354"
             />
             <h2
               className="title h2"
@@ -13724,15 +13724,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_unauthorized-MOCK-GUID"
+                        htmlFor="has_unauthorized-MOCK-GUID-1356"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_unauthorized-MOCK-GUID"
-                          name="has_unauthorized-MOCK-GUID"
+                          id="has_unauthorized-MOCK-GUID-1356"
+                          name="has_unauthorized-MOCK-GUID-1356"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -13751,15 +13751,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_unauthorized-MOCK-GUID"
+                        htmlFor="has_unauthorized-MOCK-GUID-1357"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_unauthorized-MOCK-GUID"
-                          name="has_unauthorized-MOCK-GUID"
+                          id="has_unauthorized-MOCK-GUID-1357"
+                          name="has_unauthorized-MOCK-GUID-1357"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -13819,13 +13819,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="In the last seven (7) years have you illegally or without authorization, modified, destroyed, manipulated, or denied others access to information residing on an information technology system or attempted any of the above?"
             className="field required  branch legal-technology-manipulating-has-manipulating"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1358"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1358"
+              name="field-MOCK-GUID-1358"
             />
             <h2
               className="title h2"
@@ -13863,15 +13863,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_manipulating-MOCK-GUID"
+                        htmlFor="has_manipulating-MOCK-GUID-1360"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_manipulating-MOCK-GUID"
-                          name="has_manipulating-MOCK-GUID"
+                          id="has_manipulating-MOCK-GUID-1360"
+                          name="has_manipulating-MOCK-GUID-1360"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -13890,15 +13890,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_manipulating-MOCK-GUID"
+                        htmlFor="has_manipulating-MOCK-GUID-1361"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_manipulating-MOCK-GUID"
-                          name="has_manipulating-MOCK-GUID"
+                          id="has_manipulating-MOCK-GUID-1361"
+                          name="has_manipulating-MOCK-GUID-1361"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -13958,13 +13958,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="In the last seven (7) years have you introduced, removed, or used hardware, software, or media in connection with any information technology system without authorization, when specifically prohibited by rules, procedures, guidelines, or regulations or attempted any of the above?"
             className="field required  branch legal-technology-unlawful-has-unlawful"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1362"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1362"
+              name="field-MOCK-GUID-1362"
             />
             <h2
               className="title h2"
@@ -14002,15 +14002,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_unlawful-MOCK-GUID"
+                        htmlFor="has_unlawful-MOCK-GUID-1364"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_unlawful-MOCK-GUID"
-                          name="has_unlawful-MOCK-GUID"
+                          id="has_unlawful-MOCK-GUID-1364"
+                          name="has_unlawful-MOCK-GUID-1364"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -14029,15 +14029,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_unlawful-MOCK-GUID"
+                        htmlFor="has_unlawful-MOCK-GUID-1365"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_unlawful-MOCK-GUID"
-                          name="has_unlawful-MOCK-GUID"
+                          id="has_unlawful-MOCK-GUID-1365"
+                          name="has_unlawful-MOCK-GUID-1365"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -14107,13 +14107,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Are you now or have you EVER been a member of an organization dedicated to terrorism, either with an awareness of the organization's dedication to that end, or with the specific intent to further such activities?"
             className="field required  branch legal-associations-terrorist-has-terrorist"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1366"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1366"
+              name="field-MOCK-GUID-1366"
             />
             <h2
               className="title h2"
@@ -14151,15 +14151,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_terrorist-MOCK-GUID"
+                        htmlFor="has_terrorist-MOCK-GUID-1368"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_terrorist-MOCK-GUID"
-                          name="has_terrorist-MOCK-GUID"
+                          id="has_terrorist-MOCK-GUID-1368"
+                          name="has_terrorist-MOCK-GUID-1368"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -14178,15 +14178,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_terrorist-MOCK-GUID"
+                        htmlFor="has_terrorist-MOCK-GUID-1369"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_terrorist-MOCK-GUID"
-                          name="has_terrorist-MOCK-GUID"
+                          id="has_terrorist-MOCK-GUID-1369"
+                          name="has_terrorist-MOCK-GUID-1369"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -14246,13 +14246,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER knowingly engaged in any acts of terrorism?"
             className="field required  branch legal-associations-engaged-has-engaged"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1370"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1370"
+              name="field-MOCK-GUID-1370"
             />
             <h2
               className="title h2"
@@ -14290,15 +14290,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_engaged-MOCK-GUID"
+                        htmlFor="has_engaged-MOCK-GUID-1372"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_engaged-MOCK-GUID"
-                          name="has_engaged-MOCK-GUID"
+                          id="has_engaged-MOCK-GUID-1372"
+                          name="has_engaged-MOCK-GUID-1372"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -14317,15 +14317,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_engaged-MOCK-GUID"
+                        htmlFor="has_engaged-MOCK-GUID-1373"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_engaged-MOCK-GUID"
-                          name="has_engaged-MOCK-GUID"
+                          id="has_engaged-MOCK-GUID-1373"
+                          name="has_engaged-MOCK-GUID-1373"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -14385,13 +14385,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER advocated any acts of terrorism or activities designed to overthrow the U.S. Government by force?"
             className="field required  branch legal-associations-advocating-has-advocated"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1374"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1374"
+              name="field-MOCK-GUID-1374"
             />
             <h2
               className="title h2"
@@ -14429,15 +14429,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_advocated-MOCK-GUID"
+                        htmlFor="has_advocated-MOCK-GUID-1376"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_advocated-MOCK-GUID"
-                          name="has_advocated-MOCK-GUID"
+                          id="has_advocated-MOCK-GUID-1376"
+                          name="has_advocated-MOCK-GUID-1376"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -14456,15 +14456,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_advocated-MOCK-GUID"
+                        htmlFor="has_advocated-MOCK-GUID-1377"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_advocated-MOCK-GUID"
-                          name="has_advocated-MOCK-GUID"
+                          id="has_advocated-MOCK-GUID-1377"
+                          name="has_advocated-MOCK-GUID-1377"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -14524,13 +14524,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER been a member of an organization dedicated to the use of violence or force to overthrow the United States Government, and which engaged in activities to that end with an awareness of the organization's dedication to that end or with the specific intent to further such activities?"
             className="field required  branch legal-associations-overthrow-has-overthrow"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1378"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1378"
+              name="field-MOCK-GUID-1378"
             />
             <h2
               className="title h2"
@@ -14568,15 +14568,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_overthrow-MOCK-GUID"
+                        htmlFor="has_overthrow-MOCK-GUID-1380"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_overthrow-MOCK-GUID"
-                          name="has_overthrow-MOCK-GUID"
+                          id="has_overthrow-MOCK-GUID-1380"
+                          name="has_overthrow-MOCK-GUID-1380"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -14595,15 +14595,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_overthrow-MOCK-GUID"
+                        htmlFor="has_overthrow-MOCK-GUID-1381"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_overthrow-MOCK-GUID"
-                          name="has_overthrow-MOCK-GUID"
+                          id="has_overthrow-MOCK-GUID-1381"
+                          name="has_overthrow-MOCK-GUID-1381"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -14663,13 +14663,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER been a member of an organization that advocates or practices commission of acts of force or violence to discourage others from exercising their rights under the U.S. Constitution or any state of the United States with the specific intent to further such action?"
             className="field required  branch legal-associations-violence-has-violence"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1382"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1382"
+              name="field-MOCK-GUID-1382"
             />
             <h2
               className="title h2"
@@ -14707,15 +14707,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_violence-MOCK-GUID"
+                        htmlFor="has_violence-MOCK-GUID-1384"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_violence-MOCK-GUID"
-                          name="has_violence-MOCK-GUID"
+                          id="has_violence-MOCK-GUID-1384"
+                          name="has_violence-MOCK-GUID-1384"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -14734,15 +14734,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_violence-MOCK-GUID"
+                        htmlFor="has_violence-MOCK-GUID-1385"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_violence-MOCK-GUID"
-                          name="has_violence-MOCK-GUID"
+                          id="has_violence-MOCK-GUID-1385"
+                          name="has_violence-MOCK-GUID-1385"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -14802,13 +14802,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER knowingly engaged in activities designed to overthrow the U.S. Government by force?"
             className="field required  branch legal-associations-activities-has-activities"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1386"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1386"
+              name="field-MOCK-GUID-1386"
             />
             <h2
               className="title h2"
@@ -14846,15 +14846,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_activities-MOCK-GUID"
+                        htmlFor="has_activities-MOCK-GUID-1388"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_activities-MOCK-GUID"
-                          name="has_activities-MOCK-GUID"
+                          id="has_activities-MOCK-GUID-1388"
+                          name="has_activities-MOCK-GUID-1388"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -14873,15 +14873,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_activities-MOCK-GUID"
+                        htmlFor="has_activities-MOCK-GUID-1389"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_activities-MOCK-GUID"
-                          name="has_activities-MOCK-GUID"
+                          id="has_activities-MOCK-GUID-1389"
+                          name="has_activities-MOCK-GUID-1389"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -14941,13 +14941,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER associated with anyone involved in activities to further terrorism?"
             className="field required  branch legal-associations-terrorism-has-terrorism"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1390"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1390"
+              name="field-MOCK-GUID-1390"
             />
             <h2
               className="title h2"
@@ -14985,15 +14985,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_terrorsim-MOCK-GUID"
+                        htmlFor="has_terrorsim-MOCK-GUID-1392"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_terrorsim-MOCK-GUID"
-                          name="has_terrorsim-MOCK-GUID"
+                          id="has_terrorsim-MOCK-GUID-1392"
+                          name="has_terrorsim-MOCK-GUID-1392"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -15012,15 +15012,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="has_terrorsim-MOCK-GUID"
+                        htmlFor="has_terrorsim-MOCK-GUID-1393"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="has_terrorsim-MOCK-GUID"
-                          name="has_terrorsim-MOCK-GUID"
+                          id="has_terrorsim-MOCK-GUID-1393"
+                          name="has_terrorsim-MOCK-GUID-1393"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -15075,13 +15075,13 @@ exports[`The print section renders properly 1`] = `
         <div
           aria-label="Add a comment to clarify any of your responses in the investigative and criminal history section"
           className="field   section-comment"
-          data-uuid="field-MOCK-GUID"
+          data-uuid="field-MOCK-GUID-1394"
         >
           <a
             aria-hidden="true"
             className="anchor"
-            id="field-MOCK-GUID"
-            name="field-MOCK-GUID"
+            id="field-MOCK-GUID-1394"
+            name="field-MOCK-GUID-1394"
           />
           <h4
             className="title h4"
@@ -15123,7 +15123,7 @@ exports[`The print section renders properly 1`] = `
                     autoComplete={true}
                     autoCorrect={true}
                     className=""
-                    id="Comments-MOCK-GUID"
+                    id="Comments-MOCK-GUID-1395"
                     maxLength={255}
                     name="Comments"
                     onBlur={[Function]}
@@ -15168,13 +15168,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Has a court or administrative agency ever issued an order declaring you mentally incompetent?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1396"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1396"
+              name="field-MOCK-GUID-1396"
             />
             <h2
               className="title h2"
@@ -15212,15 +15212,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="is_incompetent-MOCK-GUID"
+                        htmlFor="is_incompetent-MOCK-GUID-1398"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="is_incompetent-MOCK-GUID"
-                          name="is_incompetent-MOCK-GUID"
+                          id="is_incompetent-MOCK-GUID-1398"
+                          name="is_incompetent-MOCK-GUID-1398"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -15239,15 +15239,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="is_incompetent-MOCK-GUID"
+                        htmlFor="is_incompetent-MOCK-GUID-1399"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="is_incompetent-MOCK-GUID"
-                          name="is_incompetent-MOCK-GUID"
+                          id="is_incompetent-MOCK-GUID-1399"
+                          name="is_incompetent-MOCK-GUID-1399"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -15307,13 +15307,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Has a court or administrative agency EVER ordered you to consult with a mental health professional?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1400"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1400"
+              name="field-MOCK-GUID-1400"
             />
             <h2
               className="title h2"
@@ -15362,15 +15362,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="is_incompetent-MOCK-GUID"
+                        htmlFor="is_incompetent-MOCK-GUID-1402"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="is_incompetent-MOCK-GUID"
-                          name="is_incompetent-MOCK-GUID"
+                          id="is_incompetent-MOCK-GUID-1402"
+                          name="is_incompetent-MOCK-GUID-1402"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -15389,15 +15389,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="is_incompetent-MOCK-GUID"
+                        htmlFor="is_incompetent-MOCK-GUID-1403"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="is_incompetent-MOCK-GUID"
-                          name="is_incompetent-MOCK-GUID"
+                          id="is_incompetent-MOCK-GUID-1403"
+                          name="is_incompetent-MOCK-GUID-1403"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -15457,13 +15457,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER been hospitalized for a mental health condition?"
             className="field required  branch"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1404"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1404"
+              name="field-MOCK-GUID-1404"
             />
             <h2
               className="title h2"
@@ -15501,15 +15501,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="hospitalized-MOCK-GUID"
+                        htmlFor="hospitalized-MOCK-GUID-1406"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="hospitalized-MOCK-GUID"
-                          name="hospitalized-MOCK-GUID"
+                          id="hospitalized-MOCK-GUID-1406"
+                          name="hospitalized-MOCK-GUID-1406"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -15528,15 +15528,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="hospitalized-MOCK-GUID"
+                        htmlFor="hospitalized-MOCK-GUID-1407"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="hospitalized-MOCK-GUID"
-                          name="hospitalized-MOCK-GUID"
+                          id="hospitalized-MOCK-GUID-1407"
+                          name="hospitalized-MOCK-GUID-1407"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -15608,13 +15608,13 @@ exports[`The print section renders properly 1`] = `
           <div
             aria-label="Have you EVER been diagnosed by a physician or other health professional with psychotic disorder, schizophrenia, schizoaffective disorder, delusional disorder, bipolar mood disorder, borderline personality disorder, or antisocial personality disorder?"
             className="field required  branch diagnosed"
-            data-uuid="field-MOCK-GUID"
+            data-uuid="field-MOCK-GUID-1408"
           >
             <a
               aria-hidden="true"
               className="anchor"
-              id="field-MOCK-GUID"
-              name="field-MOCK-GUID"
+              id="field-MOCK-GUID-1408"
+              name="field-MOCK-GUID-1408"
             />
             <h2
               className="title h2"
@@ -15658,15 +15658,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="diagnosed-MOCK-GUID"
+                        htmlFor="diagnosed-MOCK-GUID-1410"
                       >
                         <input
                           aria-label="Yes for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="diagnosed-MOCK-GUID"
-                          name="diagnosed-MOCK-GUID"
+                          id="diagnosed-MOCK-GUID-1410"
+                          name="diagnosed-MOCK-GUID-1410"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -15685,15 +15685,15 @@ exports[`The print section renders properly 1`] = `
                     >
                       <label
                         className=""
-                        htmlFor="diagnosed-MOCK-GUID"
+                        htmlFor="diagnosed-MOCK-GUID-1411"
                       >
                         <input
                           aria-label="No for null"
                           checked={false}
                           className="usa-input-success"
                           disabled={false}
-                          id="diagnosed-MOCK-GUID"
-                          name="diagnosed-MOCK-GUID"
+                          id="diagnosed-MOCK-GUID-1411"
+                          name="diagnosed-MOCK-GUID-1411"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onClick={[Function]}
@@ -15748,13 +15748,13 @@ exports[`The print section renders properly 1`] = `
         <div
           aria-label="Add a comment to clarify any of your responses in the psychological and emotional health section"
           className="field   section-comment"
-          data-uuid="field-MOCK-GUID"
+          data-uuid="field-MOCK-GUID-1412"
         >
           <a
             aria-hidden="true"
             className="anchor"
-            id="field-MOCK-GUID"
-            name="field-MOCK-GUID"
+            id="field-MOCK-GUID-1412"
+            name="field-MOCK-GUID-1412"
           />
           <h4
             className="title h4"
@@ -15796,7 +15796,7 @@ exports[`The print section renders properly 1`] = `
                     autoComplete={true}
                     autoCorrect={true}
                     className=""
-                    id="Comments-MOCK-GUID"
+                    id="Comments-MOCK-GUID-1413"
                     maxLength={255}
                     name="Comments"
                     onBlur={[Function]}

--- a/src/components/Section/Section.test.jsx
+++ b/src/components/Section/Section.test.jsx
@@ -6,14 +6,6 @@ import { MemoryRouter } from 'react-router'
 import Section from './Section'
 import { mount } from 'enzyme'
 
-// give a fake GUID so the field IDs don't differ between snapshots
-// https://github.com/facebook/jest/issues/936#issuecomment-404246102
-jest.mock('../Form/ValidationElement/helpers', () =>
-  Object.assign(require.requireActual('../Form/ValidationElement/helpers'), {
-    newGuid: jest.fn().mockReturnValue('MOCK-GUID')
-  })
-)
-
 describe('The section component', () => {
   const mockStore = configureMockStore()
 

--- a/src/components/Section/__snapshots__/Section.test.jsx.snap
+++ b/src/components/Section/__snapshots__/Section.test.jsx.snap
@@ -28,13 +28,13 @@ exports[`The section component renders the Section component at a particular sub
                     <div
                       aria-label="Provide your contact information"
                       className="field   no-margin-bottom"
-                      data-uuid="field-MOCK-GUID"
+                      data-uuid="field-MOCK-GUID-0"
                     >
                       <a
                         aria-hidden="true"
                         className="anchor"
-                        id="field-MOCK-GUID"
-                        name="field-MOCK-GUID"
+                        id="field-MOCK-GUID-0"
+                        name="field-MOCK-GUID-0"
                       />
                       <h2
                         className="title h2"
@@ -76,13 +76,13 @@ exports[`The section component renders the Section component at a particular sub
                     <div
                       aria-label="Your email addresses"
                       className="field   no-margin-bottom"
-                      data-uuid="field-MOCK-GUID"
+                      data-uuid="field-MOCK-GUID-1"
                     >
                       <a
                         aria-hidden="true"
                         className="anchor"
-                        id="field-MOCK-GUID"
-                        name="field-MOCK-GUID"
+                        id="field-MOCK-GUID-1"
+                        name="field-MOCK-GUID-1"
                       />
                       <h3
                         className="title h3"
@@ -185,13 +185,13 @@ exports[`The section component renders the Section component at a particular sub
                     <div
                       aria-label="Your phone numbers"
                       className="field   no-margin-bottom"
-                      data-uuid="field-MOCK-GUID"
+                      data-uuid="field-MOCK-GUID-4"
                     >
                       <a
                         aria-hidden="true"
                         className="anchor"
-                        id="field-MOCK-GUID"
-                        name="field-MOCK-GUID"
+                        id="field-MOCK-GUID-4"
+                        name="field-MOCK-GUID-4"
                       />
                       <h3
                         className="title h3"


### PR DESCRIPTION
Rather than having to put mocks in every snapshot of form fields, this ensures that fields will not have GUIDs that change with every test run.

**The catch:** Every field having the same GUID _may_ have implications for the tests, and make things behave in a strange way. I don't understand what they're used for enough to understand the implications.

There's definitely a better way to ensure consistency (like hashing the section, subsection, and field name?), but I'm not sure what it is.