### PR TITLE
Use separate fields from applicant's home and work email addresses

### DIFF
--- a/api/migrations/20180914153510_add_contact_emails.sql
+++ b/api/migrations/20180914153510_add_contact_emails.sql
@@ -1,0 +1,16 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+-- +goose StatementBegin
+ALTER TABLE identification_contacts DROP COLUMN IF EXISTS emails_id;
+ALTER TABLE identification_contacts ADD COLUMN home_email_id bigint REFERENCES emails(id);
+ALTER TABLE identification_contacts ADD COLUMN work_email_id bigint REFERENCES emails(id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+-- +goose StatementBegin
+ALTER TABLE identification_contacts ADD COLUMN emails_id bigint REFERENCES collections(id);
+ALTER TABLE identification_contacts DROP COLUMN IF EXISTS home_email_id;
+ALTER TABLE identification_contacts DROP COLUMN IF EXISTS work_email_id;
+-- +goose StatementEnd

--- a/api/templates/identification-contacts.xml
+++ b/api/templates/identification-contacts.xml
@@ -1,10 +1,14 @@
 <ContactInformation Version="1" Type="Pooled">
+  {{- if text .props.HomeEmail -}}
   <HomeEmail>
-    <Email>{{text .HomeEmail}}</Email>
+    <Email>{{text .props.HomeEmail}}</Email>
   </HomeEmail>
+  {{end}}
+  {{- if text .props.WorkEmail -}}
   <WorkEmail>
-    <Email>{{text .WorkEmail}}</Email>
+    <Email>{{text .props.WorkEmail}}</Email>
   </WorkEmail>
+  {{end}}
   {{- range $index, $item := .props.PhoneNumbers.props.items}}
   {{- with $Item := $item.Item}}
   {{if $Item.Telephone.props.numberType | eq "Home"}}

--- a/api/templates/identification-contacts.xml
+++ b/api/templates/identification-contacts.xml
@@ -1,19 +1,10 @@
 <ContactInformation Version="1" Type="Pooled">
-  {{- range $index, $item := .props.Emails.props.items}}
-  {{- with $Item := $item.Item}}
-  <!-- XXX See https://github.com/18F/e-QIP-prototype/issues/781 -->
-  {{if $index  | eq 0}}
   <HomeEmail>
-    <Email>{{text $Item.Email}}</Email>
+    <Email>{{text .HomeEmail}}</Email>
   </HomeEmail>
-  {{end}}
-  {{if $index  | eq 1}}
   <WorkEmail>
-    <Email>{{text $Item.Email}}</Email>
+    <Email>{{text .WorkEmail}}</Email>
   </WorkEmail>
-  {{end}}
-  {{- end}}
-  {{- end}}
   {{- range $index, $item := .props.PhoneNumbers.props.items}}
   {{- with $Item := $item.Item}}
   {{if $Item.Telephone.props.numberType | eq "Home"}}

--- a/api/testdata/complete-scenarios/test1.json
+++ b/api/testdata/complete-scenarios/test1.json
@@ -1454,7 +1454,9 @@
                   "ReferenceRelationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Neighbor"]
+                      "values": [
+                        "Neighbor"
+                      ]
                     }
                   },
                   "ReferenceRelationshipComments": {
@@ -2747,7 +2749,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Friend"]
+                      "values": [
+                        "Friend"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -2858,7 +2862,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Neighbor"]
+                      "values": [
+                        "Neighbor"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -2969,7 +2975,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Neighbor"]
+                      "values": [
+                        "Neighbor"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -3097,7 +3105,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -3377,7 +3387,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {

--- a/api/testdata/complete-scenarios/test1.json
+++ b/api/testdata/complete-scenarios/test1.json
@@ -1454,9 +1454,7 @@
                   "ReferenceRelationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Neighbor"
-                      ]
+                      "values": ["Neighbor"]
                     }
                   },
                   "ReferenceRelationshipComments": {
@@ -1576,24 +1574,16 @@
     "Contacts": {
       "type": "identification.contacts",
       "props": {
-        "Emails": {
-          "type": "collection",
+        "HomeEmail": {
+          "type": "email",
           "props": {
-            "branch": {
-              "type": ""
-            },
-            "items": [
-              {
-                "Item": {
-                  "Email": {
-                    "type": "email",
-                    "props": {
-                      "value": "henry@example.com"
-                    }
-                  }
-                }
-              }
-            ]
+            "value": "henry@example.com"
+          }
+        },
+        "WorkEmail": {
+          "type": "email",
+          "props": {
+            "value": ""
           }
         },
         "PhoneNumbers": {
@@ -2757,9 +2747,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Friend"
-                      ]
+                      "values": ["Friend"]
                     }
                   },
                   "RelationshipOther": {
@@ -2870,9 +2858,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Neighbor"
-                      ]
+                      "values": ["Neighbor"]
                     }
                   },
                   "RelationshipOther": {
@@ -2983,9 +2969,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Neighbor"
-                      ]
+                      "values": ["Neighbor"]
                     }
                   },
                   "RelationshipOther": {
@@ -3113,9 +3097,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -3395,9 +3377,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {

--- a/api/testdata/complete-scenarios/test2.json
+++ b/api/testdata/complete-scenarios/test2.json
@@ -869,11 +869,7 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Alimony",
-                        "Judgement",
-                        "Lien"
-                      ]
+                      "values": ["Alimony", "Judgement", "Lien"]
                     }
                   },
                   "Name": {
@@ -973,9 +969,7 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Alimony"
-                      ]
+                      "values": ["Alimony"]
                     }
                   },
                   "Name": {
@@ -1197,9 +1191,7 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Repossession"
-                      ]
+                      "values": ["Repossession"]
                     }
                   },
                   "Name": {
@@ -1281,9 +1273,7 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Defaulted"
-                      ]
+                      "values": ["Defaulted"]
                     }
                   },
                   "Name": {
@@ -2526,9 +2516,7 @@
                   "ReferenceRelationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Neighbor"
-                      ]
+                      "values": ["Neighbor"]
                     }
                   },
                   "ReferenceRelationshipComments": {
@@ -2648,24 +2636,16 @@
     "Contacts": {
       "type": "identification.contacts",
       "props": {
-        "Emails": {
-          "type": "collection",
+        "HomeEmail": {
+          "type": "email",
           "props": {
-            "branch": {
-              "type": ""
-            },
-            "items": [
-              {
-                "Item": {
-                  "Email": {
-                    "type": "email",
-                    "props": {
-                      "value": "email@email.com"
-                    }
-                  }
-                }
-              }
-            ]
+            "value": "email@email.com"
+          }
+        },
+        "WorkEmail": {
+          "type": "email",
+          "props": {
+            "value": ""
           }
         },
         "PhoneNumbers": {
@@ -4726,9 +4706,7 @@
             "Citizenship": {
               "type": "country",
               "props": {
-                "value": [
-                  "United States"
-                ]
+                "value": ["United States"]
               }
             },
             "DateSeparated": {
@@ -5045,9 +5023,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Schoolmate"
-                      ]
+                      "values": ["Schoolmate"]
                     }
                   },
                   "RelationshipOther": {
@@ -5159,9 +5135,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Neighbor"
-                      ]
+                      "values": ["Neighbor"]
                     }
                   },
                   "RelationshipOther": {
@@ -5273,9 +5247,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Neighbor"
-                      ]
+                      "values": ["Neighbor"]
                     }
                   },
                   "RelationshipOther": {
@@ -5409,9 +5381,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -5691,9 +5661,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -6592,10 +6560,7 @@
                   "Seekers": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Employer",
-                        "CourtOfficial"
-                      ]
+                      "values": ["Employer", "CourtOfficial"]
                     }
                   },
                   "TreatmentProviderAddress": {
@@ -6688,9 +6653,7 @@
                   "Seekers": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "MedicalProfessional"
-                      ]
+                      "values": ["MedicalProfessional"]
                     }
                   },
                   "TreatmentProviderAddress": {
@@ -6783,9 +6746,7 @@
                   "OrderedBy": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Judge"
-                      ]
+                      "values": ["Judge"]
                     }
                   },
                   "TreatmentCompleted": {
@@ -6884,9 +6845,7 @@
                   "OrderedBy": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "None"
-                      ]
+                      "values": ["None"]
                     }
                   },
                   "TreatmentCompleted": {

--- a/api/testdata/complete-scenarios/test2.json
+++ b/api/testdata/complete-scenarios/test2.json
@@ -869,7 +869,11 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Alimony", "Judgement", "Lien"]
+                      "values": [
+                        "Alimony",
+                        "Judgement",
+                        "Lien"
+                      ]
                     }
                   },
                   "Name": {
@@ -969,7 +973,9 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Alimony"]
+                      "values": [
+                        "Alimony"
+                      ]
                     }
                   },
                   "Name": {
@@ -1191,7 +1197,9 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Repossession"]
+                      "values": [
+                        "Repossession"
+                      ]
                     }
                   },
                   "Name": {
@@ -1273,7 +1281,9 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Defaulted"]
+                      "values": [
+                        "Defaulted"
+                      ]
                     }
                   },
                   "Name": {
@@ -2516,7 +2526,9 @@
                   "ReferenceRelationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Neighbor"]
