### PR TITLE
Use valid date range for people test

### DIFF
--- a/src/validators/people.test.js
+++ b/src/validators/people.test.js
@@ -51,13 +51,7 @@ describe('People validator', function() {
                       year: '2009',
                       date: new Date('1/1/2009')
                     },
-                    to: {
-                      month: '1',
-                      day: '1',
-                      year: currentYear,
-                      date: new Date(`1/1/${currentYear}`)
-                    },
-                    present: false
+                    present: true
                   },
                   Rank: {
                     value: 'Some rank'


### PR DESCRIPTION
This fixes recent CI failures relating to people validation. The mock data was using fixed date ranges that did not meet the date range requirements updated in https://github.com/18F/e-QIP-prototype/pull/734. This updates the mock data to use the `present` date for the end of the range for one of the individuals, ensuring that the date will fall within the last 30 days.