### PR TITLE
Persist data with multiple employment entries

### DIFF
--- a/api/physicaladdress.go
+++ b/api/physicaladdress.go
@@ -199,7 +199,7 @@ func (entity *PhysicalAddress) SetID(id int) {
 
 // Find the previous entity stored if one is available.
 func (entity *PhysicalAddress) Find(context DatabaseService) error {
-	context.Find(&PhysicalAddress{ID: entity.AccountID}, func(result interface{}) {
+	context.Find(&PhysicalAddress{ID: entity.ID, AccountID: entity.AccountID}, func(result interface{}) {
 		previous := result.(*PhysicalAddress)
 		if entity.HasDifferentAddress == nil {
 			entity.HasDifferentAddress = &Branch{}

--- a/api/reasonleft.go
+++ b/api/reasonleft.go
@@ -197,7 +197,7 @@ func (entity *ReasonLeft) SetID(id int) {
 
 // Find the previous entity stored if one is available.
 func (entity *ReasonLeft) Find(context DatabaseService) error {
-	context.Find(&ReasonLeft{ID: entity.AccountID}, func(result interface{}) {
+	context.Find(&ReasonLeft{ID: entity.ID, AccountID: entity.AccountID}, func(result interface{}) {
 		previous := result.(*ReasonLeft)
 		if entity.Comments == nil {
 			entity.Comments = &Textarea{}

--- a/api/supervisor.go
+++ b/api/supervisor.go
@@ -295,7 +295,7 @@ func (entity *Supervisor) SetID(id int) {
 
 // Find the previous entity stored if one is available.
 func (entity *Supervisor) Find(context DatabaseService) error {
-	context.Find(&Supervisor{ID: entity.AccountID}, func(result interface{}) {
+	context.Find(&Supervisor{ID: entity.ID, AccountID: entity.AccountID}, func(result interface{}) {
 		previous := result.(*Supervisor)
 		if entity.SupervisorName == nil {
 			entity.SupervisorName = &Text{}

--- a/src/components/Section/History/Employment/Supervisor.jsx
+++ b/src/components/Section/History/Employment/Supervisor.jsx
@@ -17,7 +17,6 @@ export default class Supervisor extends ValidationElement {
 
   update (queue) {
     this.props.onUpdate({
-      name: this.props.name,
       SupervisorName: this.props.SupervisorName,
       Title: this.props.Title,
       Email: this.props.Email,


### PR DESCRIPTION
`PhysicalAddress`, `ReasonLeft`, and `Supervisor` fields were being matched solely on their entityID which meant they were not being matched within the context of the larger accountID. This caused the same entityID to be overwritten with data whenever a job was added or updated. Fixes #693.