+                      "values": [
+                        "Neighbor"
+                      ]
                     }
                   },
                   "ReferenceRelationshipComments": {
@@ -4706,7 +4718,9 @@
             "Citizenship": {
               "type": "country",
               "props": {
-                "value": ["United States"]
+                "value": [
+                  "United States"
+                ]
               }
             },
             "DateSeparated": {
@@ -5023,7 +5037,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Schoolmate"]
+                      "values": [
+                        "Schoolmate"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -5135,7 +5151,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Neighbor"]
+                      "values": [
+                        "Neighbor"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -5247,7 +5265,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Neighbor"]
+                      "values": [
+                        "Neighbor"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -5381,7 +5401,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -5661,7 +5683,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -6560,7 +6584,10 @@
                   "Seekers": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Employer", "CourtOfficial"]
+                      "values": [
+                        "Employer",
+                        "CourtOfficial"
+                      ]
                     }
                   },
                   "TreatmentProviderAddress": {
@@ -6653,7 +6680,9 @@
                   "Seekers": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["MedicalProfessional"]
+                      "values": [
+                        "MedicalProfessional"
+                      ]
                     }
                   },
                   "TreatmentProviderAddress": {
@@ -6746,7 +6775,9 @@
                   "OrderedBy": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Judge"]
+                      "values": [
+                        "Judge"
+                      ]
                     }
                   },
                   "TreatmentCompleted": {
@@ -6845,7 +6876,9 @@
                   "OrderedBy": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["None"]
+                      "values": [
+                        "None"
+                      ]
                     }
                   },
                   "TreatmentCompleted": {

--- a/api/testdata/complete-scenarios/test3.json
+++ b/api/testdata/complete-scenarios/test3.json
@@ -275,7 +275,9 @@
         "PriorCitizenship": {
           "type": "country",
           "props": {
-            "value": ["Ukraine"]
+            "value": [
+              "Ukraine"
+            ]
           }
         },
         "HasAlienRegistration": {
@@ -526,7 +528,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Chile"]
+                      "value": [
+                        "Chile"
+                      ]
                     }
                   },
                   "Dates": {
@@ -592,7 +596,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Romania"]
+                      "value": [
+                        "Romania"
+                      ]
                     }
                   },
                   "Dates": {
@@ -850,7 +856,9 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Yourself"]
+                      "values": [
+                        "Yourself"
+                      ]
                     }
                   },
                   "OneTimeBenefit": {
@@ -898,7 +906,9 @@
                       "Country": {
                         "type": "country",
                         "props": {
-                          "value": ["France"]
+                          "value": [
+                            "France"
+                          ]
                         }
                       },
                       "Value": {
@@ -1089,7 +1099,9 @@
                       "Country": {
                         "type": "country",
                         "props": {
-                          "value": ["France"]
+                          "value": [
+                            "France"
+                          ]
                         }
                       },
                       "Value": {
@@ -1127,7 +1139,9 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["DependentChildren"]
+                      "values": [
+                        "DependentChildren"
+                      ]
                     }
                   },
                   "OneTimeBenefit": {
@@ -1175,7 +1189,9 @@
                       "Country": {
                         "type": "country",
                         "props": {
-                          "value": ["France"]
+                          "value": [
+                            "France"
+                          ]
                         }
                       },
                       "Value": {
@@ -1349,7 +1365,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["United Kingdom"]
+                      "value": [
+                        "United Kingdom"
+                      ]
                     }
                   },
                   "Dates": {
@@ -1438,7 +1456,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Germany"]
+                      "value": [
+                        "Germany"
+                      ]
                     }
                   },
                   "Dates": {
@@ -1529,7 +1549,9 @@
                   "Governments": {
                     "type": "country",
                     "props": {
-                      "value": ["Bolivia"]
+                      "value": [
+                        "Bolivia"
+                      ]
                     }
                   },
                   "Location": {
@@ -1631,7 +1653,9 @@
                   "Governments": {
                     "type": "country",
                     "props": {
-                      "value": ["India"]
+                      "value": [
+                        "India"
+                      ]
                     }
                   },
                   "Location": {
@@ -1858,7 +1882,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["France"]
+                      "value": [
+                        "France"
+                      ]
                     }
                   },
                   "Employer": {
@@ -1928,7 +1954,9 @@
                   "Methods": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Telephone"]
+                      "values": [
+                        "Telephone"
+                      ]
                     }
                   },
                   "MethodsExplanation": {
@@ -1966,7 +1994,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Professional"]
+                      "values": [
+                        "Professional"
+                      ]
                     }
                   },
                   "RelationshipExplanation": {
@@ -2092,7 +2122,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["Jamaica"]
+                      "value": [
+                        "Jamaica"
+                      ]
                     }
                   },
                   "Employer": {
@@ -2165,7 +2197,9 @@
                   "Methods": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Written"]
+                      "values": [
+                        "Written"
+                      ]
                     }
                   },
                   "MethodsExplanation": {
@@ -2203,7 +2237,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Personal"]
+                      "values": [
+                        "Personal"
+                      ]
                     }
                   },
                   "RelationshipExplanation": {
@@ -2275,7 +2311,9 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": ["Morocco"]
+                                    "value": [
+                                      "Morocco"
+                                    ]
                                   }
                                 },
                                 "Has": {
@@ -2321,7 +2359,9 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": ["Germany"]
+                                    "value": [
+                                      "Germany"
+                                    ]
                                   }
                                 },
                                 "Has": {
@@ -2433,7 +2473,10 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Cohabitant", "DependentChildren"]
+                      "values": [
+                        "Cohabitant",
+                        "DependentChildren"
+                      ]
                     }
                   },
                   "Relinquished": {
@@ -2567,7 +2610,9 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Yourself"]
+                      "values": [
+                        "Yourself"
+                      ]
                     }
                   },
                   "Relinquished": {
@@ -2638,7 +2683,9 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": ["United States"]
+                                    "value": [
+                                      "United States"
+                                    ]
                                   }
                                 },
                                 "Has": {
@@ -2749,7 +2796,9 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Spouse"]
+                      "values": [
+                        "Spouse"
+                      ]
                     }
                   },
                   "Relinquished": {
@@ -3009,7 +3058,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Gabon"]
+                      "value": [
+                        "Gabon"
+                      ]
                     }
                   },
                   "Date": {
@@ -3054,7 +3105,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Denmark"]
+                      "value": [
+                        "Denmark"
+                      ]
                     }
                   },
                   "Date": {
@@ -3099,7 +3152,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Haiti"]
+                      "value": [
+                        "Haiti"
+                      ]
                     }
                   },
                   "Date": {
@@ -3307,7 +3362,11 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Yourself", "Spouse", "DependentChildren"]
+                      "values": [
+                        "Yourself",
+                        "Spouse",
+                        "DependentChildren"
+                      ]
                     }
                   },
                   "Lastname": {
@@ -3458,7 +3517,9 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["DependentChildren"]
+                      "values": [
+                        "DependentChildren"
+                      ]
                     }
                   },
                   "Lastname": {
@@ -3592,7 +3653,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Jan Mayen"]
+                      "value": [
+                        "Jan Mayen"
+                      ]
                     }
                   },
                   "Dates": {
@@ -3644,7 +3707,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Lebanon"]
+                      "value": [
+                        "Lebanon"
+                      ]
                     }
                   },
                   "Dates": {
@@ -3762,7 +3827,9 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": ["France"]
+                                    "value": [
+                                      "France"
+                                    ]
                                   }
                                 },
                                 "Has": {
@@ -3810,7 +3877,9 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": ["United States"]
+                                    "value": [
+                                      "United States"
+                                    ]
                                   }
                                 },
                                 "Has": {
@@ -3909,7 +3978,9 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Cohabitant"]
+                      "values": [
+                        "Cohabitant"
+                      ]
                     }
                   },
                   "RealEstateType": {
@@ -4045,7 +4116,9 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Spouse"]
+                      "values": [
+                        "Spouse"
+                      ]
                     }
                   },
                   "RealEstateType": {
@@ -4147,7 +4220,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["Iceland"]
+                      "value": [
+                        "Iceland"
+                      ]
                     }
                   },
                   "Dates": {
@@ -4286,7 +4361,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["Kiribati"]
+                      "value": [
+                        "Kiribati"
+                      ]
                     }
                   },
                   "Dates": {
@@ -4432,7 +4509,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["Hungary"]
+                      "value": [
+                        "Hungary"
+                      ]
                     }
                   },
                   "Frequency": {
@@ -4491,7 +4570,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["Kazakhstan"]
+                      "value": [
+                        "Kazakhstan"
+                      ]
                     }
                   },
                   "Frequency": {
@@ -4581,7 +4662,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Ukraine"]
+                      "value": [
+                        "Ukraine"
+                      ]
                     }
                   },
                   "Dates": {
@@ -4611,7 +4694,9 @@
                   "Days": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["6-10"]
+                      "values": [
+                        "6-10"
+                      ]
                     }
                   },
                   "Encounter": {
@@ -4641,7 +4726,9 @@
                   "Purpose": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Volunteer"]
+                      "values": [
+                        "Volunteer"
+                      ]
                     }
                   },
                   "Questioned": {
@@ -4711,7 +4798,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Russia"]
+                      "value": [
+                        "Russia"
+                      ]
                     }
                   },
                   "Dates": {
@@ -4741,7 +4830,9 @@
                   "Days": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["11-20"]
+                      "values": [
+                        "11-20"
+                      ]
                     }
                   },
                   "Encounter": {
@@ -4771,7 +4862,9 @@
                   "Purpose": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Conference"]
+                      "values": [
+                        "Conference"
+                      ]
                     }
                   },
                   "Questioned": {
@@ -4859,7 +4952,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["Yemen"]
+                      "value": [
+                        "Yemen"
+                      ]
                     }
                   },
                   "Compensation": {
@@ -4958,7 +5053,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["Swaziland"]
+                      "value": [
+                        "Swaziland"
+                      ]
                     }
                   },
                   "Compensation": {
@@ -5066,7 +5163,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Nauru"]
+                      "value": [
+                        "Nauru"
+                      ]
                     }
                   },
                   "Date": {
@@ -5097,7 +5196,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Macau"]
+                      "value": [
+                        "Macau"
+                      ]
                     }
                   },
                   "Date": {
@@ -5651,7 +5752,12 @@
                   "ReferenceRelationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Friend", "Neighbor", "Landlord", "Business"]
