### PR TITLE
Fix maiden name date range by adding optional to date control validation

### DIFF
--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -449,7 +449,9 @@ DateControl.defaultProps = {
   prefix: '',
   noMaxDate: false,
   maxDate: null,
+  maxDateEqualTo: false,
   minDate: null,
+  minDateEqualTo: false,
   relationship: '',
   toggleFocus: (w, changed, el, day, month) => {
     day.focus()

--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -225,7 +225,9 @@ export default class DateRange extends ValidationElement {
             {...this.state.from}
             onUpdate={this.updateFrom}
             minDate={this.props.minDate}
+            minDateEqualTo={this.props.minDateEqualTo}
             maxDate={this.props.maxDate}
+            maxDateEqualTo={this.props.maxDateEqualTo}
             prefix={this.props.prefix}
             onError={this.handleErrorFrom}
             disabled={this.props.disabled}
@@ -249,7 +251,9 @@ export default class DateRange extends ValidationElement {
             disabled={this.state.present || this.props.disabled}
             onUpdate={this.updateTo}
             minDate={this.props.minDate}
+            minDateEqualTo={this.props.minDateEqualTo}
             maxDate={this.props.maxDate}
+            maxDateEqualTo={this.props.maxDateEqualTo}
             prefix={this.props.prefix}
             onError={this.handleErrorTo}
             required={
@@ -283,7 +287,9 @@ DateRange.defaultProps = {
   present: false,
   prefix: '',
   minDate: null,
+  minDateEqualTo: false,
   maxDate: new Date(),
+  maxDateEqualTo: false,
   onError: (value, arr) => {
     return arr
   },

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -325,6 +325,7 @@ export default class CivilUnion extends ValidationElement {
                   bind={true}
                   prefix="relative"
                   minDate={(this.props.Birthdate || {}).date}
+                  minDateEqualTo={true}
                   className="datesused"
                   onError={this.props.onError}
                   required={this.props.required}

--- a/src/validators/datecontrol.js
+++ b/src/validators/datecontrol.js
@@ -21,7 +21,9 @@ export default class DateControlValidator {
     this.year = data.year
     this.hideDay = data.hideDay
     this.maxDate = data.maxDate
+    this.maxDateEqualTo = data.maxDateEqualTo || false
     this.minDate = data.minDate
+    this.minDateEqualTo = data.minDateEqualTo || false
     this.noMaxDate = data.noMaxDate
     this.relationship = data.relationship || ''
     context = context || getContext()
@@ -58,6 +60,11 @@ export default class DateControlValidator {
     }
 
     const date = new Date(`${this.month}/${this.day}/${this.year}`)
+
+    if (this.maxDateEqualTo) {
+      return date <= this.maxDate
+    }
+
     return date < this.maxDate
   }
 
@@ -73,6 +80,11 @@ export default class DateControlValidator {
     }
 
     const date = new Date(`${this.month}/${this.day}/${this.year}`)
+
+    if (this.minDateEqualTo) {
+      return date >= this.minDate
+    }
+
     return date > this.minDate
   }
 

--- a/src/validators/datecontrol.test.js
+++ b/src/validators/datecontrol.test.js
@@ -70,6 +70,16 @@ describe('date control validator', function() {
           month: '1',
           day: '1',
           year: '2005',
+          maxDate: new Date('1/1/2005'),
+          maxDateEqualTo: true
+        },
+        expected: true
+      },
+      {
+        data: {
+          month: '1',
+          day: '1',
+          year: '2005',
           maxDate: null
         },
         expected: true
@@ -148,6 +158,17 @@ describe('date control validator', function() {
           hideDay: true
         },
         expected: false
+      },
+      {
+        data: {
+          month: '1',
+          day: '1',
+          year: '2004',
+          minDate: new Date('1/1/2004'),
+          minDateEqualTo: true,
+          hideDay: true
+        },
+        expected: true
       }
     ]
 


### PR DESCRIPTION
This closes #746 by adding an optional property to allow the `datecontrol.js` to allow `minDate` and `maxDate` validations be `>=` or `<=` if passed the boolean props `minDateEquaTo` or `maxDateEqualTo`.  These are set to `false` by default to not impact another expected functionality.

Added the `minDateEqualTo` prop on the `<CivilUnion />` date range component to enable the maiden name from date to be equal to or greater than the birthdate.