### PR TITLE
Always show explanation field for dual citizenship

### DIFF
--- a/src/components/Section/Citizenship/Multiple/CitizenshipItem.jsx
+++ b/src/components/Section/Citizenship/Multiple/CitizenshipItem.jsx
@@ -80,11 +80,6 @@ export default class CitizenshipItem extends ValidationElement {
   }
 
   render() {
-    const d = this.props.Dates || {}
-    const to = d.to || {}
-    const from = d.from || {}
-    const showCurrentQuestion = to.date && from.date && !d.present
-
     return (
       <div className="citizenship-item">
         <Field
@@ -163,37 +158,33 @@ export default class CitizenshipItem extends ValidationElement {
           />
         </Field>
 
-        <Show when={showCurrentQuestion}>
-          <div>
-            <Branch
-              name="Current"
-              label={i18n.t('citizenship.multiple.heading.citizenship.current')}
-              labelSize="h3"
-              className="citizenship-current no-margin-bottom"
-              {...this.props.Current}
-              onUpdate={this.updateCurrent}
-              onError={this.props.onError}
-              required={this.props.required}
-              scrollIntoView={this.props.scrollIntoView}
-            />
+        <Branch
+          name="Current"
+          label={i18n.t('citizenship.multiple.heading.citizenship.current')}
+          labelSize="h3"
+          className="citizenship-current no-margin-bottom"
+          {...this.props.Current}
+          onUpdate={this.updateCurrent}
+          onError={this.props.onError}
+          required={this.props.required}
+          scrollIntoView={this.props.scrollIntoView}
+        />
 
-            <Field
-              title={i18n.t(
-                'citizenship.multiple.heading.citizenship.currentexplanation'
-              )}
-              titleSize="label"
-              scrollIntoView={this.props.scrollIntoView}>
-              <Textarea
-                name="CurrentExplanation"
-                {...this.props.CurrentExplanation}
-                className="citizenship-current-explanation"
-                onUpdate={this.updateCurrentExplanation}
-                onError={this.props.onError}
-                required={this.props.required}
-              />
-            </Field>
-          </div>
-        </Show>
+        <Field
+          title={i18n.t(
+            'citizenship.multiple.heading.citizenship.currentexplanation'
+          )}
+          titleSize="label"
+          scrollIntoView={this.props.scrollIntoView}>
+          <Textarea
+            name="CurrentExplanation"
+            {...this.props.CurrentExplanation}
+            className="citizenship-current-explanation"
+            onUpdate={this.updateCurrentExplanation}
+            onError={this.props.onError}
+            required={this.props.required}
+          />
+        </Field>
       </div>
     )
   }

--- a/src/components/Section/Citizenship/Multiple/CitizenshipItem.test.jsx
+++ b/src/components/Section/Citizenship/Multiple/CitizenshipItem.test.jsx
@@ -3,34 +3,6 @@ import { mount } from 'enzyme'
 import CitizenshipItem from './CitizenshipItem'
 
 describe('The citizenship item component', () => {
-  it('display display question for current citizenship if NOT present', () => {
-    const props = {
-      Dates: {
-        from: {},
-        to: {},
-        present: true
-      }
-    }
-    const component = mount(<CitizenshipItem {...props} />)
-    expect(component.find('.citizenship-current').length).toBe(0)
-  })
-
-  it('display display question for current citizenship if NOT present', () => {
-    const props = {
-      Dates: {
-        from: {
-          date: new Date('1/1/2009')
-        },
-        to: {
-          date: new Date('1/1/2010')
-        },
-        present: false
-      }
-    }
-    const component = mount(<CitizenshipItem {...props} />)
-    expect(component.find('.citizenship-current').length).toBe(1)
-  })
-
   it('can trigger updates', () => {
     let updates = 0
     const expected = {


### PR DESCRIPTION
Fixes #799 

This ensures that dual citizenship questions are displayed in all scenarios. Previously the `Do you currently hold citizenship with this country?` and `Provide explanation` fields were being suppressed if the date range associated with the country was set to `Present`. 