### PR TITLE
Require divorce location

### DIFF
--- a/api/templates/spouse-former.xml
+++ b/api/templates/spouse-former.xml
@@ -49,7 +49,7 @@
       <DivorceRecordLocation>
         <!-- XXX Placeholder text as work-around for https://github.com/18F/e-QIP-prototype/issues/808 -->
         <Place>
-          <City>Unknown</City><State>CA</State><ZipCode>93940</ZipCode>
+          {{locationOverrideLayout $Item.DivorceLocation "US City, State, Zipcode International city"}}
         </Place>
       </DivorceRecordLocation>
       {{end}}

--- a/api/testdata/complete-scenarios/test3.json
+++ b/api/testdata/complete-scenarios/test3.json
@@ -7548,6 +7548,12 @@
                       "estimated": false
                     }
                   },
+                  "DivorceLocation": {
+                    "type": "location",
+                    "props": {
+                      "layout": ""
+                    }
+                  },
                   "Deceased": {
                     "type": "radio",
                     "props": {

--- a/api/testdata/complete-scenarios/test5.json
+++ b/api/testdata/complete-scenarios/test5.json
@@ -16639,6 +16639,16 @@
                       "estimated": false
                     }
                   },
+                  "DivorceLocation": {
+                    "type": "location",
+                    "props": {
+                      "layout": "US City, State, International city",
+                      "city": "Monterey",
+                      "state": "CA",
+                      "zipcode": "93940",
+                      "country": "United States"
+                    }
+                  },
                   "Deceased": {
                     "type": "radio",
                     "props": {

--- a/api/testdata/complete-scenarios/test5.xml
+++ b/api/testdata/complete-scenarios/test5.xml
@@ -713,7 +713,7 @@
                     </Date>
                     <DivorceRecordLocation>
                       <Place>
-                        <City>Unknown</City>
+                        <City>Monterey</City>
                         <State>CA</State>
                         <ZipCode>93940</ZipCode>
                       </Place>

--- a/api/testdata/relationships-status-marital.json
+++ b/api/testdata/relationships-status-marital.json
@@ -383,6 +383,20 @@
                   "date": "2017-07-25T00:00:00Z"
                 }
               },
+              "DivorceLocation": {
+                "type": "location",
+                "props": {
+                  "layout": "US City, State, International city",
+                  "street": "",
+                  "street2": "",
+                  "city": "Arlington",
+                  "state": "VA",
+                  "zipcode": "22202",
+                  "county": "",
+                  "country": "United States",
+                  "validated": false
+                }
+              },
               "Status": {
                 "type": "radio",
                 "props": {

--- a/api/testdata/spouse-former.json
+++ b/api/testdata/spouse-former.json
@@ -88,6 +88,16 @@
               "date": "2017-07-25T00:00:00Z"
             }
           },
+          "DivorceLocation": {
+            "type": "location",
+            "props": {
+              "layout": "US City, State, International city",
+              "city": "Arlington",
+              "state": "VA",
+              "zipcode": "22202",
+              "country": "United States"
+            }
+          },
           "Status": {
             "type": "radio",
             "props": {

--- a/api/testdata/spouse-have-former.json
+++ b/api/testdata/spouse-have-former.json
@@ -87,6 +87,17 @@
               "date": "2017-07-25T00:00:00Z"
             }
           },
