### PR TITLE
Cap currency values at positive 32-bit signed int

### DIFF
--- a/src/components/Form/Currency/Currency.jsx
+++ b/src/components/Form/Currency/Currency.jsx
@@ -42,7 +42,7 @@ Currency.defaultProps = {
   disabled: false,
   value: '',
   min: '1',
-  max: '',
+  max: '2147483647',
   onError: (value, arr) => {
     return arr
   }

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -777,6 +777,10 @@ export const error = {
     }
   },
   currency: {
+    max: {
+      title: 'Currency value is too large',
+      message: 'Currency amounts over $2,147,483,647 are not supported.'
+    },
     min: {
       title: 'There is a problem with the losses',
       message: 'The reported losses should have a dollar value.',

--- a/src/validators/helpers.js
+++ b/src/validators/helpers.js
@@ -18,7 +18,7 @@ export const validCurrency = obj => {
   if (!obj || !obj.value || isNaN(obj.value)) {
     return false
   }
-  return true
+  return +obj.value < 2147483648
 }
 
 /**

--- a/src/validators/helpers.test.js
+++ b/src/validators/helpers.test.js
@@ -79,6 +79,12 @@ describe('Helpers for validators', function() {
           value: 'f'
         },
         expected: false
+      },
+      {
+        Field: {
+          value: '2147483648'
+        },
+        expected: false
       }
     ]
 


### PR DESCRIPTION
On the `Currency.jsx` component, sets a max value.  Adds an error message.  Updates the currency validator to enforce max value.

![screen shot 2018-09-11 at 3 27 07 pm](https://user-images.githubusercontent.com/1775733/45385713-2b120f00-b5d7-11e8-89b6-2d36379c7645.png)

closes #749 