### PR TITLE
Allow opting in to the redux logger, off by default

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -4,21 +4,22 @@ The frontend is built in [React](https://reactjs.org/), wired up with [React Rou
 
 Here are some of the major directories:
 
-* [`/`](..): Things like the [`package.json`](../package.json) and config files for other tools live at the root directory of the repository
-* [`specs/`](../specs): [Integration tests](../specs/README.md)
-* [`src/`](../src): All the frontend source files live here
-  * [`actions/`](../src/actions): [Redux action creators](https://redux.js.org/basics/actions#action-creators)
-  * [`components/`](../src/components): Underlying React components used by the views or other components. Each should have corresponding styles (where applicable), tests, etc. in the same subdirectory.
-  * [`config/locales/`](../src/config/locales): Where any user-visible text is stored
-  * [`reducers/`](../src/reducers): [Redux reducers](https://redux.js.org/basics/reducers)
-  * [`sass/`](../src/sass): Handful of shared SASS files
-  * [`validators/`](../src/validators): The validation logic
-  * [`views/`](../src/views): Higher-level React components that correspond to different pages/routes
+- [`/`](..): Things like the [`package.json`](../package.json) and config files for other tools live at the root directory of the repository
+- [`specs/`](../specs): [Integration tests](../specs/README.md)
+- [`src/`](../src): All the frontend source files live here
+  - [`actions/`](../src/actions): [Redux action creators](https://redux.js.org/basics/actions#action-creators)
+  - [`components/`](../src/components): Underlying React components used by the views or other components. Each should have corresponding styles (where applicable), tests, etc. in the same subdirectory.
+  - [`config/locales/`](../src/config/locales): Where any user-visible text is stored
+  - [`reducers/`](../src/reducers): [Redux reducers](https://redux.js.org/basics/reducers)
+  - [`sass/`](../src/sass): Handful of shared SASS files
+  - [`validators/`](../src/validators): The validation logic
+  - [`views/`](../src/views): Higher-level React components that correspond to different pages/routes
 
 ## Troubleshooting
 
-* Use of the [React Developer Tools](https://github.com/facebook/react-devtools) and [Redux DevTools Extension](http://extension.remotedev.io/) are recommended for frontend work.
-* With the React extension, the Redux store can be inspected by running `$r.store.getState();` in your browser's JavaScript console.
+- Use of the [React Developer Tools](https://github.com/facebook/react-devtools) and [Redux DevTools Extension](http://extension.remotedev.io/) are recommended for frontend work.
+- With the React extension, the Redux store can be inspected by running `$r.store.getState();` in your browser's JavaScript console.
+- You may opt in to [Logger for Redux](https://github.com/evgenyrodionov/redux-logger) by appending `logger` as a query param on initial load (`?logger`).
 
 ## Tests
 

--- a/src/services/store.js
+++ b/src/services/store.js
@@ -18,7 +18,7 @@ switch (process.env.NODE_ENV) {
     store = createStore(rootReducer, applyMiddleware(...middleware))
     break
   default:
-    if (urlParams.has('logger')) {
+    if (!urlParams.has('no-redux-logger')) {
       middleware.push(createLogger())
     }
     store = createStore(

--- a/src/services/store.js
+++ b/src/services/store.js
@@ -5,6 +5,7 @@ import { composeWithDevTools } from 'redux-devtools-extension'
 import { createLogger } from 'redux-logger'
 
 const middleware = [thunk]
+const urlParams = new URLSearchParams(window.location.search)
 
 // Creates a redux store that defines the state tree for the application.
 // See rootReducer for all sub-states.
@@ -17,7 +18,9 @@ switch (process.env.NODE_ENV) {
     store = createStore(rootReducer, applyMiddleware(...middleware))
     break
   default:
-    middleware.push(createLogger())
+    if (urlParams.has('logger')) {
+      middleware.push(createLogger())
+    }
     store = createStore(
       rootReducer,
       composeWithDevTools(applyMiddleware(...middleware))


### PR DESCRIPTION
While the redux logger can be helpful, it does create a lot of noise in the console. This turns it off by default and instead allows you to opt-in with a query param in non-prod environments.