+          "DivorceLocation": {
+            "type": "location",
+            "props": {
+              "layout": "US City, State, International city",
+              "city": "Arlington",
+              "state": "VA",
+              "zipcode": "22202",
+              "country": "United States",
+              "validated": false
+            }
+          },
           "Status": {
             "type": "radio",
             "props": {

--- a/api/testdata/spouse-have-former.json
+++ b/api/testdata/spouse-have-former.json
@@ -91,9 +91,12 @@
             "type": "location",
             "props": {
               "layout": "US City, State, International city",
+              "street": "",
+              "street2": "",
               "city": "Arlington",
               "state": "VA",
               "zipcode": "22202",
+              "county": "",
               "country": "United States",
               "validated": false
             }

--- a/src/components/Form/Location/ToggleableLocation.jsx
+++ b/src/components/Form/Location/ToggleableLocation.jsx
@@ -114,14 +114,7 @@ export default class ToggleableLocation extends ValidationElement {
   zipcodeInstate() {
     const validator = new LocationValidator(this.props)
 
-    if (
-      validator.isDomestic() &&
-      validator.layout === Layouts.US_CITY_STATE_ZIP_INTERNATIONAL_CITY
-    ) {
-      if (validator.validFields(['city', 'state', 'zipcode'])) {
-        return validator.validZipcodeState()
-      }
-    }
+    return validator.validZipcodeState()
   }
 
   render() {

--- a/src/components/Form/Location/ToggleableLocation.jsx
+++ b/src/components/Form/Location/ToggleableLocation.jsx
@@ -11,7 +11,8 @@ import Show from '../Show'
 import Radio from '../Radio'
 import RadioGroup from '../RadioGroup'
 import { country, countryValueResolver } from './Location'
-import { countryString } from '../../../validators/location'
+import LocationValidator, { countryString } from '../../../validators/location'
+import Layouts from './Layouts'
 
 const mappingWarning = property => {
   if (!env.IsTest()) {
@@ -32,6 +33,7 @@ export default class ToggleableLocation extends ValidationElement {
     this.updateCountry = this.updateCountry.bind(this)
     this.updateToggle = this.updateToggle.bind(this)
     this.updateZipcode = this.updateZipcode.bind(this)
+    this.zipcodeInstate = this.zipcodeInstate.bind(this)
     this.onError = this.onError.bind(this)
 
     this.state = {
@@ -109,7 +111,21 @@ export default class ToggleableLocation extends ValidationElement {
     }
   }
 
+  zipcodeInstate() {
+    const validator = new LocationValidator(this.props)
+
+    if (
+      validator.isDomestic() &&
+      validator.layout === Layouts.US_CITY_STATE_ZIP_INTERNATIONAL_CITY
+    ) {
+      if (validator.validFields(['city', 'state', 'zipcode'])) {
+        return validator.validZipcodeState()
+      }
+    }
+  }
+
   render() {
+    const instateZipcode = this.zipcodeInstate()
     const domesticFields = this.props.domesticFields.map(field => {
       const key = `domestic-${field}`
       switch (field) {
@@ -201,6 +217,7 @@ export default class ToggleableLocation extends ValidationElement {
                 label={this.props.zipcodeLabel}
                 placeholder={this.props.zipcodePlaceholder}
                 value={this.props.zipcode}
+                status={instateZipcode}
                 onUpdate={this.updateZipcode}
                 onError={this.onError}
                 onFocus={this.props.onFocus}

--- a/src/components/Section/Relationships/RelationshipStatus/Divorce.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Divorce.jsx
@@ -25,6 +25,7 @@ export default class Divorce extends React.Component {
     this.updateRecognized = this.updateRecognized.bind(this)
     this.updateAddress = this.updateAddress.bind(this)
     this.updateDateDivorced = this.updateDateDivorced.bind(this)
+    this.updateDivorceLocation = this.updateDivorceLocation.bind(this)
     this.updateStatus = this.updateStatus.bind(this)
     this.updateDeceased = this.updateDeceased.bind(this)
     this.updateDeceasedAddress = this.updateDeceasedAddress.bind(this)
@@ -43,6 +44,7 @@ export default class Divorce extends React.Component {
       Recognized: this.props.Recognized,
       Address: this.props.Address,
       DateDivorced: this.props.DateDivorced,
+      DivorceLocation: this.props.DivorceLocation,
       Status: this.props.Status,
       Deceased: this.props.Deceased,
       DeceasedAddress: this.props.DeceasedAddress,
@@ -95,6 +97,12 @@ export default class Divorce extends React.Component {
   updateDateDivorced(values) {
     this.update({
       DateDivorced: values
+    })
+  }
+
+  updateDivorceLocation(values) {
+    this.update({
+      DivorceLocation: values
     })
   }
 
@@ -287,6 +295,25 @@ export default class Divorce extends React.Component {
             (this.props.Status || {}).value
           )}>
           <div>
+            <Field
+              title={i18n.t(
+                'relationships.civilUnion.divorce.heading.divorceLocation'
+              )}
+              optional={true}
+              scrollIntoView={this.props.scrollIntoView}
+              adjustFor="labels">
+              <Location
+                name="divorce-location"
+                className="location"
+                {...this.props.DivorceLocation}
+                layout={Location.US_CITY_STATE_ZIP_INTERNATIONAL_CITY}
+                label={i18n.t('relationships.civilUnion.label.location')}
+                onUpdate={this.updateDivorceLocation}
+                onError={this.props.onError}
+                required={this.props.required}
+              />
+            </Field>
+
             <Field
               title={i18n.t(
                 'relationships.civilUnion.divorce.heading.deceased'

--- a/src/components/Section/Relationships/RelationshipStatus/Divorce.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Divorce.jsx
@@ -303,8 +303,7 @@ export default class Divorce extends React.Component {
               scrollIntoView={this.props.scrollIntoView}
               adjustFor="labels">
               <Location
-                name="divorce-location"
-                className="location"
+                className="divorce-location"
                 {...this.props.DivorceLocation}
                 layout={Location.US_CITY_STATE_ZIP_INTERNATIONAL_CITY}
                 label={i18n.t('relationships.civilUnion.label.location')}

--- a/src/components/Section/Relationships/RelationshipStatus/Divorce.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Divorce.test.jsx
@@ -18,6 +18,7 @@ describe('The Divorce component', () => {
       name: 'cohabitant',
       Status: { value: 'Divorced' },
       BirthPlace: { country: { value: 'United States' } },
+      DivorceLocation: { country: { value: 'United States' } },
       Deceased: { value: 'No' },
       onUpdate: () => {
         updates++
@@ -43,8 +44,8 @@ describe('The Divorce component', () => {
     component
       .find('.date-divorced .month input')
       .simulate('change', { target: { value: '12' } })
-    component.find('.divorce-location .city input').simulate('change')
     component.find('.status .divorced input').simulate('change')
+    component.find('.divorce-location .city input').simulate('change')
     component.find('.deceased .widowed input').simulate('change')
     component.find('.address-deceased .city input').simulate('change')
     component.find('.deceased-notapplicable .button input').simulate('change')

--- a/src/components/Section/Relationships/RelationshipStatus/Divorce.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Divorce.test.jsx
@@ -43,10 +43,11 @@ describe('The Divorce component', () => {
     component
       .find('.date-divorced .month input')
       .simulate('change', { target: { value: '12' } })
+    component.find('.divorce-location .city input').simulate('change')
     component.find('.status .divorced input').simulate('change')
     component.find('.deceased .widowed input').simulate('change')
     component.find('.address-deceased .city input').simulate('change')
     component.find('.deceased-notapplicable .button input').simulate('change')
-    expect(updates).toBe(11)
+    expect(updates).toBe(12)
   })
 })

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -639,6 +639,12 @@ export const error = {
           title: 'There is a problem with the ZIP Code',
           message: 'The ZIP Code should be either 5 or 9 digits.',
           note: ''
+        },
+        status: {
+          title: 'There is a problem with the ZIP Code',
+          message: 'The ZIP Code must be from the state in the address.',
+          note:
+            'Note: Please make sure you also entered the correct state code.'
         }
       },
       country: {
@@ -702,7 +708,8 @@ export const error = {
         status: {
           title: 'There is a problem with the ZIP Code',
           message: 'The ZIP Code must be from the state in the address.',
-          note: 'Note: Please make sure you also entered the correct state code.'
+          note:
+            'Note: Please make sure you also entered the correct state code.'
         }
       },
       country: {

--- a/src/config/locales/en/relationships.js
+++ b/src/config/locales/en/relationships.js
@@ -403,6 +403,8 @@ export const relationships = {
         birthplace: "Provide this person's place of birth",
         dateDivorced:
           'Provide the date divorced/dissolved, annulled or widowed',
+        divorceLocation:
+          'Provide where the record of divorce/dissolution or annulment is located',
         recognized:
           'Provide the date your civil marriage, civil union, or domestic partnership was legally recognized',
         deceased: 'Is this person deceased?',

--- a/src/schema/section/relationships-marital.js
+++ b/src/schema/section/relationships-marital.js
@@ -13,6 +13,7 @@ export const relationshipsMarital = (data = {}) => {
         Recognized: form.datecontrol(xitem.Recognized),
         Address: form.location(xitem.Address),
         DateDivorced: form.datecontrol(xitem.DateDivorced),
+        DivorceLocation: form.location(xitem.DivorceLocation),
         Status: form.radio(xitem.Status),
         Deceased: form.radio(xitem.Deceased),
         DeceasedAddress: form.location(xitem.DeceasedAddress),

--- a/src/schema/section/relationships-marital.test.js
+++ b/src/schema/section/relationships-marital.test.js
@@ -72,6 +72,9 @@ describe('Schema for financial taxes', () => {
                 country: null
               },
               DateDivorced: {},
+              DivorceLocation: {
+                country: null
+              },
               Status: {},
               Deceased: {},
               DeceasedAddress: {

--- a/src/validators/divorce.js
+++ b/src/validators/divorce.js
@@ -12,7 +12,7 @@ export default class DivorceValidator {
     this.recognized = data.Recognized || {}
     this.address = data.Address || {}
     this.dateDivorced = data.DateDivorced || {}
-    this.divorceLocation = data.DateDivorced || {}
+    this.divorceLocation = data.DivorceLocation || {}
     this.status = data.Status || {}
     this.deceased = data.Deceased || {}
     this.deceasedAddress = data.DeceasedAddress || {}

--- a/src/validators/divorce.js
+++ b/src/validators/divorce.js
@@ -12,6 +12,7 @@ export default class DivorceValidator {
     this.recognized = data.Recognized || {}
     this.address = data.Address || {}
     this.dateDivorced = data.DateDivorced || {}
+    this.divorceLocation = data.DateDivorced || {}
     this.status = data.Status || {}
     this.deceased = data.Deceased || {}
     this.deceasedAddress = data.DeceasedAddress || {}
@@ -20,6 +21,15 @@ export default class DivorceValidator {
   validStatus() {
     const statusValue = this.status.value || ''
     return ['Divorced', 'Widowed', 'Annulled'].includes(statusValue)
+  }
+
+  validDivorceLocation() {
+    const statusValue = this.status.value || ''
+    if (statusValue === 'Widowed') {
+      return true
+    }
+
+    return new LocationValidator(this.divorceLocation).isValid()
   }
 
   validDeceased() {
@@ -54,6 +64,7 @@ export default class DivorceValidator {
       validDateField(this.recognized) &&
       new LocationValidator(this.address).isValid() &&
       validDateField(this.dateDivorced) &&
+      this.validDivorceLocation() &&
       this.validStatus() &&
       this.validDeceased()
     )

--- a/src/validators/divorce.test.js
+++ b/src/validators/divorce.test.js
@@ -77,6 +77,26 @@ describe('Divorce validation', function() {
           DivorceLocation: {}
         },
         expected: true
+      },
+      {
+        state: {
+          Status: { value: 'Divorced' },
+          DivorceLocation: {}
+        },
+        expected: false
+      },
+      {
+        state: {
+          Status: { value: 'Divorced' },
+          DivorceLocation: {
+            country: { value: 'United States' },
+            city: 'Arlington',
+            state: 'VA',
+            zipcode: '22202',
+            layout: Location.US_CITY_STATE_ZIP_INTERNATIONAL_CITY
+          }
+        },
+        expected: true
       }
     ]
     tests.forEach(test => {

--- a/src/validators/divorce.test.js
+++ b/src/validators/divorce.test.js
@@ -69,6 +69,23 @@ describe('Divorce validation', function() {
     })
   })
 
+  it('validates divorce location', () => {
+    const tests = [
+      {
+        state: {
+          Status: { value: 'Widowed' },
+          DivorceLocation: {}
+        },
+        expected: true
+      }
+    ]
+    tests.forEach(test => {
+      expect(
+        new DivorceValidator(test.state, null).validDivorceLocation()
+      ).toBe(test.expected)
+    })
+  })
+
   it('validates divorced', () => {
     const tests = [
       {


### PR DESCRIPTION
Fixes #808 

This field was previously missing. It is now shown when a relationship is marked as `Divorced` or `Annulled`. Also updated `ToggleableLocation` component to incorporate zip code validation changes.

**After:**
<img width="664" alt="screen shot 2018-09-20 at 12 11 00 pm" src="https://user-images.githubusercontent.com/1178494/45831784-3d263880-bcce-11e8-96b5-a6a1789e440d.png">