+                      "values": [
+                        "Friend",
+                        "Neighbor",
+                        "Landlord",
+                        "Business"
+                      ]
                     }
                   },
                   "ReferenceRelationshipComments": {
@@ -6814,7 +6920,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CohabitationBegan": {
@@ -6977,7 +7085,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CohabitationBegan": {
@@ -7195,7 +7305,9 @@
             "Citizenship": {
               "type": "country",
               "props": {
-                "value": ["United States"]
+                "value": [
+                  "United States"
+                ]
               }
             },
             "DateSeparated": {
@@ -7615,7 +7727,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Friend"]
+                      "values": [
+                        "Friend"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -7727,7 +7841,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Other"]
+                      "values": [
+                        "Other"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -7838,7 +7954,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Neighbor"]
+                      "values": [
+                        "Neighbor"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -7972,7 +8090,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -8265,7 +8385,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -8550,7 +8672,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -8769,7 +8893,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -8988,7 +9114,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {

--- a/api/testdata/complete-scenarios/test3.json
+++ b/api/testdata/complete-scenarios/test3.json
@@ -275,9 +275,7 @@
         "PriorCitizenship": {
           "type": "country",
           "props": {
-            "value": [
-              "Ukraine"
-            ]
+            "value": ["Ukraine"]
           }
         },
         "HasAlienRegistration": {
@@ -528,9 +526,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Chile"
-                      ]
+                      "value": ["Chile"]
                     }
                   },
                   "Dates": {
@@ -596,9 +592,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Romania"
-                      ]
+                      "value": ["Romania"]
                     }
                   },
                   "Dates": {
@@ -856,9 +850,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Yourself"
-                      ]
+                      "values": ["Yourself"]
                     }
                   },
                   "OneTimeBenefit": {
@@ -906,9 +898,7 @@
                       "Country": {
                         "type": "country",
                         "props": {
-                          "value": [
-                            "France"
-                          ]
+                          "value": ["France"]
                         }
                       },
                       "Value": {
@@ -1099,9 +1089,7 @@
                       "Country": {
                         "type": "country",
                         "props": {
-                          "value": [
-                            "France"
-                          ]
+                          "value": ["France"]
                         }
                       },
                       "Value": {
@@ -1139,9 +1127,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "DependentChildren"
-                      ]
+                      "values": ["DependentChildren"]
                     }
                   },
                   "OneTimeBenefit": {
@@ -1189,9 +1175,7 @@
                       "Country": {
                         "type": "country",
                         "props": {
-                          "value": [
-                            "France"
-                          ]
+                          "value": ["France"]
                         }
                       },
                       "Value": {
@@ -1365,9 +1349,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United Kingdom"
-                      ]
+                      "value": ["United Kingdom"]
                     }
                   },
                   "Dates": {
@@ -1456,9 +1438,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Germany"
-                      ]
+                      "value": ["Germany"]
                     }
                   },
                   "Dates": {
@@ -1549,9 +1529,7 @@
                   "Governments": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Bolivia"
-                      ]
+                      "value": ["Bolivia"]
                     }
                   },
                   "Location": {
@@ -1653,9 +1631,7 @@
                   "Governments": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "India"
-                      ]
+                      "value": ["India"]
                     }
                   },
                   "Location": {
@@ -1882,9 +1858,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "France"
-                      ]
+                      "value": ["France"]
                     }
                   },
                   "Employer": {
@@ -1954,9 +1928,7 @@
                   "Methods": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Telephone"
-                      ]
+                      "values": ["Telephone"]
                     }
                   },
                   "MethodsExplanation": {
@@ -1994,9 +1966,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Professional"
-                      ]
+                      "values": ["Professional"]
                     }
                   },
                   "RelationshipExplanation": {
@@ -2122,9 +2092,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Jamaica"
-                      ]
+                      "value": ["Jamaica"]
                     }
                   },
                   "Employer": {
@@ -2197,9 +2165,7 @@
                   "Methods": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Written"
-                      ]
+                      "values": ["Written"]
                     }
                   },
                   "MethodsExplanation": {
@@ -2237,9 +2203,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Personal"
-                      ]
+                      "values": ["Personal"]
                     }
                   },
                   "RelationshipExplanation": {
@@ -2311,9 +2275,7 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": [
-                                      "Morocco"
-                                    ]
+                                    "value": ["Morocco"]
                                   }
                                 },
                                 "Has": {
@@ -2359,9 +2321,7 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": [
-                                      "Germany"
-                                    ]
+                                    "value": ["Germany"]
                                   }
                                 },
                                 "Has": {
@@ -2473,10 +2433,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Cohabitant",
-                        "DependentChildren"
-                      ]
+                      "values": ["Cohabitant", "DependentChildren"]
                     }
                   },
                   "Relinquished": {
@@ -2610,9 +2567,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Yourself"
-                      ]
+                      "values": ["Yourself"]
                     }
                   },
                   "Relinquished": {
@@ -2683,9 +2638,7 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": [
-                                      "United States"
-                                    ]
+                                    "value": ["United States"]
                                   }
                                 },
                                 "Has": {
@@ -2796,9 +2749,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Spouse"
-                      ]
+                      "values": ["Spouse"]
                     }
                   },
                   "Relinquished": {
@@ -3058,9 +3009,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Gabon"
-                      ]
+                      "value": ["Gabon"]
                     }
                   },
                   "Date": {
@@ -3105,9 +3054,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Denmark"
-                      ]
+                      "value": ["Denmark"]
                     }
                   },
                   "Date": {
@@ -3152,9 +3099,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Haiti"
-                      ]
+                      "value": ["Haiti"]
                     }
                   },
                   "Date": {
@@ -3362,11 +3307,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Yourself",
-                        "Spouse",
-                        "DependentChildren"
-                      ]
+                      "values": ["Yourself", "Spouse", "DependentChildren"]
                     }
                   },
                   "Lastname": {
@@ -3517,9 +3458,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "DependentChildren"
-                      ]
+                      "values": ["DependentChildren"]
                     }
                   },
                   "Lastname": {
@@ -3653,9 +3592,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Jan Mayen"
-                      ]
+                      "value": ["Jan Mayen"]
                     }
                   },
                   "Dates": {
@@ -3707,9 +3644,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Lebanon"
-                      ]
+                      "value": ["Lebanon"]
                     }
                   },
                   "Dates": {
@@ -3827,9 +3762,7 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": [
-                                      "France"
-                                    ]
+                                    "value": ["France"]
                                   }
                                 },
                                 "Has": {
@@ -3877,9 +3810,7 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": [
-                                      "United States"
-                                    ]
+                                    "value": ["United States"]
                                   }
                                 },
                                 "Has": {
@@ -3978,9 +3909,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Cohabitant"
-                      ]
+                      "values": ["Cohabitant"]
                     }
                   },
                   "RealEstateType": {
@@ -4116,9 +4045,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Spouse"
-                      ]
+                      "values": ["Spouse"]
                     }
                   },
                   "RealEstateType": {
@@ -4220,9 +4147,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Iceland"
-                      ]
+                      "value": ["Iceland"]
                     }
                   },
                   "Dates": {
@@ -4361,9 +4286,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Kiribati"
-                      ]
+                      "value": ["Kiribati"]
                     }
                   },
                   "Dates": {
@@ -4509,9 +4432,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Hungary"
-                      ]
+                      "value": ["Hungary"]
                     }
                   },
                   "Frequency": {
@@ -4570,9 +4491,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Kazakhstan"
-                      ]
+                      "value": ["Kazakhstan"]
                     }
                   },
                   "Frequency": {
@@ -4662,9 +4581,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Ukraine"
-                      ]
+                      "value": ["Ukraine"]
                     }
                   },
                   "Dates": {
@@ -4694,9 +4611,7 @@
                   "Days": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "6-10"
-                      ]
+                      "values": ["6-10"]
                     }
                   },
                   "Encounter": {
@@ -4726,9 +4641,7 @@
                   "Purpose": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Volunteer"
-                      ]
+                      "values": ["Volunteer"]
                     }
                   },
                   "Questioned": {
@@ -4798,9 +4711,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Russia"
-                      ]
+                      "value": ["Russia"]
                     }
                   },
                   "Dates": {
@@ -4830,9 +4741,7 @@
                   "Days": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "11-20"
-                      ]
+                      "values": ["11-20"]
                     }
                   },
                   "Encounter": {
@@ -4862,9 +4771,7 @@
                   "Purpose": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Conference"
-                      ]
+                      "values": ["Conference"]
                     }
                   },
                   "Questioned": {
@@ -4952,9 +4859,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Yemen"
-                      ]
+                      "value": ["Yemen"]
                     }
                   },
                   "Compensation": {
@@ -5053,9 +4958,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Swaziland"
-                      ]
+                      "value": ["Swaziland"]
                     }
                   },
                   "Compensation": {
@@ -5163,9 +5066,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Nauru"
-                      ]
+                      "value": ["Nauru"]
                     }
                   },
                   "Date": {
@@ -5196,9 +5097,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Macau"
-                      ]
+                      "value": ["Macau"]
                     }
                   },
                   "Date": {
@@ -5752,12 +5651,7 @@
                   "ReferenceRelationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Friend",
-                        "Neighbor",
-                        "Landlord",
-                        "Business"
-                      ]
+                      "values": ["Friend", "Neighbor", "Landlord", "Business"]
                     }
                   },
                   "ReferenceRelationshipComments": {
@@ -5877,24 +5771,16 @@
     "Contacts": {
       "type": "identification.contacts",
       "props": {
-        "Emails": {
-          "type": "collection",
+        "HomeEmail": {
+          "type": "email",
           "props": {
-            "branch": {
-              "type": ""
-            },
-            "items": [
-              {
-                "Item": {
-                  "Email": {
-                    "type": "email",
-                    "props": {
-                      "value": "rgf@gmaol.com"
-                    }
-                  }
-                }
-              }
-            ]
+            "value": "rgf@gmaol.com"
+          }
+        },
+        "WorkEmail": {
+          "type": "email",
+          "props": {
+            "value": ""
           }
         },
         "PhoneNumbers": {
@@ -6928,9 +6814,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CohabitationBegan": {
@@ -7093,9 +6977,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CohabitationBegan": {
@@ -7313,9 +7195,7 @@
             "Citizenship": {
               "type": "country",
               "props": {
-                "value": [
-                  "United States"
-                ]
+                "value": ["United States"]
               }
             },
             "DateSeparated": {
@@ -7735,9 +7615,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Friend"
-                      ]
+                      "values": ["Friend"]
                     }
                   },
                   "RelationshipOther": {
@@ -7849,9 +7727,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Other"
-                      ]
+                      "values": ["Other"]
                     }
                   },
                   "RelationshipOther": {
@@ -7962,9 +7838,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Neighbor"
-                      ]
+                      "values": ["Neighbor"]
                     }
                   },
                   "RelationshipOther": {
@@ -8098,9 +7972,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -8393,9 +8265,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -8680,9 +8550,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -8901,9 +8769,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -9122,9 +8988,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {

--- a/api/testdata/complete-scenarios/test4.json
+++ b/api/testdata/complete-scenarios/test4.json
@@ -35,9 +35,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United Kingdom"
-                      ]
+                      "value": ["United Kingdom"]
                     }
                   },
                   "Current": {
@@ -101,9 +99,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Zimbabwe"
-                      ]
+                      "value": ["Zimbabwe"]
                     }
                   },
                   "Current": {
@@ -145,7 +141,8 @@
                   "How": {
                     "type": "textarea",
                     "props": {
-                      "value": "My mother is Zimbabwean and that citizenship is conferred by parental lineage."
+                      "value":
+                        "My mother is Zimbabwean and that citizenship is conferred by parental lineage."
                     }
                   },
                   "Renounced": {
@@ -157,7 +154,8 @@
                   "RenouncedExplanation": {
                     "type": "textarea",
                     "props": {
-                      "value": "I've never been there and feel no affiliation to the country."
+                      "value":
+                        "I've never been there and feel no affiliation to the country."
                     }
                   }
                 }
@@ -167,9 +165,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "China"
-                      ]
+                      "value": ["China"]
                     }
                   },
                   "Current": {
@@ -211,7 +207,8 @@
                   "How": {
                     "type": "textarea",
                     "props": {
-                      "value": "My father was born in China and citizenship is passed through lineage."
+                      "value":
+                        "My father was born in China and citizenship is passed through lineage."
                     }
                   },
                   "Renounced": {
@@ -223,7 +220,8 @@
                   "RenouncedExplanation": {
                     "type": "textarea",
                     "props": {
-                      "value": "My father was born in China, but I have never been and feel no affiliation. I've recently submitted my paperwork. "
+                      "value":
+                        "My father was born in China, but I have never been and feel no affiliation. I've recently submitted my paperwork. "
                     }
                   }
                 }
@@ -257,9 +255,7 @@
                             "Country": {
                               "type": "country",
                               "props": {
-                                "value": [
-                                  "United States"
-                                ]
+                                "value": ["United States"]
                               }
                             },
                             "Dates": {
@@ -293,9 +289,7 @@
                             "Country": {
                               "type": "country",
                               "props": {
-                                "value": [
-                                  "Saint Barthelemy"
-                                ]
+                                "value": ["Saint Barthelemy"]
                               }
                             },
                             "Dates": {
@@ -330,9 +324,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United Kingdom"
-                      ]
+                      "value": ["United Kingdom"]
                     }
                   },
                   "Expiration": {
@@ -409,9 +401,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Zimbabwe"
-                      ]
+                      "value": ["Zimbabwe"]
                     }
                   },
                   "Expiration": {
@@ -705,9 +695,7 @@
         "PriorCitizenship": {
           "type": "country",
           "props": {
-            "value": [
-              "United Kingdom"
-            ]
+            "value": ["United Kingdom"]
           }
         },
         "HasAlienRegistration": {
@@ -2041,10 +2029,7 @@
                   "ReferenceRelationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Neighbor",
-                        "Other"
-                      ]
+                      "values": ["Neighbor", "Other"]
                     }
                   },
                   "ReferenceRelationshipComments": {
@@ -2162,24 +2147,16 @@
     "Contacts": {
       "type": "identification.contacts",
       "props": {
-        "Emails": {
-          "type": "collection",
+        "HomeEmail": {
+          "type": "email",
           "props": {
-            "branch": {
-              "type": ""
-            },
-            "items": [
-              {
-                "Item": {
-                  "Email": {
-                    "type": "email",
-                    "props": {
-                      "value": "dcmccallum@nyanderie.com"
-                    }
-                  }
-                }
-              }
-            ]
+            "value": "dcmccallum@nyanderie.com"
+          }
+        },
+        "WorkEmail": {
+          "type": "email",
+          "props": {
+            "value": ""
           }
         },
         "PhoneNumbers": {
@@ -2426,7 +2403,8 @@
                   "Action": {
                     "type": "textarea",
                     "props": {
-                      "value": "The hotel manager took pity on me because it was, in fact, our honey moon, and didn't call the cops."
+                      "value":
+                        "The hotel manager took pity on me because it was, in fact, our honey moon, and didn't call the cops."
                     }
                   },
                   "Date": {
@@ -2441,7 +2419,8 @@
                   "Incident": {
                     "type": "textarea",
                     "props": {
-                      "value": "I was on vacation and decided that I wanted an extra night free so I went behind the counter at the hotel and comp'ed myself. "
+                      "value":
+                        "I was on vacation and decided that I wanted an extra night free so I went behind the counter at the hotel and comp'ed myself. "
                     }
                   },
                   "Location": {
@@ -2460,7 +2439,8 @@
                   "Action": {
                     "type": "textarea",
                     "props": {
-                      "value": "The catfisher came back this time and I was fed up with it. So I went to their house and accessed their computer without their knowledge and proceeded to delete their OS so they could stop tricking me into talking to them."
+                      "value":
+                        "The catfisher came back this time and I was fed up with it. So I went to their house and accessed their computer without their knowledge and proceeded to delete their OS so they could stop tricking me into talking to them."
                     }
                   },
                   "Date": {
@@ -2475,7 +2455,8 @@
                   "Incident": {
                     "type": "textarea",
                     "props": {
-                      "value": "Broke into someone's house and deleted their operating system."
+                      "value":
+                        "Broke into someone's house and deleted their operating system."
                     }
                   },
                   "Location": {
@@ -2716,7 +2697,8 @@
                   "Incident": {
                     "type": "textarea",
                     "props": {
-                      "value": "One time I threw a SQL injection prompt into my local baker's invoicing system so I could drop all my outstanding charges for double mocha frappachinos"
+                      "value":
+                        "One time I threw a SQL injection prompt into my local baker's invoicing system so I could drop all my outstanding charges for double mocha frappachinos"
                     }
                   },
                   "Location": {
@@ -2737,7 +2719,8 @@
                   "Action": {
                     "type": "textarea",
                     "props": {
-                      "value": "Welllll so the catfisher figured out my phishing technique and called the local sheriff who found me hiding in the bathroom of an internet cafe."
+                      "value":
+                        "Welllll so the catfisher figured out my phishing technique and called the local sheriff who found me hiding in the bathroom of an internet cafe."
                     }
                   },
                   "Date": {
@@ -2752,7 +2735,8 @@
                   "Incident": {
                     "type": "textarea",
                     "props": {
-                      "value": "I spear phished a catfisher to figure out their real identity."
+                      "value":
+                        "I spear phished a catfisher to figure out their real identity."
                     }
                   },
                   "Location": {
@@ -2797,7 +2781,8 @@
                   "Action": {
                     "type": "textarea",
                     "props": {
-                      "value": "Look it was a program that went wild. We were trying to get more votes for Boaty McBoatface to help support our friends in the UK."
+                      "value":
+                        "Look it was a program that went wild. We were trying to get more votes for Boaty McBoatface to help support our friends in the UK."
                     }
                   },
                   "Date": {
@@ -2812,7 +2797,8 @@
                   "Incident": {
                     "type": "textarea",
                     "props": {
-                      "value": "Raised a botnet to vote for Boaty McBoatface on US government computers"
+                      "value":
+                        "Raised a botnet to vote for Boaty McBoatface on US government computers"
                     }
                   },
                   "Location": {
@@ -2833,7 +2819,8 @@
                   "Action": {
                     "type": "textarea",
                     "props": {
-                      "value": "DOD was like, hey we wont' charge you, you're on our team now buddy."
+                      "value":
+                        "DOD was like, hey we wont' charge you, you're on our team now buddy."
                     }
                   },
                   "Date": {
@@ -2848,7 +2835,8 @@
                   "Incident": {
                     "type": "textarea",
                     "props": {
-                      "value": "You know that movie \"War Games\"?   That was me."
+                      "value":
+                        "You know that movie \"War Games\"?   That was me."
                     }
                   },
                   "Location": {
@@ -2878,7 +2866,8 @@
         "Comments": {
           "type": "text",
           "props": {
-            "value": "Look, I know I'm a weird bird, but trust me I really need this TS-SCI"
+            "value":
+              "Look, I know I'm a weird bird, but trust me I really need this TS-SCI"
           }
         }
       }
@@ -2928,7 +2917,8 @@
                   "Offenses": {
                     "type": "textarea",
                     "props": {
-                      "value": "Abandoning my post when I jumped off the aircraft carrier after seeing a tarantula crawling through the porthole  "
+                      "value":
+                        "Abandoning my post when I jumped off the aircraft carrier after seeing a tarantula crawling through the porthole  "
                     }
                   },
                   "Outcome": {
@@ -2944,7 +2934,8 @@
                   "Court": {
                     "type": "textarea",
                     "props": {
-                      "value": "A scary building made of stones and gargoyles located in the mystical rainforests of Georgia"
+                      "value":
+                        "A scary building made of stones and gargoyles located in the mystical rainforests of Georgia"
                     }
                   },
                   "Date": {
@@ -2965,7 +2956,8 @@
                   "Offenses": {
                     "type": "textarea",
                     "props": {
-                      "value": "Mischief: Before I saw the huge spider, I was caught stealing frozen pizzas from the kitchen and cooking them on the heat shield where they launch the planes"
+                      "value":
+                        "Mischief: Before I saw the huge spider, I was caught stealing frozen pizzas from the kitchen and cooking them on the heat shield where they launch the planes"
                     }
                   },
                   "Outcome": {
@@ -2996,15 +2988,14 @@
                   "Circumstances": {
                     "type": "textarea",
                     "props": {
-                      "value": "I worked as a consultant to the PLA's cybersecurity division working on offensive capabilities."
+                      "value":
+                        "I worked as a consultant to the PLA's cybersecurity division working on offensive capabilities."
                     }
                   },
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "China"
-                      ]
+                      "value": ["China"]
                     }
                   },
                   "Dates": {
@@ -3091,7 +3082,8 @@
                             "Frequency": {
                               "type": "text",
                               "props": {
-                                "value": "Literally he's my best friend on snapchat"
+                                "value":
+                                  "Literally he's my best friend on snapchat"
                               }
                             },
                             "Has": {
@@ -4152,9 +4144,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "WorkAssociate"
-                      ]
+                      "values": ["WorkAssociate"]
                     }
                   },
                   "RelationshipOther": {
@@ -4266,9 +4256,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "WorkAssociate"
-                      ]
+                      "values": ["WorkAssociate"]
                     }
                   },
                   "RelationshipOther": {
@@ -4380,9 +4368,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "WorkAssociate"
-                      ]
+                      "values": ["WorkAssociate"]
                     }
                   },
                   "RelationshipOther": {
@@ -4509,9 +4495,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United Kingdom"
-                      ]
+                      "value": ["United Kingdom"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -4790,9 +4774,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United Kingdom"
-                      ]
+                      "value": ["United Kingdom"]
                     }
                   },
                   "CitizenshipDocumentation": {

--- a/api/testdata/complete-scenarios/test4.json
+++ b/api/testdata/complete-scenarios/test4.json
@@ -35,7 +35,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["United Kingdom"]
+                      "value": [
+                        "United Kingdom"
+                      ]
                     }
                   },
                   "Current": {
@@ -99,7 +101,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Zimbabwe"]
+                      "value": [
+                        "Zimbabwe"
+                      ]
                     }
                   },
                   "Current": {
@@ -141,8 +145,7 @@
                   "How": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "My mother is Zimbabwean and that citizenship is conferred by parental lineage."
+                      "value": "My mother is Zimbabwean and that citizenship is conferred by parental lineage."
                     }
                   },
                   "Renounced": {
@@ -154,8 +157,7 @@
                   "RenouncedExplanation": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "I've never been there and feel no affiliation to the country."
+                      "value": "I've never been there and feel no affiliation to the country."
                     }
                   }
                 }
@@ -165,7 +167,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["China"]
+                      "value": [
+                        "China"
+                      ]
                     }
                   },
                   "Current": {
@@ -207,8 +211,7 @@
                   "How": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "My father was born in China and citizenship is passed through lineage."
+                      "value": "My father was born in China and citizenship is passed through lineage."
                     }
                   },
                   "Renounced": {
@@ -220,8 +223,7 @@
                   "RenouncedExplanation": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "My father was born in China, but I have never been and feel no affiliation. I've recently submitted my paperwork. "
+                      "value": "My father was born in China, but I have never been and feel no affiliation. I've recently submitted my paperwork. "
                     }
                   }
                 }
