### PR TITLE
Remove (comment out) Attachments sub-section

### DIFF
--- a/src/components/Navigation/__snapshots__/Navigation.test.jsx.snap
+++ b/src/components/Navigation/__snapshots__/Navigation.test.jsx.snap
@@ -2289,23 +2289,6 @@ exports[`Navigation component renders correctly 1`] = `
             <a
               aria-current={false}
               className="section-link"
-              href="/form/package/attachments"
-              onClick={[Function]}
-            >
-              <span
-                className="section-name"
-              >
-                Attachments
-              </span>
-              <span
-                className="eapp-status-icon"
-              />
-            </a>
-          </li>
-          <li>
-            <a
-              aria-current={false}
-              className="section-link"
               href="/form/package/review"
               onClick={[Function]}
             >

--- a/src/config/navigation.js
+++ b/src/config/navigation.js
@@ -30,6 +30,8 @@ const navigation = [
     showNumber: false,
     exclude: true,
     subsections: [
+      /* XXX See: https://github.com/18F/e-QIP-prototype/issues/795
+                  https://github.com/18F/e-QIP-prototype/issues/787
       {
         name: 'Attachments',
         url: 'attachments',
@@ -38,6 +40,7 @@ const navigation = [
           return !env.AttachmentsEnabled()
         }
       },
+      */
       {
         name: 'Review',
         url: 'review',


### PR DESCRIPTION
Fixes #787 (really more like "fixes")

Due to time constraints of NBIS 1.0, just remove this section.
Follow up with  https://github.com/18F/e-QIP-prototype/issues/795
ATTACHMENTS_ENABLED continues to function for back-end as expected.