### PR TITLE
Do not require aliases for non-immediate family members

### DIFF
--- a/src/validators/relatives.js
+++ b/src/validators/relatives.js
@@ -159,6 +159,12 @@ export class RelativeValidator {
 
   validAliases() {
     const items = this.aliases.items || []
+    const nonImmediateFamily = ['Fosterparent', 'Father-in-law', 'Mother-in-law', 'Guardian']
+
+    if (nonImmediateFamily.includes(this.relation)) {
+      return true
+    }
+
     if (items.length === 0) {
       return false
     }

--- a/src/validators/relatives.test.js
+++ b/src/validators/relatives.test.js
@@ -268,6 +268,17 @@ describe('Relatives validation', function() {
       },
       {
         data: {
+          Relation: {
+            value: 'Guardian'
+          },
+          Aliases: {
+            items: []
+          }
+        },
+        expected: true
+      },
+      {
+        data: {
           hideMaiden: false,
           Aliases: {
             items: [


### PR DESCRIPTION
When entering relatives the `Has this relative used any additional names?` question is required unless the relative is not considered an immediate family member (in which case the question is hidden). This updates the validation logic to not flag non-immediate family members when the alias field is not answered. Fixes https://github.com/18F/e-QIP-prototype/issues/735