### PR TITLE
Fix conditional statement for calculating date ranges

### DIFF
--- a/src/components/Section/History/dateranges.js
+++ b/src/components/Section/History/dateranges.js
@@ -2,7 +2,7 @@
  * Take one of the many schemas of a date and always output a valid
  * Date object or null.
  */
-export const extractDate = (dateObj) => {
+export const extractDate = dateObj => {
   if (dateObj instanceof Date) {
     return dateObj
   }
@@ -39,11 +39,11 @@ export const decimalAdjust = (type, value, exp) => {
 
   // Shift
   value = value.toString().split('e')
-  value = Math[type](+(value[0] + 'e' + (value[1] ? (+value[1] - exp) : -exp)))
+  value = Math[type](+(value[0] + 'e' + (value[1] ? +value[1] - exp : -exp)))
 
   // Shift back
   value = value.toString().split('e')
-  return +(value[0] + 'e' + (value[1] ? (+value[1] + exp) : exp))
+  return +(value[0] + 'e' + (value[1] ? +value[1] + exp : exp))
 }
 
 /**
@@ -73,13 +73,13 @@ export const rangeSorter = (a, b) => {
  * Calculate a date in the past
  */
 export const daysAgo = (from, days) => {
-  return new Date(from - (1000 * 60 * 60 * 24 * days))
+  return new Date(from - 1000 * 60 * 60 * 24 * days)
 }
 
 /**
  * Convert date to UTC
  */
-export const utc = (date) => {
+export const utc = date => {
   if (!date) {
     return null
   }
@@ -93,17 +93,17 @@ export const utc = (date) => {
 /**
  * Get the Julian date
  */
-export const julian = (date) => {
+export const julian = date => {
   if (!date) {
     return null
   }
-  return (((+utc(date)) / 86400000) + 2440587.5).toFixed(6)
+  return (+utc(date) / 86400000 + 2440587.5).toFixed(6)
 }
 
 /**
  * Convert a Julian date to a normal date
  */
-export const fromJulian = (julian) => {
+export const fromJulian = julian => {
   return new Date((Number(julian) - 2440587.5) * 86400000)
 }
 
@@ -143,8 +143,8 @@ export const daysBetween = (from, to) => {
 /**
  * Determine if a specified year is considered a leap year
  */
-export const leapYear = (year) => {
-  return ((year % 4 === 0) && (year % 100 !== 0)) || (year % 400 === 0)
+export const leapYear = year => {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0
 }
 
 /**
@@ -180,10 +180,15 @@ export const validDate = (month, day, year) => {
   const d = parseInt(day || 0)
   const y = parseInt(year || 0)
 
-  return (y > 1000 && y < 10000) && (m > 0 && m < 13) && (d > 0 && d <= daysInMonth(m, y))
+  return (
+    y > 1000 &&
+    y < 10000 &&
+    (m > 0 && m < 13) &&
+    (d > 0 && d <= daysInMonth(m, y))
+  )
 }
 
-export const endOfMonth = (date) => {
+export const endOfMonth = date => {
   if (!date) {
     return null
   }
@@ -199,7 +204,10 @@ export const endOfMonth = (date) => {
 export const gaps = (ranges = [], start = ten, buffer = 30) => {
   // If any of the ranges covers the entire timeline then return no gaps
   for (const range of ranges) {
-    if (daysAgo(range.from, -1 * buffer) <= start && range.to >= daysAgo(start, buffer)) {
+    if (
+      daysAgo(range.from, -1 * buffer) <= start &&
+      range.to >= daysAgo(today, buffer)
+    ) {
       return []
     }
   }
@@ -223,7 +231,11 @@ export const gaps = (ranges = [], start = ten, buffer = 30) => {
     start = range.to
 
     // If this is the last date range check for gaps in the future
-    if (i === length && start < fullStop && daysBetween(start, fullStop) > buffer) {
+    if (
+      i === length &&
+      start < fullStop &&
+      daysBetween(start, fullStop) > buffer
+    ) {
       holes.push({ from: range.to, to: fullStop })
     }
   })

--- a/src/components/Section/History/summaries.test.jsx
+++ b/src/components/Section/History/summaries.test.jsx
@@ -1,6 +1,11 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import { ResidenceCustomSummary, EmploymentCustomSummary, EducationCustomSummary, InjectGaps } from './summaries'
+import {
+  ResidenceCustomSummary,
+  EmploymentCustomSummary,
+  EducationCustomSummary,
+  InjectGaps
+} from './summaries'
 import Location from '../../Form/Location'
 import { today } from './dateranges'
 
@@ -43,15 +48,18 @@ describe('The summary components', () => {
       byline: () => {}
     }
 
-    const component = mount(ResidenceCustomSummary(
-      expected.item,
-      expected.index,
-      expected.initial,
-      expected.callback,
-      expected.toggle,
-      expected.openText,
-      expected.remove,
-      expected.byline))
+    const component = mount(
+      ResidenceCustomSummary(
+        expected.item,
+        expected.index,
+        expected.initial,
+        expected.callback,
+        expected.toggle,
+        expected.openText,
+        expected.remove,
+        expected.byline
+      )
+    )
     expect(component.find('.index').length).toEqual(1)
     expect(component.find('.context').length).toEqual(1)
     expect(component.find('.dates').length).toEqual(1)
@@ -90,15 +98,18 @@ describe('The summary components', () => {
       byline: () => {}
     }
 
-    const component = mount(EmploymentCustomSummary(
-      expected.item,
-      expected.index,
-      expected.initial,
-      expected.callback,
-      expected.toggle,
-      expected.openText,
-      expected.remove,
-      expected.byline))
+    const component = mount(
+      EmploymentCustomSummary(
+        expected.item,
+        expected.index,
+        expected.initial,
+        expected.callback,
+        expected.toggle,
+        expected.openText,
+        expected.remove,
+        expected.byline
+      )
+    )
     expect(component.find('.index').length).toEqual(1)
     expect(component.find('.context').length).toEqual(1)
     expect(component.find('.dates').length).toEqual(1)
@@ -137,22 +148,25 @@ describe('The summary components', () => {
       byline: () => {}
     }
 
-    const component = mount(EducationCustomSummary(
-      expected.item,
-      expected.index,
-      expected.initial,
-      expected.callback,
-      expected.toggle,
-      expected.openText,
-      expected.remove,
-      expected.byline))
+    const component = mount(
+      EducationCustomSummary(
+        expected.item,
+        expected.index,
+        expected.initial,
+        expected.callback,
+        expected.toggle,
+        expected.openText,
+        expected.remove,
+        expected.byline
+      )
+    )
     expect(component.find('.index').length).toEqual(1)
     expect(component.find('.context').length).toEqual(1)
     expect(component.find('.dates').length).toEqual(1)
   })
 
   it('can inject gaps', () => {
-    const expand = (date) => {
+    const expand = date => {
       return {
         day: `${date.getDate()}`,
         month: `${date.getMonth() + 1}`,
@@ -174,18 +188,34 @@ describe('The summary components', () => {
     }
 
     const list = [
-      item('Residence',  new Date(today.getFullYear() -  5, 12, 17), today),
-      item('Residence',  new Date(today.getFullYear() - 11, 12, 17), new Date(today.getFullYear() - 9, 12, 17)),
-      item('Employment', new Date(today.getFullYear() -  5, 12, 17), today),
-      item('Gap',        new Date(today.getFullYear() - 10, 12, 17), new Date(today.getFullYear() - 5, 12, 17))
+      item('Residence', new Date(today.getFullYear() - 5, 12, 17), today),
+      item(
+        'Residence',
+        new Date(today.getFullYear() - 11, 12, 17),
+        new Date(today.getFullYear() - 9, 12, 17)
+      ),
+      item('Employment', new Date(today.getFullYear() - 5, 12, 17), today),
+      item(
+        'Gap',
+        new Date(today.getFullYear() - 10, 12, 17),
+        new Date(today.getFullYear() - 5, 12, 17)
+      )
     ]
 
-    const residence = InjectGaps(list.filter(x => x.type === 'Residence' || x.type === 'Gap'))
-    const employment = InjectGaps(list.filter(x => x.type === 'Employment' || x.type === 'Gap'))
+    const residence = InjectGaps(
+      list.filter(x => x.type === 'Residence' || x.type === 'Gap')
+    )
+    const employment = InjectGaps(
+      list.filter(x => x.type === 'Employment' || x.type === 'Gap')
+    )
 
-    expect(residence.filter(item => item.type === 'Residence').length).toEqual(2)
-    expect(residence.filter(item => item.type === 'Gap').length).toEqual(0)
-    expect(employment.filter(item => item.type === 'Employment').length).toEqual(1)
+    expect(residence.filter(item => item.type === 'Residence').length).toEqual(
+      2
+    )
+    expect(residence.filter(item => item.type === 'Gap').length).toEqual(1)
+    expect(
+      employment.filter(item => item.type === 'Employment').length
+    ).toEqual(1)
     expect(employment.filter(item => item.type === 'Gap').length).toEqual(1)
   })
 })


### PR DESCRIPTION
There was some logic introduced recently (https://github.com/ryanhofdotgov/e-QIP-prototype-truetandem/pull/2689) to suppress gaps when the date range of an entry met or exceeded the required date range of the section. I _think_ this was meant mostly to address an issue with the `People who know you well` section, since it was still showing gaps between entries even if one of the people spanned the entire 7 year period.

It looks like there was a mistake in the logic which causes some false positives and suppresses gaps even when they should be appearing as in https://github.com/18F/e-QIP-prototype/issues/574. Rather than using today's date to calculate the end of the desired range, it was using the date for the beginning of the range. So if _any_ entry has a start date that occurs before the required beginning date of the range all gaps would be suppressed. This corrects that to make sure the range begins before the required start date, and ends at today's date (with a 30 day buffer on each end of the range).