### PR TITLE
Only send digits for selective service number

### DIFF
--- a/src/components/Section/Military/Selective/Selective.jsx
+++ b/src/components/Section/Military/Selective/Selective.jsx
@@ -121,7 +121,6 @@ export default class Selective extends SubsectionElement {
                     name="RegistrationNumber"
                     className="registration-number"
                     label={i18n.t('military.selective.label.number')}
-                    name={this.props.RegistrationNumber.name}
                     value={this.state.RegistrationNumber}
                     onUpdate={this.updateRegistrationNumber}
                     onError={this.handleError}

--- a/src/components/Section/Military/Selective/Selective.jsx
+++ b/src/components/Section/Military/Selective/Selective.jsx
@@ -15,10 +15,6 @@ export default class Selective extends SubsectionElement {
     this.updateRegistered = this.updateRegistered.bind(this)
     this.updateRegistrationNumber = this.updateRegistrationNumber.bind(this)
     this.updateExplanation = this.updateExplanation.bind(this)
-
-    this.state = {
-      registrationNumber: ''
-    }
   }
 
   update(queue) {
@@ -56,16 +52,9 @@ export default class Selective extends SubsectionElement {
   }
 
   updateRegistrationNumber(value) {
-    const valueWithDashes = value.value.replace(/[^0-9-]/g, '')
-    const valueJustNumbers = value.value.replace(/\D/g, '')
-
-    this.setState({ RegistrationNumber: valueWithDashes })
-
-    if (valueJustNumbers !== this.props.RegistrationNumber.value) {
-      this.update({
-        RegistrationNumber: { ...value, value: valueJustNumbers }
-      })
-    }
+    this.update({
+      RegistrationNumber: value
+    })
   }
 
   updateExplanation(value) {
@@ -121,7 +110,9 @@ export default class Selective extends SubsectionElement {
                     name="RegistrationNumber"
                     className="registration-number"
                     label={i18n.t('military.selective.label.number')}
-                    value={this.state.RegistrationNumber}
+                    {...this.props.RegistrationNumber}
+                    pattern="^\d*$"
+                    prefix="selective"
                     onUpdate={this.updateRegistrationNumber}
                     onError={this.handleError}
                     required={this.props.required}

--- a/src/components/Section/Military/Selective/Selective.jsx
+++ b/src/components/Section/Military/Selective/Selective.jsx
@@ -15,6 +15,10 @@ export default class Selective extends SubsectionElement {
     this.updateRegistered = this.updateRegistered.bind(this)
     this.updateRegistrationNumber = this.updateRegistrationNumber.bind(this)
     this.updateExplanation = this.updateExplanation.bind(this)
+
+    this.state = {
+      registrationNumber: ''
+    }
   }
 
   update(queue) {
@@ -52,9 +56,16 @@ export default class Selective extends SubsectionElement {
   }
 
   updateRegistrationNumber(value) {
-    this.update({
-      RegistrationNumber: value
-    })
+    const valueWithDashes = value.value.replace(/[^0-9-]/g, '')
+    const valueJustNumbers = value.value.replace(/\D/g, '')
+
+    this.setState({ RegistrationNumber: valueWithDashes })
+
+    if (valueJustNumbers !== this.props.RegistrationNumber.value) {
+      this.update({
+        RegistrationNumber: { ...value, value: valueJustNumbers }
+      })
+    }
   }
 
   updateExplanation(value) {
@@ -110,7 +121,8 @@ export default class Selective extends SubsectionElement {
                     name="RegistrationNumber"
                     className="registration-number"
                     label={i18n.t('military.selective.label.number')}
-                    {...this.props.RegistrationNumber}
+                    name={this.props.RegistrationNumber.name}
+                    value={this.state.RegistrationNumber}
                     onUpdate={this.updateRegistrationNumber}
                     onError={this.handleError}
                     required={this.props.required}

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -119,6 +119,13 @@ export const error = {
       message: 'The social security number is considered invalid.'
     }
   },
+  selective: {
+    pattern: {
+      title: 'Oops, there’s a problem.',
+      message: 'Your Selective Service Number should only be numbers.',
+      note: ''
+    }
+  },
   date: {
     month: {
       notfound: {

--- a/src/validators/selectiveservice.js
+++ b/src/validators/selectiveservice.js
@@ -41,7 +41,11 @@ export default class SelectiveServiceValidator {
 
   validRegistrationNumber() {
     if (this.wasBornAfter === 'Yes' && this.hasRegistered === 'Yes') {
-      return validGenericTextfield(this.registrationNumber)
+      return !!(
+        this.registrationNumber &&
+        this.registrationNumber.value &&
+        /^\d*$/g.test(this.registrationNumber.value)
+      )
     }
 
     return true

--- a/src/validators/selectiveservice.test.js
+++ b/src/validators/selectiveservice.test.js
@@ -162,6 +162,16 @@ describe('Selective service validation', function() {
           WasBornAfter: { value: 'Yes' },
           HasRegistered: { value: 'Yes' },
           RegistrationNumber: {
+            value: '123abc7890'
+          }
+        },
+        expected: false
+      },
+      {
+        state: {
+          WasBornAfter: { value: 'Yes' },
+          HasRegistered: { value: 'Yes' },
+          RegistrationNumber: {
             value: '1234567890'
           }
         },


### PR DESCRIPTION
In the redux state, only store digits for the Selective Service registration number.  Within the UI, however, also allow dashes to match the output from sso.gov, but strip everything else.

Closes #750