@@ -255,7 +257,9 @@
                             "Country": {
                               "type": "country",
                               "props": {
-                                "value": ["United States"]
+                                "value": [
+                                  "United States"
+                                ]
                               }
                             },
                             "Dates": {
@@ -289,7 +293,9 @@
                             "Country": {
                               "type": "country",
                               "props": {
-                                "value": ["Saint Barthelemy"]
+                                "value": [
+                                  "Saint Barthelemy"
+                                ]
                               }
                             },
                             "Dates": {
@@ -324,7 +330,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["United Kingdom"]
+                      "value": [
+                        "United Kingdom"
+                      ]
                     }
                   },
                   "Expiration": {
@@ -401,7 +409,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Zimbabwe"]
+                      "value": [
+                        "Zimbabwe"
+                      ]
                     }
                   },
                   "Expiration": {
@@ -695,7 +705,9 @@
         "PriorCitizenship": {
           "type": "country",
           "props": {
-            "value": ["United Kingdom"]
+            "value": [
+              "United Kingdom"
+            ]
           }
         },
         "HasAlienRegistration": {
@@ -2029,7 +2041,10 @@
                   "ReferenceRelationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Neighbor", "Other"]
+                      "values": [
+                        "Neighbor",
+                        "Other"
+                      ]
                     }
                   },
                   "ReferenceRelationshipComments": {
@@ -2403,8 +2418,7 @@
                   "Action": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "The hotel manager took pity on me because it was, in fact, our honey moon, and didn't call the cops."
+                      "value": "The hotel manager took pity on me because it was, in fact, our honey moon, and didn't call the cops."
                     }
                   },
                   "Date": {
@@ -2419,8 +2433,7 @@
                   "Incident": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "I was on vacation and decided that I wanted an extra night free so I went behind the counter at the hotel and comp'ed myself. "
+                      "value": "I was on vacation and decided that I wanted an extra night free so I went behind the counter at the hotel and comp'ed myself. "
                     }
                   },
                   "Location": {
@@ -2439,8 +2452,7 @@
                   "Action": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "The catfisher came back this time and I was fed up with it. So I went to their house and accessed their computer without their knowledge and proceeded to delete their OS so they could stop tricking me into talking to them."
+                      "value": "The catfisher came back this time and I was fed up with it. So I went to their house and accessed their computer without their knowledge and proceeded to delete their OS so they could stop tricking me into talking to them."
                     }
                   },
                   "Date": {
@@ -2455,8 +2467,7 @@
                   "Incident": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "Broke into someone's house and deleted their operating system."
+                      "value": "Broke into someone's house and deleted their operating system."
                     }
                   },
                   "Location": {
@@ -2697,8 +2708,7 @@
                   "Incident": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "One time I threw a SQL injection prompt into my local baker's invoicing system so I could drop all my outstanding charges for double mocha frappachinos"
+                      "value": "One time I threw a SQL injection prompt into my local baker's invoicing system so I could drop all my outstanding charges for double mocha frappachinos"
                     }
                   },
                   "Location": {
@@ -2719,8 +2729,7 @@
                   "Action": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "Welllll so the catfisher figured out my phishing technique and called the local sheriff who found me hiding in the bathroom of an internet cafe."
+                      "value": "Welllll so the catfisher figured out my phishing technique and called the local sheriff who found me hiding in the bathroom of an internet cafe."
                     }
                   },
                   "Date": {
@@ -2735,8 +2744,7 @@
                   "Incident": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "I spear phished a catfisher to figure out their real identity."
+                      "value": "I spear phished a catfisher to figure out their real identity."
                     }
                   },
                   "Location": {
@@ -2781,8 +2789,7 @@
                   "Action": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "Look it was a program that went wild. We were trying to get more votes for Boaty McBoatface to help support our friends in the UK."
+                      "value": "Look it was a program that went wild. We were trying to get more votes for Boaty McBoatface to help support our friends in the UK."
                     }
                   },
                   "Date": {
@@ -2797,8 +2804,7 @@
                   "Incident": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "Raised a botnet to vote for Boaty McBoatface on US government computers"
+                      "value": "Raised a botnet to vote for Boaty McBoatface on US government computers"
                     }
                   },
                   "Location": {
@@ -2819,8 +2825,7 @@
                   "Action": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "DOD was like, hey we wont' charge you, you're on our team now buddy."
+                      "value": "DOD was like, hey we wont' charge you, you're on our team now buddy."
                     }
                   },
                   "Date": {
@@ -2835,8 +2840,7 @@
                   "Incident": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "You know that movie \"War Games\"?   That was me."
+                      "value": "You know that movie \"War Games\"?   That was me."
                     }
                   },
                   "Location": {
@@ -2866,8 +2870,7 @@
         "Comments": {
           "type": "text",
           "props": {
-            "value":
-              "Look, I know I'm a weird bird, but trust me I really need this TS-SCI"
+            "value": "Look, I know I'm a weird bird, but trust me I really need this TS-SCI"
           }
         }
       }
@@ -2917,8 +2920,7 @@
                   "Offenses": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "Abandoning my post when I jumped off the aircraft carrier after seeing a tarantula crawling through the porthole  "
