### PR TITLE
add a testSectionSnapshots() helper

### DIFF
--- a/src/components/Section/Identification/Identification.test.jsx
+++ b/src/components/Section/Identification/Identification.test.jsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux'
 import Identification, { IdentificationSections } from './Identification'
 import { mount } from 'enzyme'
 import navigation from './navigation'
-import { testSnapshot } from '../../test-helpers'
+import { testSectionSnapshots, testSnapshot } from '../../test-helpers'
 
 const applicationState = {
   Identification: {
@@ -85,21 +85,13 @@ describe('The identification section', () => {
     })
   })
 
-  navigation.subsections.forEach(subsection => {
-    it(`renders the Identification component for the ${
-      subsection.url
-    } subsection`, () => {
-      const store = mockStore({
-        authentication: { authenticated: true },
-        application: applicationState
-      })
-      testSnapshot(
-        <Provider store={store}>
-          <Identification subsection={subsection.url} />
-        </Provider>
-      )
+  {
+    const store = mockStore({
+      authentication: { authenticated: true },
+      application: applicationState
     })
-  })
+    testSectionSnapshots(navigation, store, Identification)
+  }
 
   it('renders the IdentificationSections component', () => {
     testSnapshot(<IdentificationSections />)

--- a/src/components/test-helpers.js
+++ b/src/components/test-helpers.js
@@ -1,4 +1,6 @@
+import React from 'react'
 import renderer from 'react-test-renderer'
+import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
 
 export const testSnapshot = (jsx, minElements = 3) => {
@@ -9,4 +11,18 @@ export const testSnapshot = (jsx, minElements = 3) => {
   const component = renderer.create(jsx)
   let tree = component.toJSON()
   expect(tree).toMatchSnapshot()
+}
+
+export const testSectionSnapshots = (navigation, store, Component) => {
+  navigation.subsections.forEach(subsection => {
+    it(`renders the ${navigation.store} component for the ${
+      subsection.url
+    } subsection`, () => {
+      testSnapshot(
+        <Provider store={store}>
+          <Component subsection={subsection.url} />
+        </Provider>
+      )
+    })
+  })
 }


### PR DESCRIPTION
Alternative to #702, for slightly less boilerplate than what's on `develop` but still having the snapshots in every test file. Thoughts?