### PR TITLE
Do not ask for full address for former spouse marriage location

### DIFF
--- a/src/components/Section/Relationships/RelationshipStatus/Divorce.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Divorce.jsx
@@ -223,8 +223,8 @@ export default class Divorce extends React.Component {
             name="address"
             className="location"
             {...this.props.Address}
-            layout={Location.ADDRESS}
-            geocode={true}
+            layout={Location.BIRTHPLACE_WITHOUT_COUNTY}
+            label={i18n.t('relationships.civilUnion.label.location')}
             onUpdate={this.updateAddress}
             onError={this.props.onError}
             required={this.props.required}


### PR DESCRIPTION
Fixes #763 

Currently, the full address is collected for former spouses ('Annulled', 'Divorced', 'Widowed'), however only City and State are required.

**Before**:
<img width="606" alt="screen shot 2018-09-17 at 1 30 42 pm" src="https://user-images.githubusercontent.com/1178494/45639488-27223900-ba7e-11e8-8b4c-174cc2c1903f.png">

**After**:
<img width="656" alt="screen shot 2018-09-17 at 1 29 00 pm" src="https://user-images.githubusercontent.com/1178494/45639477-1b367700-ba7e-11e8-85f5-30d18109105c.png">