+                      "value": "Abandoning my post when I jumped off the aircraft carrier after seeing a tarantula crawling through the porthole  "
                     }
                   },
                   "Outcome": {
@@ -2934,8 +2936,7 @@
                   "Court": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "A scary building made of stones and gargoyles located in the mystical rainforests of Georgia"
+                      "value": "A scary building made of stones and gargoyles located in the mystical rainforests of Georgia"
                     }
                   },
                   "Date": {
@@ -2956,8 +2957,7 @@
                   "Offenses": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "Mischief: Before I saw the huge spider, I was caught stealing frozen pizzas from the kitchen and cooking them on the heat shield where they launch the planes"
+                      "value": "Mischief: Before I saw the huge spider, I was caught stealing frozen pizzas from the kitchen and cooking them on the heat shield where they launch the planes"
                     }
                   },
                   "Outcome": {
@@ -2988,14 +2988,15 @@
                   "Circumstances": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "I worked as a consultant to the PLA's cybersecurity division working on offensive capabilities."
+                      "value": "I worked as a consultant to the PLA's cybersecurity division working on offensive capabilities."
                     }
                   },
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["China"]
+                      "value": [
+                        "China"
+                      ]
                     }
                   },
                   "Dates": {
@@ -3082,8 +3083,7 @@
                             "Frequency": {
                               "type": "text",
                               "props": {
-                                "value":
-                                  "Literally he's my best friend on snapchat"
+                                "value": "Literally he's my best friend on snapchat"
                               }
                             },
                             "Has": {
@@ -4144,7 +4144,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["WorkAssociate"]
+                      "values": [
+                        "WorkAssociate"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -4256,7 +4258,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["WorkAssociate"]
+                      "values": [
+                        "WorkAssociate"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -4368,7 +4372,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["WorkAssociate"]
+                      "values": [
+                        "WorkAssociate"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -4495,7 +4501,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United Kingdom"]
+                      "value": [
+                        "United Kingdom"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -4774,7 +4782,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United Kingdom"]
+                      "value": [
+                        "United Kingdom"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {

--- a/api/testdata/complete-scenarios/test5.json
+++ b/api/testdata/complete-scenarios/test5.json
@@ -35,9 +35,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Canada"
-                      ]
+                      "value": ["Canada"]
                     }
                   },
                   "Current": {
@@ -101,9 +99,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Mexico"
-                      ]
+                      "value": ["Mexico"]
                     }
                   },
                   "Current": {
@@ -191,9 +187,7 @@
                             "Country": {
                               "type": "country",
                               "props": {
-                                "value": [
-                                  "Cuba"
-                                ]
+                                "value": ["Cuba"]
                               }
                             },
                             "Dates": {
@@ -227,9 +221,7 @@
                             "Country": {
                               "type": "country",
                               "props": {
-                                "value": [
-                                  "North Korea"
-                                ]
+                                "value": ["North Korea"]
                               }
                             },
                             "Dates": {
@@ -264,9 +256,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Canada"
-                      ]
+                      "value": ["Canada"]
                     }
                   },
                   "Expiration": {
@@ -343,9 +333,7 @@
                             "Country": {
                               "type": "country",
                               "props": {
-                                "value": [
-                                  "Iran"
-                                ]
+                                "value": ["Iran"]
                               }
                             },
                             "Dates": {
@@ -379,9 +367,7 @@
                             "Country": {
                               "type": "country",
                               "props": {
-                                "value": [
-                                  "Jordan"
-                                ]
+                                "value": ["Jordan"]
                               }
                             },
                             "Dates": {
@@ -416,9 +402,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Mexico"
-                      ]
+                      "value": ["Mexico"]
                     }
                   },
                   "Expiration": {
@@ -1301,9 +1285,7 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Judgement"
-                      ]
+                      "values": ["Judgement"]
                     }
                   },
                   "Name": {
@@ -1321,7 +1303,8 @@
                   "Reason": {
                     "type": "textarea",
                     "props": {
-                      "value": "Didn't return videos before the store closed down."
+                      "value":
+                        "Didn't return videos before the store closed down."
                     }
                   },
                   "Resolved": {
@@ -1402,9 +1385,7 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Federal"
-                      ]
+                      "values": ["Federal"]
                     }
                   },
                   "Name": {
@@ -1626,9 +1607,7 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Collections"
-                      ]
+                      "values": ["Collections"]
                     }
                   },
                   "Name": {
@@ -1710,9 +1689,7 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Repossession"
-                      ]
+                      "values": ["Repossession"]
                     }
                   },
                   "Name": {
@@ -1963,9 +1940,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Japan"
-                      ]
+                      "value": ["Japan"]
                     }
                   },
                   "Dates": {
@@ -2031,9 +2006,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Germany"
-                      ]
+                      "value": ["Germany"]
                     }
                   },
                   "Dates": {
@@ -2291,10 +2264,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Spouse",
-                        "Yourself"
-                      ]
+                      "values": ["Spouse", "Yourself"]
                     }
                   },
                   "OneTimeBenefit": {
@@ -2342,9 +2312,7 @@
                       "Country": {
                         "type": "country",
                         "props": {
-                          "value": [
-                            "Canada"
-                          ]
+                          "value": ["Canada"]
                         }
                       },
                       "Value": {
@@ -2572,9 +2540,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Cohabitant"
-                      ]
+                      "values": ["Cohabitant"]
                     }
                   },
                   "OneTimeBenefit": {
@@ -2622,9 +2588,7 @@
                       "Country": {
                         "type": "country",
                         "props": {
-                          "value": [
-                            "Canada"
-                          ]
+                          "value": ["Canada"]
                         }
                       },
                       "Value": {
@@ -2731,7 +2695,8 @@
                                 "Explanation": {
                                   "type": "textarea",
                                   "props": {
-                                    "value": "I met Joe Brown, researcher at University of Waterloo. "
+                                    "value":
+                                      "I met Joe Brown, researcher at University of Waterloo. "
                                   }
                                 },
                                 "Has": {
@@ -2747,7 +2712,8 @@
                                 "Explanation": {
                                   "type": "textarea",
                                   "props": {
-                                    "value": "I met Cindy Hartnell, researcher at UVic."
+                                    "value":
+                                      "I met Cindy Hartnell, researcher at UVic."
                                   }
                                 },
                                 "Has": {
@@ -2782,9 +2748,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Canada"
-                      ]
+                      "value": ["Canada"]
                     }
                   },
                   "Dates": {
@@ -2873,9 +2837,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United Kingdom"
-                      ]
+                      "value": ["United Kingdom"]
                     }
                   },
                   "Dates": {
@@ -2966,9 +2928,7 @@
                   "Governments": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Canada"
-                      ]
+                      "value": ["Canada"]
                     }
                   },
                   "Location": {
@@ -3132,9 +3092,7 @@
                   "Governments": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Mexico"
-                      ]
+                      "value": ["Mexico"]
                     }
                   },
                   "Location": {
@@ -3322,9 +3280,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Greece"
-                      ]
+                      "value": ["Greece"]
                     }
                   },
                   "Employer": {
@@ -3396,9 +3352,7 @@
                   "Methods": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "In person"
-                      ]
+                      "values": ["In person"]
                     }
                   },
                   "MethodsExplanation": {
@@ -3436,9 +3390,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Professional"
-                      ]
+                      "values": ["Professional"]
                     }
                   },
                   "RelationshipExplanation": {
@@ -3538,9 +3490,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "France"
-                      ]
+                      "value": ["France"]
                     }
                   },
                   "Employer": {
@@ -3610,10 +3560,7 @@
                   "Methods": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "In person",
-                        "Electronic"
-                      ]
+                      "values": ["In person", "Electronic"]
                     }
                   },
                   "MethodsExplanation": {
@@ -3651,9 +3598,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Personal"
-                      ]
+                      "values": ["Personal"]
                     }
                   },
                   "RelationshipExplanation": {
@@ -3725,9 +3670,7 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": [
-                                      "United States"
-                                    ]
+                                    "value": ["United States"]
                                   }
                                 },
                                 "Has": {
@@ -3774,9 +3717,7 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": [
-                                      "United States"
-                                    ]
+                                    "value": ["United States"]
                                   }
                                 },
                                 "Has": {
@@ -3887,9 +3828,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Yourself"
-                      ]
+                      "values": ["Yourself"]
                     }
                   },
                   "Relinquished": {
@@ -4022,9 +3961,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Yourself"
-                      ]
+                      "values": ["Yourself"]
                     }
                   },
                   "Relinquished": {
@@ -4231,9 +4168,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United Kingdom"
-                      ]
+                      "value": ["United Kingdom"]
                     }
                   },
                   "Date": {
@@ -4272,15 +4207,14 @@
                   "Circumstances": {
                     "type": "textarea",
                     "props": {
-                      "value": "There was a garbage strike and asked for my help to clean up the streets."
+                      "value":
+                        "There was a garbage strike and asked for my help to clean up the streets."
                     }
                   },
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Italy"
-                      ]
+                      "value": ["Italy"]
                     }
                   },
                   "Date": {
@@ -4367,9 +4301,7 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": [
-                                      "United Kingdom"
-                                    ]
+                                    "value": ["United Kingdom"]
                                   }
                                 },
                                 "Has": {
@@ -4414,9 +4346,7 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": [
-                                      "United Kingdom"
-                                    ]
+                                    "value": ["United Kingdom"]
                                   }
                                 },
                                 "Has": {
@@ -4533,9 +4463,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Yourself"
-                      ]
+                      "values": ["Yourself"]
                     }
                   },
                   "Lastname": {
@@ -4686,9 +4614,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Yourself"
-                      ]
+                      "values": ["Yourself"]
                     }
                   },
                   "Lastname": {
@@ -4822,9 +4748,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Canada"
-                      ]
+                      "value": ["Canada"]
                     }
                   },
                   "Dates": {
@@ -4876,9 +4800,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Canada"
-                      ]
+                      "value": ["Canada"]
                     }
                   },
                   "Dates": {
@@ -4993,9 +4915,7 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": [
-                                      "Canada"
-                                    ]
+                                    "value": ["Canada"]
                                   }
                                 },
                                 "Has": {
@@ -5040,9 +4960,7 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": [
-                                      "Canada"
-                                    ]
+                                    "value": ["Canada"]
                                   }
                                 },
                                 "Has": {
@@ -5141,9 +5059,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Yourself"
-                      ]
+                      "values": ["Yourself"]
                     }
                   },
                   "RealEstateType": {
@@ -5279,9 +5195,7 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Yourself"
-                      ]
+                      "values": ["Yourself"]
                     }
                   },
                   "RealEstateType": {
@@ -5382,9 +5296,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Canada"
-                      ]
+                      "value": ["Canada"]
                     }
                   },
                   "Dates": {
@@ -5517,9 +5429,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Canada"
-                      ]
+                      "value": ["Canada"]
                     }
                   },
                   "Dates": {
@@ -5666,9 +5576,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Zimbabwe"
-                      ]
+                      "value": ["Zimbabwe"]
                     }
                   },
                   "Frequency": {
@@ -5727,9 +5635,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Germany"
-                      ]
+                      "value": ["Germany"]
                     }
                   },
                   "Frequency": {
@@ -5819,9 +5725,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Greece"
-                      ]
+                      "value": ["Greece"]
                     }
                   },
                   "Dates": {
@@ -5851,9 +5755,7 @@
                   "Days": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "6-10"
-                      ]
+                      "values": ["6-10"]
                     }
                   },
                   "Encounter": {
@@ -5877,15 +5779,14 @@
                   "InterestExplanation": {
                     "type": "textarea",
                     "props": {
-                      "value": "I was contacted by someone interested in my job."
+                      "value":
+                        "I was contacted by someone interested in my job."
                     }
                   },
                   "Purpose": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Tourism"
-                      ]
+                      "values": ["Tourism"]
                     }
                   },
                   "Questioned": {
@@ -5909,7 +5810,8 @@
                   "SensitiveExplanation": {
                     "type": "textarea",
                     "props": {
-                      "value": "I was contacted by someone who wanted FOUO information."
+                      "value":
+                        "I was contacted by someone who wanted FOUO information."
                     }
                   },
                   "Threatened": {
@@ -5955,9 +5857,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Vatican City"
-                      ]
+                      "value": ["Vatican City"]
                     }
                   },
                   "Dates": {
@@ -5987,9 +5887,7 @@
                   "Days": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "6-10"
-                      ]
+                      "values": ["6-10"]
                     }
                   },
                   "Encounter": {
@@ -6019,9 +5917,7 @@
                   "Purpose": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Volunteer"
-                      ]
+                      "values": ["Volunteer"]
                     }
                   },
                   "Questioned": {
@@ -6106,9 +6002,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Canada"
-                      ]
+                      "value": ["Canada"]
                     }
                   },
                   "Compensation": {
@@ -6207,9 +6101,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United Kingdom"
-                      ]
+                      "value": ["United Kingdom"]
                     }
                   },
                   "Compensation": {
@@ -6317,9 +6209,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Canada"
-                      ]
+                      "value": ["Canada"]
                     }
                   },
                   "Date": {
@@ -6350,9 +6240,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Japan"
-                      ]
+                      "value": ["Japan"]
                     }
                   },
                   "Date": {
@@ -11222,9 +11110,7 @@
                   "ReferenceRelationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Neighbor"
-                      ]
+                      "values": ["Neighbor"]
                     }
                   },
                   "ReferenceRelationshipComments": {
@@ -11344,34 +11230,16 @@
     "Contacts": {
       "type": "identification.contacts",
       "props": {
-        "Emails": {
-          "type": "collection",
+        "HomeEmail": {
+          "type": "email",
           "props": {
-            "branch": {
-              "type": ""
-            },
-            "items": [
-              {
-                "Item": {
-                  "Email": {
-                    "type": "email",
-                    "props": {
-                      "value": "kirk1@example.com"
-                    }
-                  }
-                }
-              },
-              {
-                "Item": {
-                  "Email": {
-                    "type": "email",
-                    "props": {
-                      "value": "kirk2@example.com"
-                    }
-                  }
-                }
-              }
-            ]
+            "value": "kirk1@example.com"
+          }
+        },
+        "WorkEmail": {
+          "type": "email",
+          "props": {
+            "value": "kirk2@example.com"
           }
         },
         "PhoneNumbers": {
@@ -13818,7 +13686,8 @@
                   "Incident": {
                     "type": "textarea",
                     "props": {
-                      "value": "Denial of service attack on Department of Energy"
+                      "value":
+                        "Denial of service attack on Department of Energy"
                     }
                   },
                   "Location": {
@@ -14067,9 +13936,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Canada"
-                      ]
+                      "value": ["Canada"]
                     }
                   },
                   "Dates": {
@@ -14303,9 +14170,7 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Canada"
-                      ]
+                      "value": ["Canada"]
                     }
                   },
                   "Dates": {
@@ -15863,10 +15728,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "Canada",
-                        "United States"
-                      ]
+                      "value": ["Canada", "United States"]
                     }
                   },
                   "CohabitationBegan": {
@@ -16029,9 +15891,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CohabitationBegan": {
@@ -16297,9 +16157,7 @@
             "Citizenship": {
               "type": "country",
               "props": {
-                "value": [
-                  "United States"
-                ]
+                "value": ["United States"]
               }
             },
             "DateSeparated": {
@@ -16645,9 +16503,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "DateDivorced": {
@@ -16839,9 +16695,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Neighbor"
-                      ]
+                      "values": ["Neighbor"]
                     }
                   },
                   "RelationshipOther": {
@@ -16952,9 +16806,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Friend"
-                      ]
+                      "values": ["Friend"]
                     }
                   },
                   "RelationshipOther": {
@@ -17065,9 +16917,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Neighbor"
-                      ]
+                      "values": ["Neighbor"]
                     }
                   },
                   "RelationshipOther": {
@@ -17200,9 +17050,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -17484,9 +17332,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United Kingdom"
-                      ]
+                      "value": ["United Kingdom"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -17633,9 +17479,7 @@
                   "Methods": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Telephone"
-                      ]
+                      "values": ["Telephone"]
                     }
                   },
                   "MethodsComments": {
@@ -17776,10 +17620,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United Kingdom",
-                        "United States"
-                      ]
+                      "value": ["United Kingdom", "United States"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -18009,9 +17850,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -18296,9 +18135,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -18517,9 +18354,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -18738,9 +18573,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -19639,9 +19472,7 @@
                   "Seekers": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "MentalHealthProfessional"
-                      ]
+                      "values": ["MentalHealthProfessional"]
                     }
                   },
                   "TreatmentProviderAddress": {
@@ -19733,9 +19564,7 @@
                   "Seekers": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "CourtOfficial"
-                      ]
+                      "values": ["CourtOfficial"]
                     }
                   },
                   "TreatmentProviderAddress": {
@@ -19822,9 +19651,7 @@
                   "OrderedBy": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Employer"
-                      ]
+                      "values": ["Employer"]
                     }
                   },
                   "TreatmentCompleted": {
@@ -19922,9 +19749,7 @@
                   "OrderedBy": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "MedicalProfessional"
-                      ]
+                      "values": ["MedicalProfessional"]
                     }
                   },
                   "TreatmentCompleted": {

--- a/api/testdata/complete-scenarios/test5.json
+++ b/api/testdata/complete-scenarios/test5.json
@@ -35,7 +35,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Canada"]
+                      "value": [
+                        "Canada"
+                      ]
                     }
                   },
                   "Current": {
@@ -99,7 +101,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Mexico"]
+                      "value": [
+                        "Mexico"
+                      ]
                     }
                   },
                   "Current": {
@@ -187,7 +191,9 @@
                             "Country": {
                               "type": "country",
                               "props": {
-                                "value": ["Cuba"]
+                                "value": [
+                                  "Cuba"
+                                ]
                               }
                             },
                             "Dates": {
@@ -221,7 +227,9 @@
                             "Country": {
                               "type": "country",
                               "props": {
-                                "value": ["North Korea"]
+                                "value": [
+                                  "North Korea"
+                                ]
                               }
                             },
                             "Dates": {
@@ -256,7 +264,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Canada"]
+                      "value": [
+                        "Canada"
+                      ]
                     }
                   },
                   "Expiration": {
@@ -333,7 +343,9 @@
                             "Country": {
                               "type": "country",
                               "props": {
-                                "value": ["Iran"]
+                                "value": [
+                                  "Iran"
+                                ]
                               }
                             },
                             "Dates": {
@@ -367,7 +379,9 @@
                             "Country": {
                               "type": "country",
                               "props": {
-                                "value": ["Jordan"]
+                                "value": [
+                                  "Jordan"
+                                ]
                               }
                             },
                             "Dates": {
@@ -402,7 +416,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Mexico"]
+                      "value": [
+                        "Mexico"
+                      ]
                     }
                   },
                   "Expiration": {
@@ -1285,7 +1301,9 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Judgement"]
+                      "values": [
+                        "Judgement"
+                      ]
                     }
                   },
                   "Name": {
@@ -1303,8 +1321,7 @@
                   "Reason": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "Didn't return videos before the store closed down."
+                      "value": "Didn't return videos before the store closed down."
                     }
                   },
                   "Resolved": {
@@ -1385,7 +1402,9 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Federal"]
+                      "values": [
+                        "Federal"
+                      ]
                     }
                   },
                   "Name": {
@@ -1607,7 +1626,9 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Collections"]
+                      "values": [
+                        "Collections"
+                      ]
                     }
                   },
                   "Name": {
@@ -1689,7 +1710,9 @@
                   "Infractions": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Repossession"]
+                      "values": [
+                        "Repossession"
+                      ]
                     }
                   },
                   "Name": {
@@ -1940,7 +1963,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Japan"]
+                      "value": [
+                        "Japan"
+                      ]
                     }
                   },
                   "Dates": {
@@ -2006,7 +2031,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Germany"]
+                      "value": [
+                        "Germany"
+                      ]
                     }
                   },
                   "Dates": {
@@ -2264,7 +2291,10 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Spouse", "Yourself"]
+                      "values": [
+                        "Spouse",
+                        "Yourself"
+                      ]
                     }
                   },
                   "OneTimeBenefit": {
@@ -2312,7 +2342,9 @@
                       "Country": {
                         "type": "country",
                         "props": {
-                          "value": ["Canada"]
+                          "value": [
+                            "Canada"
+                          ]
                         }
                       },
                       "Value": {
@@ -2540,7 +2572,9 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Cohabitant"]
+                      "values": [
+                        "Cohabitant"
+                      ]
                     }
                   },
                   "OneTimeBenefit": {
@@ -2588,7 +2622,9 @@
                       "Country": {
                         "type": "country",
                         "props": {
-                          "value": ["Canada"]
+                          "value": [
+                            "Canada"
+                          ]
                         }
                       },
                       "Value": {
@@ -2695,8 +2731,7 @@
                                 "Explanation": {
                                   "type": "textarea",
                                   "props": {
-                                    "value":
-                                      "I met Joe Brown, researcher at University of Waterloo. "
+                                    "value": "I met Joe Brown, researcher at University of Waterloo. "
                                   }
                                 },
                                 "Has": {
@@ -2712,8 +2747,7 @@
                                 "Explanation": {
                                   "type": "textarea",
                                   "props": {
-                                    "value":
-                                      "I met Cindy Hartnell, researcher at UVic."
+                                    "value": "I met Cindy Hartnell, researcher at UVic."
                                   }
                                 },
                                 "Has": {
@@ -2748,7 +2782,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Canada"]
+                      "value": [
+                        "Canada"
+                      ]
                     }
                   },
                   "Dates": {
@@ -2837,7 +2873,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["United Kingdom"]
+                      "value": [
+                        "United Kingdom"
+                      ]
                     }
                   },
                   "Dates": {
@@ -2928,7 +2966,9 @@
                   "Governments": {
                     "type": "country",
                     "props": {
-                      "value": ["Canada"]
+                      "value": [
+                        "Canada"
+                      ]
                     }
                   },
                   "Location": {
@@ -3092,7 +3132,9 @@
                   "Governments": {
                     "type": "country",
                     "props": {
-                      "value": ["Mexico"]
+                      "value": [
+                        "Mexico"
+                      ]
                     }
                   },
                   "Location": {
@@ -3280,7 +3322,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["Greece"]
+                      "value": [
+                        "Greece"
+                      ]
                     }
                   },
                   "Employer": {
@@ -3352,7 +3396,9 @@
                   "Methods": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["In person"]
+                      "values": [
+                        "In person"
+                      ]
                     }
                   },
                   "MethodsExplanation": {
@@ -3390,7 +3436,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Professional"]
+                      "values": [
+                        "Professional"
+                      ]
                     }
                   },
                   "RelationshipExplanation": {
@@ -3490,7 +3538,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["France"]
+                      "value": [
+                        "France"
+                      ]
                     }
                   },
                   "Employer": {
@@ -3560,7 +3610,10 @@
                   "Methods": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["In person", "Electronic"]
+                      "values": [
+                        "In person",
+                        "Electronic"
+                      ]
                     }
                   },
                   "MethodsExplanation": {
@@ -3598,7 +3651,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Personal"]
+                      "values": [
+                        "Personal"
+                      ]
                     }
                   },
                   "RelationshipExplanation": {
@@ -3670,7 +3725,9 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": ["United States"]
+                                    "value": [
+                                      "United States"
+                                    ]
                                   }
                                 },
                                 "Has": {
@@ -3717,7 +3774,9 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": ["United States"]
+                                    "value": [
+                                      "United States"
+                                    ]
                                   }
                                 },
                                 "Has": {
@@ -3828,7 +3887,9 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Yourself"]
+                      "values": [
+                        "Yourself"
+                      ]
                     }
                   },
                   "Relinquished": {
@@ -3961,7 +4022,9 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Yourself"]
+                      "values": [
+                        "Yourself"
+                      ]
                     }
                   },
                   "Relinquished": {
@@ -4168,7 +4231,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["United Kingdom"]
+                      "value": [
+                        "United Kingdom"
+                      ]
                     }
                   },
                   "Date": {
@@ -4207,14 +4272,15 @@
                   "Circumstances": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "There was a garbage strike and asked for my help to clean up the streets."
+                      "value": "There was a garbage strike and asked for my help to clean up the streets."
                     }
                   },
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Italy"]
+                      "value": [
+                        "Italy"
+                      ]
                     }
                   },
                   "Date": {
@@ -4301,7 +4367,9 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": ["United Kingdom"]
+                                    "value": [
+                                      "United Kingdom"
+                                    ]
                                   }
                                 },
                                 "Has": {
@@ -4346,7 +4414,9 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": ["United Kingdom"]
+                                    "value": [
+                                      "United Kingdom"
+                                    ]
                                   }
                                 },
                                 "Has": {
@@ -4463,7 +4533,9 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Yourself"]
+                      "values": [
+                        "Yourself"
+                      ]
                     }
                   },
                   "Lastname": {
@@ -4614,7 +4686,9 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Yourself"]
+                      "values": [
+                        "Yourself"
+                      ]
                     }
                   },
                   "Lastname": {
@@ -4748,7 +4822,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Canada"]
+                      "value": [
+                        "Canada"
+                      ]
                     }
                   },
                   "Dates": {
@@ -4800,7 +4876,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Canada"]
+                      "value": [
+                        "Canada"
+                      ]
                     }
                   },
                   "Dates": {
@@ -4915,7 +4993,9 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": ["Canada"]
+                                    "value": [
+                                      "Canada"
+                                    ]
                                   }
                                 },
                                 "Has": {
@@ -4960,7 +5040,9 @@
                                 "Countries": {
                                   "type": "country",
                                   "props": {
-                                    "value": ["Canada"]
+                                    "value": [
+                                      "Canada"
+                                    ]
                                   }
                                 },
                                 "Has": {
@@ -5059,7 +5141,9 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Yourself"]
+                      "values": [
+                        "Yourself"
+                      ]
                     }
                   },
                   "RealEstateType": {
@@ -5195,7 +5279,9 @@
                   "InterestTypes": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Yourself"]
+                      "values": [
+                        "Yourself"
+                      ]
                     }
                   },
                   "RealEstateType": {
@@ -5296,7 +5382,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["Canada"]
+                      "value": [
+                        "Canada"
+                      ]
                     }
                   },
                   "Dates": {
@@ -5429,7 +5517,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["Canada"]
+                      "value": [
+                        "Canada"
+                      ]
                     }
                   },
                   "Dates": {
@@ -5576,7 +5666,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["Zimbabwe"]
+                      "value": [
+                        "Zimbabwe"
+                      ]
                     }
                   },
                   "Frequency": {
@@ -5635,7 +5727,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["Germany"]
+                      "value": [
+                        "Germany"
+                      ]
                     }
                   },
                   "Frequency": {
@@ -5725,7 +5819,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Greece"]
+                      "value": [
+                        "Greece"
+                      ]
                     }
                   },
                   "Dates": {
@@ -5755,7 +5851,9 @@
                   "Days": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["6-10"]
+                      "values": [
+                        "6-10"
+                      ]
                     }
                   },
                   "Encounter": {
@@ -5779,14 +5877,15 @@
                   "InterestExplanation": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "I was contacted by someone interested in my job."
+                      "value": "I was contacted by someone interested in my job."
                     }
                   },
                   "Purpose": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Tourism"]
