### PR TITLE
Fix former spouse encoding

### DIFF
--- a/api/templates/spouse-former.xml
+++ b/api/templates/spouse-former.xml
@@ -49,7 +49,7 @@
       <DivorceRecordLocation>
         <!-- XXX Placeholder text as work-around for https://github.com/18F/e-QIP-prototype/issues/808 -->
         <Place>
-          <City>Unknown</City><State>CA</State>
+          <City>Unknown</City><State>CA</State><ZipCode>93940</ZipCode>
         </Place>
       </DivorceRecordLocation>
       {{end}}
@@ -63,9 +63,7 @@
   {{end}}
   {{end}}
 
-  {{if branch .props.branch | eq "Yes"}}
   <HaveAdditionalEntryAnswer>{{branch .props.branch}}</HaveAdditionalEntryAnswer>
   <SummaryComment></SummaryComment>
   <Comment></Comment>
-  {{end}}
 </FormerSpouses>

--- a/api/testdata/complete-scenarios/test5.xml
+++ b/api/testdata/complete-scenarios/test5.xml
@@ -689,7 +689,6 @@
                   <Deceased>
                     <Answer>IDontKnow</Answer>
                   </Deceased>
-                  <DivorcedAnnulledComment2/>
                   <LegalName>
                     <Last>Xan</Last>
                     <First>Eileen</First>
@@ -716,11 +715,13 @@
                       <Place>
                         <City>Unknown</City>
                         <State>CA</State>
+                        <ZipCode>93940</ZipCode>
                       </Place>
                     </DivorceRecordLocation>
                   </Separation>
                   <Telephone DoNotKnow="True"/>
                 </FormerSpouse>
+                <HaveAdditionalEntryAnswer>No</HaveAdditionalEntryAnswer>
               </FormerSpouses>
               <HaveFormerSpouse>
                 <Answer>Yes</Answer>
@@ -1407,18 +1408,16 @@
                         <Month>04</Month>
                         <Year>2009</Year>
                       </Date>
-                      <Reason>Because 9</Reason>
+                      <Reason>Reason 9 for quitting</Reason>
                       <SeveranceType>QuitKnowingWouldBeFired</SeveranceType>
-                      <SeveranceTypeComment>Reason 9 for quitting</SeveranceTypeComment>
                     </Dismissal>
                     <Dismissal ID="2">
                       <Date>
                         <Month>06</Month>
                         <Year>2009</Year>
                       </Date>
-                      <Reason>Because 9</Reason>
+                      <Reason>Reason 9 for Misconduct</Reason>
                       <SeveranceType>AllegedMisconduct</SeveranceType>
-                      <SeveranceTypeComment>Reason 9 for Misconduct</SeveranceTypeComment>
                     </Dismissal>
                     <HaveAdditionalEntryAnswer>No</HaveAdditionalEntryAnswer>
                   </Dismissals>
@@ -4690,7 +4689,7 @@
                       <Charge ID="1">
                         <Charge>Break and Enter</Charge>
                         <Date>
-                          <Month>01</Month>
+                          <Month>02</Month>
                           <Year>2000</Year>
                         </Date>
                         <Outcome>Not Guilty</Outcome>

--- a/api/testdata/complete-scenarios/test5.xml
+++ b/api/testdata/complete-scenarios/test5.xml
@@ -1408,16 +1408,18 @@
                         <Month>04</Month>
                         <Year>2009</Year>
                       </Date>
-                      <Reason>Reason 9 for quitting</Reason>
+                      <Reason>Because 9</Reason>
                       <SeveranceType>QuitKnowingWouldBeFired</SeveranceType>
+                      <SeveranceTypeComment>Reason 9 for quitting</SeveranceTypeComment>
                     </Dismissal>
                     <Dismissal ID="2">
                       <Date>
                         <Month>06</Month>
                         <Year>2009</Year>
                       </Date>
-                      <Reason>Reason 9 for Misconduct</Reason>
+                      <Reason>Because 9</Reason>
                       <SeveranceType>AllegedMisconduct</SeveranceType>
+                      <SeveranceTypeComment>Reason 9 for Misconduct</SeveranceTypeComment>
                     </Dismissal>
                     <HaveAdditionalEntryAnswer>No</HaveAdditionalEntryAnswer>
                   </Dismissals>
@@ -4689,7 +4691,7 @@
                       <Charge ID="1">
                         <Charge>Break and Enter</Charge>
                         <Date>
-                          <Month>02</Month>
+                          <Month>01</Month>
                           <Year>2000</Year>
                         </Date>
                         <Outcome>Not Guilty</Outcome>

--- a/api/xml/xml.go
+++ b/api/xml/xml.go
@@ -105,7 +105,7 @@ func (service Service) DefaultTemplate(templateName string, data map[string]inte
 // https://github.com/18F/e-QIP-prototype/issues/717
 func applyBulkFixes(xml string) string {
 	replaceWithEmpty := []string{
-		"<[a-zA-Z_]+></[a-zA-Z_]+>", // empty elements
+		"<[a-zA-Z_0-9]+></[a-zA-Z_0-9]+>", // empty elements
 		" DoNotKnow=\"False\"",
 		" DoNotKnow=\"\"",
 		" Type=\"\"",


### PR DESCRIPTION
Looks like during last round of XML fixes I validated against XSDs but did not do a trial submission to e-QIP:

* Add zip code to placeholder city/state
* remove DivorcedAnnulledComment2 in bulk processing if empty (always the case right now)
* fix logic around "have additional entries" answer