+                      "values": [
+                        "Tourism"
+                      ]
                     }
                   },
                   "Questioned": {
@@ -5810,8 +5909,7 @@
                   "SensitiveExplanation": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "I was contacted by someone who wanted FOUO information."
+                      "value": "I was contacted by someone who wanted FOUO information."
                     }
                   },
                   "Threatened": {
@@ -5857,7 +5955,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Vatican City"]
+                      "value": [
+                        "Vatican City"
+                      ]
                     }
                   },
                   "Dates": {
@@ -5887,7 +5987,9 @@
                   "Days": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["6-10"]
+                      "values": [
+                        "6-10"
+                      ]
                     }
                   },
                   "Encounter": {
@@ -5917,7 +6019,9 @@
                   "Purpose": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Volunteer"]
+                      "values": [
+                        "Volunteer"
+                      ]
                     }
                   },
                   "Questioned": {
@@ -6002,7 +6106,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["Canada"]
+                      "value": [
+                        "Canada"
+                      ]
                     }
                   },
                   "Compensation": {
@@ -6101,7 +6207,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United Kingdom"]
+                      "value": [
+                        "United Kingdom"
+                      ]
                     }
                   },
                   "Compensation": {
@@ -6209,7 +6317,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Canada"]
+                      "value": [
+                        "Canada"
+                      ]
                     }
                   },
                   "Date": {
@@ -6240,7 +6350,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Japan"]
+                      "value": [
+                        "Japan"
+                      ]
                     }
                   },
                   "Date": {
@@ -11110,7 +11222,9 @@
                   "ReferenceRelationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Neighbor"]
+                      "values": [
+                        "Neighbor"
+                      ]
                     }
                   },
                   "ReferenceRelationshipComments": {
@@ -13686,8 +13800,7 @@
                   "Incident": {
                     "type": "textarea",
                     "props": {
-                      "value":
-                        "Denial of service attack on Department of Energy"
+                      "value": "Denial of service attack on Department of Energy"
                     }
                   },
                   "Location": {
@@ -13936,7 +14049,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Canada"]
+                      "value": [
+                        "Canada"
+                      ]
                     }
                   },
                   "Dates": {
@@ -14170,7 +14285,9 @@
                   "Country": {
                     "type": "country",
                     "props": {
-                      "value": ["Canada"]
+                      "value": [
+                        "Canada"
+                      ]
                     }
                   },
                   "Dates": {
@@ -15728,7 +15845,10 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["Canada", "United States"]
+                      "value": [
+                        "Canada",
+                        "United States"
+                      ]
                     }
                   },
                   "CohabitationBegan": {
@@ -15891,7 +16011,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CohabitationBegan": {
@@ -16157,7 +16279,9 @@
             "Citizenship": {
               "type": "country",
               "props": {
-                "value": ["United States"]
+                "value": [
+                  "United States"
+                ]
               }
             },
             "DateSeparated": {
@@ -16503,7 +16627,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "DateDivorced": {
@@ -16695,7 +16821,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Neighbor"]
+                      "values": [
+                        "Neighbor"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -16806,7 +16934,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Friend"]
+                      "values": [
+                        "Friend"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -16917,7 +17047,9 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Neighbor"]
+                      "values": [
+                        "Neighbor"
+                      ]
                     }
                   },
                   "RelationshipOther": {
@@ -17050,7 +17182,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -17332,7 +17466,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United Kingdom"]
+                      "value": [
+                        "United Kingdom"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -17479,7 +17615,9 @@
                   "Methods": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Telephone"]
+                      "values": [
+                        "Telephone"
+                      ]
                     }
                   },
                   "MethodsComments": {
@@ -17620,7 +17758,10 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United Kingdom", "United States"]
+                      "value": [
+                        "United Kingdom",
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -17850,7 +17991,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -18135,7 +18278,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -18354,7 +18499,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -18573,7 +18720,9 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": ["United States"]
+                      "value": [
+                        "United States"
+                      ]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -19472,7 +19621,9 @@
                   "Seekers": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["MentalHealthProfessional"]
+                      "values": [
+                        "MentalHealthProfessional"
+                      ]
                     }
                   },
                   "TreatmentProviderAddress": {
@@ -19564,7 +19715,9 @@
                   "Seekers": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["CourtOfficial"]
+                      "values": [
+                        "CourtOfficial"
+                      ]
                     }
                   },
                   "TreatmentProviderAddress": {
@@ -19651,7 +19804,9 @@
                   "OrderedBy": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["Employer"]
+                      "values": [
+                        "Employer"
+                      ]
                     }
                   },
                   "TreatmentCompleted": {
@@ -19749,7 +19904,9 @@
                   "OrderedBy": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": ["MedicalProfessional"]
+                      "values": [
+                        "MedicalProfessional"
+                      ]
                     }
                   },
                   "TreatmentCompleted": {

--- a/api/testdata/complete-scenarios/test6.json
+++ b/api/testdata/complete-scenarios/test6.json
@@ -1820,10 +1820,7 @@
                   "ReferenceRelationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Neighbor",
-                        "Friend"
-                      ]
+                      "values": ["Neighbor", "Friend"]
                     }
                   },
                   "ReferenceRelationshipComments": {
@@ -1943,24 +1940,16 @@
     "Contacts": {
       "type": "identification.contacts",
       "props": {
-        "Emails": {
-          "type": "collection",
+        "HomeEmail": {
+          "type": "email",
           "props": {
-            "branch": {
-              "type": ""
-            },
-            "items": [
-              {
-                "Item": {
-                  "Email": {
-                    "type": "email",
-                    "props": {
-                      "value": "ian.chris@testmail.com"
-                    }
-                  }
-                }
-              }
-            ]
+            "value": "ian.chris@testmail.com"
+          }
+        },
+        "WorkEmail": {
+          "type": "email",
+          "props": {
+            "value": ""
           }
         },
         "PhoneNumbers": {
@@ -3101,11 +3090,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Neighbor",
-                        "Friend",
-                        "Schoolmate"
-                      ]
+                      "values": ["Neighbor", "Friend", "Schoolmate"]
                     }
                   },
                   "RelationshipOther": {
@@ -3216,10 +3201,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Neighbor",
-                        "Friend"
-                      ]
+                      "values": ["Neighbor", "Friend"]
                     }
                   },
                   "RelationshipOther": {
@@ -3331,9 +3313,7 @@
                   "Relationship": {
                     "type": "checkboxgroup",
                     "props": {
-                      "values": [
-                        "Friend"
-                      ]
+                      "values": ["Friend"]
                     }
                   },
                   "RelationshipOther": {
@@ -3461,9 +3441,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {
@@ -3743,9 +3721,7 @@
                   "Citizenship": {
                     "type": "country",
                     "props": {
-                      "value": [
-                        "United States"
-                      ]
+                      "value": ["United States"]
                     }
                   },
                   "CitizenshipDocumentation": {

--- a/api/testdata/identification-contacts.json
+++ b/api/testdata/identification-contacts.json
@@ -1,27 +1,16 @@
 {
   "type": "identification.contacts",
   "props": {
-    "Emails": {
-      "type": "collection",
+    "HomeEmail": {
+      "type": "email",
       "props": {
-        "items": [
-          {
-            "Item": {
-              "Email": {
-                "type": "email",
-                "props": {
-                  "value": "test@abc.com"
-                }
-              }
-            }
-          }
-        ],
-        "branch": {
-          "type": "branch",
-          "props": {
-            "value": "No"
-          }
-        }
+        "value": "test@abc.com"
+      }
+    },
+    "WorkEmail": {
+      "type": "email",
+      "props": {
+        "value": "test@abc.com"
       }
     },
     "PhoneNumbers": {

--- a/src/components/Section/Identification/ContactInformation/ContactInformation.jsx
+++ b/src/components/Section/Identification/ContactInformation/ContactInformation.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { i18n } from '../../../../config'
 import {
   IdentificationContactInformationValidator,
-  ContactEmailValidator,
   ContactPhoneNumberValidator
 } from '../../../../validators'
 import SubsectionElement from '../../SubsectionElement'
@@ -19,51 +18,35 @@ export default class ContactInformation extends SubsectionElement {
   constructor(props) {
     super(props)
     this.update = this.update.bind(this)
-    this.updateEmails = this.updateEmails.bind(this)
+    this.updateHomeEmail = this.updateHomeEmail.bind(this)
+    this.updateWorkEmail = this.updateWorkEmail.bind(this)
     this.updatePhoneNumbers = this.updatePhoneNumbers.bind(this)
   }
 
   update(queue) {
-    const delay =
-      this.props.Emails.length && this.props.PhoneNumbers.length ? 0 : 100
-
-    // Little bit of delay here because on first load both accordions send
-    // updates which clobber one another.
-    window.setTimeout(() => {
-      this.props.onUpdate({
-        Emails: this.props.Emails,
-        PhoneNumbers: this.props.PhoneNumbers,
-        ...queue
-      })
-    }, delay)
+    this.props.onUpdate({
+      HomeEmail: this.props.HomeEmail,
+      WorkEmail: this.props.WorkEmail,
+      PhoneNumbers: this.props.PhoneNumbers,
+      ...queue
+    })
   }
 
-  updateEmails(values) {
+  updateHomeEmail(values) {
     this.update({
-      Emails: values
+      HomeEmail: values
+    })
+  }
+
+  updateWorkEmail(values) {
+    this.update({
+      WorkEmail: values
     })
   }
 
   updatePhoneNumbers(values) {
     this.update({
       PhoneNumbers: values
-    })
-  }
-
-  /**
-   * Assists in rendering the summary section.
-   */
-  emailSummary(item, index) {
-    const email = (item.Item || {}).Email
-    const addr = email && email.value ? email.value : ''
-    return Summary({
-      type: i18n.t('identification.contacts.collection.summary.email'),
-      index: index,
-      left: addr,
-      right: null,
-      placeholder: i18n.t(
-        'identification.contacts.collection.summary.unknownEmail'
-      )
     })
   }
 
@@ -99,24 +82,10 @@ export default class ContactInformation extends SubsectionElement {
 
   render() {
     const klass = `${this.props.className || ''}`.trim()
-    let emails = this.props.Emails
     let phoneNumbers = this.props.PhoneNumbers
 
     if (this.props.shouldFilterEmptyItems) {
-      let filtered = emails.items.length
-      const filteredEmails = emails.items.filter(x => {
-        const item = x.Item || {}
-        if (!item.Email || !item.Email.value) {
-          filtered--
-          if (filtered < 1) {
-            return item
-          }
-        }
-        return item.Email && item.Email.value
-      })
-      emails.items = filteredEmails
-
-      filtered = phoneNumbers.items.length
+      let filtered = phoneNumbers.items.length
       const filteredPhoneNumbers = phoneNumbers.items.filter(x => {
         const item = x.Item || {}
         if (!item.Telephone || !item.Telephone.value) {
@@ -128,11 +97,6 @@ export default class ContactInformation extends SubsectionElement {
         return (item.Telephone && item.Telephone.number) || item.noNumber
       })
       phoneNumbers.items = filteredPhoneNumbers
-    }
-
-    let emailMin = this.props.minimumEmails
-    if (emails.items.length === 0) {
-      emailMin = this.props.shouldFilterEmptyItems ? 1 : 2
     }
 
     let phoneMin = this.props.minimumPhoneNumbers
@@ -161,40 +125,35 @@ export default class ContactInformation extends SubsectionElement {
           {i18n.m('identification.contacts.para.email')}
         </Field>
 
-        <div className={klass + ' email-collection'}>
-          <Accordion
-            {...emails}
-            minimum={emailMin}
-            defaultState={this.props.defaultState}
-            onUpdate={this.updateEmails}
-            onError={this.handleError}
-            required={this.props.required}
-            summary={this.emailSummary}
-            validator={ContactEmailValidator}
-            description={i18n.t(
-              'identification.contacts.collection.summary.title'
-            )}
-            appendLabel={i18n.t('identification.contacts.collection.append')}
-            scrollIntoView={this.props.scrollIntoView}>
-            <AccordionItem
-              scrollIntoView={this.props.scrollIntoView}
-              required={false}>
-              <Field
-                title={i18n.t('identification.contacts.label.email')}
-                titleSize="label"
-                optional={true}
-                scrollIntoView={this.props.scrollIntoView}>
-                <Email
-                  name="Email"
-                  placeholder={i18n.t(
-                    'identification.contacts.placeholder.email'
-                  )}
-                  bind={true}
-                />
-              </Field>
-            </AccordionItem>
-          </Accordion>
-        </div>
+        <Field
+          title={i18n.t('identification.contacts.heading.emailHome')}
+          titleSize="label"
+          optional={true}
+          scrollIntoView={this.props.scrollIntoView}>
+          <Email
+            name="HomeEmail"
+            className="email-home"
+            placeholder={i18n.t('identification.contacts.placeholder.email')}
+            {...this.props.HomeEmail}
+            onUpdate={this.updateHomeEmail}
+            onError={this.props.onError}
+          />
+        </Field>
+
+        <Field
+          title={i18n.t('identification.contacts.heading.emailWork')}
+          titleSize="label"
+          optional={true}
+          scrollIntoView={this.props.scrollIntoView}>
+          <Email
+            name="WorkEmail"
+            className="email-work"
+            placeholder={i18n.t('identification.contacts.placeholder.email')}
+            {...this.props.WorkEmail}
+            onUpdate={this.updateWorkEmail}
+            onError={this.props.onError}
+          />
+        </Field>
 
         <Field
           title={i18n.t('identification.contacts.heading.phoneNumber')}
@@ -253,10 +212,10 @@ export default class ContactInformation extends SubsectionElement {
 }
 
 ContactInformation.defaultProps = {
-  Emails: Accordion.defaultList,
+  HomeEmail: {},
+  WorkEmail: {},
   PhoneNumbers: Accordion.defaultList,
   minimumPhoneNumbers: 1,
-  minimumEmails: 1,
   shouldFilterEmptyItems: false,
   onUpdate: queue => {},
   onError: (value, arr) => {

--- a/src/components/Section/Identification/ContactInformation/ContactInformation.test.jsx
+++ b/src/components/Section/Identification/ContactInformation/ContactInformation.test.jsx
@@ -7,7 +7,8 @@ describe('The ContactInformation component', () => {
     let blurs = 0
     const expected = {
       name: 'input-focus',
-      Emails: { items: [{}] },
+      HomeEmail: {},
+      WorkEmail: {},
       PhoneNumbers: { items: [{}] },
       onBlur: function(event) {
         blurs++
@@ -103,54 +104,10 @@ describe('The ContactInformation component', () => {
     ).toEqual('+001 1234567890')
   })
 
-  it('formats emails appropriately', () => {
-    const expected = {
-      Emails: {
-        items: [
-          {
-            Item: {
-              Email: {
-                value: 'test@abc.com'
-              }
-            }
-          },
-          {
-            Item: {}
-          }
-        ]
-      }
-    }
-    const component = mount(<ContactInformation {...expected} />)
-    expect(component.find('.index').length).toEqual(2)
-    expect(
-      component
-        .find('.summary strong')
-        .at(0)
-        .text()
-    ).toEqual('test@abc.com')
-    expect(
-      component
-        .find('.summary strong')
-        .at(1)
-        .text()
-    ).toEqual('Provide your email address below')
-  })
-
   it('should filter empty items out leaving only the minimum visible', () => {
-    let emails = {}
     let phoneNumbers = {}
     const expected = {
       shouldFilterEmptyItems: true,
-      Emails: {
-        items: [
-          {},
-          {
-            Item: {
-              Email: { value: 'test@abc.com' }
-            }
-          }
-        ]
-      },
       PhoneNumbers: {
         items: [
           {},
@@ -167,17 +124,11 @@ describe('The ContactInformation component', () => {
       }
     }
     const component = mount(<ContactInformation {...expected} />)
-    expect(component.find('.index').length).toEqual(1 + 1)
+    expect(component.find('.index').length).toEqual(1)
     expect(
       component
         .find('.summary strong')
         .at(0)
-        .text()
-    ).toEqual('test@abc.com')
-    expect(
-      component
-        .find('.summary strong')
-        .at(1)
         .text()
     ).toEqual('+001 1234567890')
   })

--- a/src/components/Section/Identification/Identification.test.jsx
+++ b/src/components/Section/Identification/Identification.test.jsx
@@ -9,7 +9,6 @@ import { testSnapshot } from '../../test-helpers'
 const applicationState = {
   Identification: {
     Contacts: {
-      Emails: { items: [] },
       PhoneNumbers: { items: [] }
     }
   }

--- a/src/components/Section/Identification/__snapshots__/Identification.test.jsx.snap
+++ b/src/components/Section/Identification/__snapshots__/Identification.test.jsx.snap
@@ -1272,34 +1272,149 @@ exports[`The identification section renders the IdentificationSections component
       </div>
     </div>
     <div
-      className=" email-collection"
+      aria-label="Home email address"
+      className="field"
+      data-uuid="field-MOCK-GUID"
     >
-      <div>
-        <div
-          className="accordion"
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
+      />
+      <label
+        className="title label"
+      >
+        Home email address
+      </label>
+      <span
+        className="icon"
+      />
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
         >
-          <strong
-            className="aria-description"
+          <span
+            className="component"
           >
-            Summary of email addresses
-          </strong>
-          <div
-            className="items"
-          />
-          <div
-            className="append-button"
-          >
-            <button
-              className="add usa-button-outline"
-              onClick={[Function]}
+            <div
+              className="email email-home"
             >
-              Add another email
-              <i
-                className="fa fa-plus-circle"
+              <input
+                aria-describedby="HomeEmail-error"
+                aria-label={null}
+                autoCapitalize={false}
+                autoComplete={true}
+                autoCorrect={false}
+                className=""
+                id="HomeEmail-MOCK-GUID"
+                maxLength={255}
+                name="HomeEmail"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                pattern={/\\^\\(\\[A-z0-9_\\.-\\]\\+\\)@\\(\\[A-z0-9\\.-\\]\\+\\)\\\\\\.\\+\\(\\[A-z\\.\\]\\{2,63\\}\\)\\$/}
+                placeholder="Enter an email address"
+                spellCheck={false}
+                type="text"
+                value=""
               />
-            </button>
-          </div>
-        </div>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        />
+      </div>
+    </div>
+    <div
+      aria-label="Work email address"
+      className="field"
+      data-uuid="field-MOCK-GUID"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
+      />
+      <label
+        className="title label"
+      >
+        Work email address
+      </label>
+      <span
+        className="icon"
+      />
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component"
+          >
+            <div
+              className="email email-work"
+            >
+              <input
+                aria-describedby="WorkEmail-error"
+                aria-label={null}
+                autoCapitalize={false}
+                autoComplete={true}
+                autoCorrect={false}
+                className=""
+                id="WorkEmail-MOCK-GUID"
+                maxLength={255}
+                name="WorkEmail"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                pattern={/\\^\\(\\[A-z0-9_\\.-\\]\\+\\)@\\(\\[A-z0-9\\.-\\]\\+\\)\\\\\\.\\+\\(\\[A-z\\.\\]\\{2,63\\}\\)\\$/}
+                placeholder="Enter an email address"
+                spellCheck={false}
+                type="text"
+                value=""
+              />
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        />
       </div>
     </div>
     <div

--- a/src/components/Section/Package/__snapshots__/Print.test.jsx.snap
+++ b/src/components/Section/Package/__snapshots__/Print.test.jsx.snap
@@ -1336,34 +1336,149 @@ exports[`The print section renders properly 1`] = `
             </div>
           </div>
           <div
-            className=" email-collection"
+            aria-label="Home email address"
+            className="field"
+            data-uuid="field-MOCK-GUID"
           >
-            <div>
-              <div
-                className="accordion"
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <label
+              className="title label"
+            >
+              Home email address
+            </label>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
               >
-                <strong
-                  className="aria-description"
+                <span
+                  className="component"
                 >
-                  Summary of email addresses
-                </strong>
-                <div
-                  className="items"
-                />
-                <div
-                  className="append-button"
-                >
-                  <button
-                    className="add usa-button-outline"
-                    onClick={[Function]}
+                  <div
+                    className="email email-home"
                   >
-                    Add another email
-                    <i
-                      className="fa fa-plus-circle"
+                    <input
+                      aria-describedby="HomeEmail-error"
+                      aria-label={null}
+                      autoCapitalize={false}
+                      autoComplete={true}
+                      autoCorrect={false}
+                      className=""
+                      id="HomeEmail-MOCK-GUID"
+                      maxLength={255}
+                      name="HomeEmail"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      pattern={/\\^\\(\\[A-z0-9_\\.-\\]\\+\\)@\\(\\[A-z0-9\\.-\\]\\+\\)\\\\\\.\\+\\(\\[A-z\\.\\]\\{2,63\\}\\)\\$/}
+                      placeholder="Enter an email address"
+                      spellCheck={false}
+                      type="text"
+                      value=""
                     />
-                  </button>
-                </div>
-              </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+          </div>
+          <div
+            aria-label="Work email address"
+            className="field"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <label
+              className="title label"
+            >
+              Work email address
+            </label>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div
+                    className="email email-work"
+                  >
+                    <input
+                      aria-describedby="WorkEmail-error"
+                      aria-label={null}
+                      autoCapitalize={false}
+                      autoComplete={true}
+                      autoCorrect={false}
+                      className=""
+                      id="WorkEmail-MOCK-GUID"
+                      maxLength={255}
+                      name="WorkEmail"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      pattern={/\\^\\(\\[A-z0-9_\\.-\\]\\+\\)@\\(\\[A-z0-9\\.-\\]\\+\\)\\\\\\.\\+\\(\\[A-z\\.\\]\\{2,63\\}\\)\\$/}
+                      placeholder="Enter an email address"
+                      spellCheck={false}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </span>
+              </span>
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
             </div>
           </div>
           <div

--- a/src/components/Section/__snapshots__/Section.test.jsx.snap
+++ b/src/components/Section/__snapshots__/Section.test.jsx.snap
@@ -12779,34 +12779,149 @@ exports[`The section component renders identification.contacts 1`] = `
                       </div>
                     </div>
                     <div
-                      className=" email-collection"
+                      aria-label="Home email address"
+                      className="field"
+                      data-uuid="field-MOCK-GUID"
                     >
-                      <div>
-                        <div
-                          className="accordion"
+                      <a
+                        aria-hidden="true"
+                        className="anchor"
+                        id="field-MOCK-GUID"
+                        name="field-MOCK-GUID"
+                      />
+                      <label
+                        className="title label"
+                      >
+                        Home email address
+                      </label>
+                      <span
+                        className="icon"
+                      />
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages help-messages"
+                        />
+                      </div>
+                      <div
+                        className="table"
+                      >
+                        <span
+                          className="content"
                         >
-                          <strong
-                            className="aria-description"
+                          <span
+                            className="component"
                           >
-                            Summary of email addresses
-                          </strong>
-                          <div
-                            className="items"
-                          />
-                          <div
-                            className="append-button"
-                          >
-                            <button
-                              className="add usa-button-outline"
-                              onClick={[Function]}
+                            <div
+                              className="email email-home"
                             >
-                              Add another email
-                              <i
-                                className="fa fa-plus-circle"
+                              <input
+                                aria-describedby="HomeEmail-error"
+                                aria-label={null}
+                                autoCapitalize={false}
+                                autoComplete={true}
+                                autoCorrect={false}
+                                className=""
+                                id="HomeEmail-MOCK-GUID"
+                                maxLength={255}
+                                name="HomeEmail"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                pattern={/\\^\\(\\[A-z0-9_\\.-\\]\\+\\)@\\(\\[A-z0-9\\.-\\]\\+\\)\\\\\\.\\+\\(\\[A-z\\.\\]\\{2,63\\}\\)\\$/}
+                                placeholder="Enter an email address"
+                                spellCheck={false}
+                                type="text"
+                                value=""
                               />
-                            </button>
-                          </div>
-                        </div>
+                            </div>
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages error-messages"
+                          role="alert"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      aria-label="Work email address"
+                      className="field"
+                      data-uuid="field-MOCK-GUID"
+                    >
+                      <a
+                        aria-hidden="true"
+                        className="anchor"
+                        id="field-MOCK-GUID"
+                        name="field-MOCK-GUID"
+                      />
+                      <label
+                        className="title label"
+                      >
+                        Work email address
+                      </label>
+                      <span
+                        className="icon"
+                      />
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages help-messages"
+                        />
+                      </div>
+                      <div
+                        className="table"
+                      >
+                        <span
+                          className="content"
+                        >
+                          <span
+                            className="component"
+                          >
+                            <div
+                              className="email email-work"
+                            >
+                              <input
+                                aria-describedby="WorkEmail-error"
+                                aria-label={null}
+                                autoCapitalize={false}
+                                autoComplete={true}
+                                autoCorrect={false}
+                                className=""
+                                id="WorkEmail-MOCK-GUID"
+                                maxLength={255}
+                                name="WorkEmail"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                pattern={/\\^\\(\\[A-z0-9_\\.-\\]\\+\\)@\\(\\[A-z0-9\\.-\\]\\+\\)\\\\\\.\\+\\(\\[A-z\\.\\]\\{2,63\\}\\)\\$/}
+                                placeholder="Enter an email address"
+                                spellCheck={false}
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages error-messages"
+                          role="alert"
+                        />
                       </div>
                     </div>
                     <div
@@ -17570,34 +17685,149 @@ exports[`The section component renders identification.review 1`] = `
                       </div>
                     </div>
                     <div
-                      className=" email-collection"
+                      aria-label="Home email address"
+                      className="field"
+                      data-uuid="field-MOCK-GUID"
                     >
-                      <div>
-                        <div
-                          className="accordion"
+                      <a
+                        aria-hidden="true"
+                        className="anchor"
+                        id="field-MOCK-GUID"
+                        name="field-MOCK-GUID"
+                      />
+                      <label
+                        className="title label"
+                      >
+                        Home email address
+                      </label>
+                      <span
+                        className="icon"
+                      />
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages help-messages"
+                        />
+                      </div>
+                      <div
+                        className="table"
+                      >
+                        <span
+                          className="content"
                         >
-                          <strong
-                            className="aria-description"
+                          <span
+                            className="component"
                           >
-                            Summary of email addresses
-                          </strong>
-                          <div
-                            className="items"
-                          />
-                          <div
-                            className="append-button"
-                          >
-                            <button
-                              className="add usa-button-outline"
-                              onClick={[Function]}
+                            <div
+                              className="email email-home"
                             >
-                              Add another email
-                              <i
-                                className="fa fa-plus-circle"
+                              <input
+                                aria-describedby="HomeEmail-error"
+                                aria-label={null}
+                                autoCapitalize={false}
+                                autoComplete={true}
+                                autoCorrect={false}
+                                className=""
+                                id="HomeEmail-MOCK-GUID"
+                                maxLength={255}
+                                name="HomeEmail"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                pattern={/\\^\\(\\[A-z0-9_\\.-\\]\\+\\)@\\(\\[A-z0-9\\.-\\]\\+\\)\\\\\\.\\+\\(\\[A-z\\.\\]\\{2,63\\}\\)\\$/}
+                                placeholder="Enter an email address"
+                                spellCheck={false}
+                                type="text"
+                                value=""
                               />
-                            </button>
-                          </div>
-                        </div>
+                            </div>
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages error-messages"
+                          role="alert"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      aria-label="Work email address"
+                      className="field"
+                      data-uuid="field-MOCK-GUID"
+                    >
+                      <a
+                        aria-hidden="true"
+                        className="anchor"
+                        id="field-MOCK-GUID"
+                        name="field-MOCK-GUID"
+                      />
+                      <label
+                        className="title label"
+                      >
+                        Work email address
+                      </label>
+                      <span
+                        className="icon"
+                      />
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages help-messages"
+                        />
+                      </div>
+                      <div
+                        className="table"
+                      >
+                        <span
+                          className="content"
+                        >
+                          <span
+                            className="component"
+                          >
+                            <div
+                              className="email email-work"
+                            >
+                              <input
+                                aria-describedby="WorkEmail-error"
+                                aria-label={null}
+                                autoCapitalize={false}
+                                autoComplete={true}
+                                autoCorrect={false}
+                                className=""
+                                id="WorkEmail-MOCK-GUID"
+                                maxLength={255}
+                                name="WorkEmail"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                pattern={/\\^\\(\\[A-z0-9_\\.-\\]\\+\\)@\\(\\[A-z0-9\\.-\\]\\+\\)\\\\\\.\\+\\(\\[A-z\\.\\]\\{2,63\\}\\)\\$/}
+                                placeholder="Enter an email address"
+                                spellCheck={false}
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages error-messages"
+                          role="alert"
+                        />
                       </div>
                     </div>
                     <div

--- a/src/config/locales/en/identification.js
+++ b/src/config/locales/en/identification.js
@@ -164,7 +164,7 @@ export const identification = {
       email: {
         title: 'Email addresses are not required',
         message:
-          'More than 2 email addresses are not required but may assist in the completion of your background investigation.',
+          'Email addresses are not required but may assist in the completion of your background investigation.',
         note: 'Email format example: name@example.com'
       },
       phoneNumber: {
@@ -176,9 +176,6 @@ export const identification = {
     },
     collection: {
       summary: {
-        title: 'Summary of email addresses',
-        email: 'Email',
-        unknownEmail: 'Provide your email address below',
         unknownPhone: 'Provide your telephone number below',
         phoneNumber: 'Phone number'
       },
@@ -187,11 +184,12 @@ export const identification = {
           title: 'Summary of phone numbers'
         },
         append: 'Add another phone number'
-      },
-      append: 'Add another email'
+      }
     },
     heading: {
       email: 'Your email addresses',
+      emailHome: 'Home email address',
+      emailWork: 'Work email address',
       phoneNumber: 'Your phone numbers',
       comments: 'Add optional comments'
     },

--- a/src/schema/section/identification-contacts.js
+++ b/src/schema/section/identification-contacts.js
@@ -10,8 +10,8 @@ export const identificationContacts = (data = {}) => {
     }
   })
   return {
-    HomeEmail: form.text(data.HomeEmail),
-    WorkEmail: form.text(data.WorkEmail),
+    HomeEmail: form.email(data.HomeEmail),
+    WorkEmail: form.email(data.WorkEmail),
     PhoneNumbers: form.collection(phoneNumbers)
   }
 }

--- a/src/schema/section/identification-contacts.js
+++ b/src/schema/section/identification-contacts.js
@@ -1,14 +1,6 @@
 import * as form from '../form'
 
 export const identificationContacts = (data = {}) => {
-  const emails = ((data.Emails || {}).items || []).map(x => {
-    const xitem = x.Item || {}
-    return {
-      Item: {
-        Email: form.email(xitem.Email)
-      }
-    }
-  })
   const phoneNumbers = ((data.PhoneNumbers || {}).items || []).map(x => {
     const xitem = x.Item || {}
     return {
@@ -18,7 +10,8 @@ export const identificationContacts = (data = {}) => {
     }
   })
   return {
-    Emails: form.collection(emails),
+    HomeEmail: form.text(data.HomeEmail),
+    WorkEmail: form.text(data.WorkEmail),
     PhoneNumbers: form.collection(phoneNumbers)
   }
 }

--- a/src/schema/section/identification-contacts.test.js
+++ b/src/schema/section/identification-contacts.test.js
@@ -4,16 +4,8 @@ import { identificationContacts } from './identification-contacts'
 describe('Schema for financial taxes', () => {
   it('can wrap in schema', () => {
     const data = {
-      Emails: {
-        branch: null,
-        items: [
-          {
-            Item: {
-              Email: {}
-            }
-          }
-        ]
-      },
+      HomeEmail: {},
+      WorkEmail: {},
       PhoneNumbers: {
         branch: null,
         items: [

--- a/src/validators/identificationcontacts.js
+++ b/src/validators/identificationcontacts.js
@@ -2,7 +2,8 @@ import { validGenericTextfield, validPhoneNumber } from './helpers'
 
 export default class IdentificationContactInformationValidator {
   constructor(data = {}) {
-    this.emails = (data.Emails || { items: [] }).items
+    this.homeEmail = data.HomeEmail
+    this.workEmail = data.WorkEmail
     this.phoneNumbers = (data.PhoneNumbers || { items: [] }).items
   }
 
@@ -10,20 +11,12 @@ export default class IdentificationContactInformationValidator {
    * Validates a collection of emails
    */
   validEmails() {
-    const required = 0
-    if (!this.emails || this.emails.length < required) {
-      return false
-    }
-
-    let successful = 0
-    for (const email of this.emails) {
-      if (!new ContactEmailValidator(email.Item).isValid()) {
-        continue
-      }
-      successful++
-    }
-
-    return successful >= required
+    console.log(this.homeEmail)
+    console.log(this.workEmail)
+    return (
+      validGenericTextfield(this.homeEmail) &&
+      validGenericTextfield(this.workEmail)
+    )
   }
 
   /**
@@ -63,19 +56,10 @@ export default class IdentificationContactInformationValidator {
    * Validates emails and phone numbers
    */
   isValid() {
+    console.log(this.validEmails())
     return (
       this.validEmails() && this.validPhoneNumbers() && this.validPhoneTypes()
     )
-  }
-}
-
-export class ContactEmailValidator {
-  constructor(data = {}) {
-    this.email = data.Email
-  }
-
-  isValid() {
-    return validGenericTextfield(this.email)
   }
 }
 

--- a/src/validators/identificationcontacts.js
+++ b/src/validators/identificationcontacts.js
@@ -8,18 +8,6 @@ export default class IdentificationContactInformationValidator {
   }
 
   /**
-   * Validates a collection of emails
-   */
-  validEmails() {
-    console.log(this.homeEmail)
-    console.log(this.workEmail)
-    return (
-      validGenericTextfield(this.homeEmail) &&
-      validGenericTextfield(this.workEmail)
-    )
-  }
-
-  /**
    * Validates a collection of phone numbers
    */
   validPhoneNumbers() {
@@ -56,10 +44,7 @@ export default class IdentificationContactInformationValidator {
    * Validates emails and phone numbers
    */
   isValid() {
-    console.log(this.validEmails())
-    return (
-      this.validEmails() && this.validPhoneNumbers() && this.validPhoneTypes()
-    )
+    return this.validPhoneNumbers() && this.validPhoneTypes()
   }
 }
 

--- a/src/validators/identificationcontacts.test.js
+++ b/src/validators/identificationcontacts.test.js
@@ -1,47 +1,6 @@
 import IdentificationContactInformationValidator from './identificationcontacts'
 
 describe('Contact Information validation', function() {
-  it('should validate emails', function() {
-    const tests = [
-      {
-        state: {
-          HomeEmail: {},
-          WorkEmail: {}
-        },
-        expected: true
-      },
-      {
-        state: {
-          HomeEmail: {
-            value: 'foobar2@local.dev'
-          },
-          WorkEmail: {
-            value: 'foobar2@local.dev'
-          }
-        },
-        expected: true
-      },
-      {
-        state: {
-          HomeEmail: {},
-          WorkEmail: {
-            value: 'foobar2@local.dev'
-          }
-        },
-        expected: true
-      }
-    ]
-
-    tests.forEach(test => {
-      expect(
-        new IdentificationContactInformationValidator(
-          test.state,
-          null
-        ).validEmails()
-      ).toBe(test.expected)
-    })
-  })
-
   it('should validate phone numbers', function() {
     const tests = [
       {

--- a/src/validators/identificationcontacts.test.js
+++ b/src/validators/identificationcontacts.test.js
@@ -5,41 +5,27 @@ describe('Contact Information validation', function() {
     const tests = [
       {
         state: {
-          Emails: { items: [] }
+          HomeEmail: {},
+          WorkEmail: {}
         },
         expected: true
       },
       {
         state: {
-          Emails: {
-            items: [
-              {
-                Item: {
-                  Email: {
-                    value: 'foobar@local.dev'
-                  }
-                }
-              }
-            ]
+          HomeEmail: {
+            value: 'foobar2@local.dev'
+          },
+          WorkEmail: {
+            value: 'foobar2@local.dev'
           }
         },
         expected: true
       },
       {
         state: {
-          Emails: {
-            items: [
-              {
-                Item: {}
-              },
-              {
-                Item: {
-                  Email: {
-                    value: 'foobar@local.dev'
-                  }
-                }
-              }
-            ]
+          HomeEmail: {},
+          WorkEmail: {
+            value: 'foobar2@local.dev'
           }
         },
         expected: true
@@ -158,23 +144,11 @@ describe('Contact Information validation', function() {
     const tests = [
       {
         state: {
-          Emails: {
-            items: [
-              {
-                Item: {
-                  Email: {
-                    value: 'foobar2@local.dev'
-                  }
-                }
-              },
-              {
-                Item: {
-                  Email: {
-                    value: 'foobar2@local.dev'
-                  }
-                }
-              }
-            ]
+          HomeEmail: {
+            value: 'foobar2@local.dev'
+          },
+          WorkEmail: {
+            value: 'foobar2@local.dev'
           },
           PhoneNumbers: {
             items: [

--- a/src/validators/index.js
+++ b/src/validators/index.js
@@ -4,7 +4,6 @@ import DateRangeValidator from './daterange'
 import BankruptcyValidator, { BankruptcyItemValidator } from './bankruptcy'
 import BirthPlaceValidator from './birthplace'
 import IdentificationContactInformationValidator, {
-  ContactEmailValidator,
   ContactPhoneNumberValidator
 } from './identificationcontacts'
 import IdentificationValidator from './identification'
@@ -224,7 +223,6 @@ export {
   BankruptcyItemValidator,
   BirthPlaceValidator,
   IdentificationContactInformationValidator,
-  ContactEmailValidator,
   ContactPhoneNumberValidator,
   IdentificationValidator,
   NameValidator,


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/781

Currently we allow for an applicant to add an infinite number of personal email addresses even though the form only allows for a home and work email address. This refactors the email address section into a two separate fields instead of the accordion based pattern.

**Before:**
![screen shot 2018-09-14 at 4 35 01 pm](https://user-images.githubusercontent.com/1178494/45573897-09659180-b83c-11e8-96b7-ec1a38cca891.png)

**After:**
![screen shot 2018-09-14 at 4 30 01 pm](https://user-images.githubusercontent.com/1178494/45573763-a247dd00-b83b-11e8-8156-1e3768376e4a.png)

_*Sorry for the unrelated formatting changes in the json files, it looks like I previously missed those when I ran `prettier` on the code base._
