### PR TITLE
Remove passport card option

### DIFF
--- a/src/components/Section/Foreign/Passport/Passport.jsx
+++ b/src/components/Section/Foreign/Passport/Passport.jsx
@@ -296,7 +296,7 @@ Passport.defaultProps = {
   Comments: {},
   HasPassports: {},
   suggestedNames: [],
-  reBook: '^[a-zA-Z0-9]{6,9}$',
+  reBook: '^[a-zA-Z0-9]{9}$',
   onUpdate: queue => {},
   onError: (value, arr) => {
     return arr

--- a/src/components/Section/Foreign/Passport/Passport.jsx
+++ b/src/components/Section/Foreign/Passport/Passport.jsx
@@ -219,7 +219,7 @@ export default class Passport extends SubsectionElement {
                     `foreign.passport.placeholder.bookNumber`
                   )}
                   pattern={this.props.reBook}
-                  maxlength="10"
+                  maxlength="9"
                   className="number passport-number"
                   ref="number"
                   prefix="passport"
@@ -282,7 +282,7 @@ Passport.defaultProps = {
   Comments: {},
   HasPassports: {},
   suggestedNames: [],
-  reBook: '^[a-zA-Z]{1}[0-9]{6,9}$',
+  reBook: '^[a-zA-Z0-9]{6,9}$',
   onUpdate: queue => {},
   onError: (value, arr) => {
     return arr

--- a/src/components/Section/Foreign/Passport/Passport.jsx
+++ b/src/components/Section/Foreign/Passport/Passport.jsx
@@ -265,9 +265,6 @@ export default class Passport extends SubsectionElement {
                   label={i18n.t(
                     `foreign.passport.label.bookNumber`
                   )}
-                  placeholder={i18n.t(
-                    `foreign.passport.placeholder.bookNumber`
-                  )}
                   pattern={numberRegEx}
                   maxlength={numberLength}
                   className="number passport-number"

--- a/src/components/Section/Foreign/Passport/Passport.jsx
+++ b/src/components/Section/Foreign/Passport/Passport.jsx
@@ -139,7 +139,7 @@ export default class Passport extends SubsectionElement {
       const cutoffDate = new Date('1/1/1990 00:00')
       const issueDate = extractDate(this.props.Issued)
 
-      if (issueDate < cutoffDate) {
+      if (issueDate && issueDate < cutoffDate) {
         return true
       }
     }

--- a/src/components/Section/Foreign/Passport/Passport.jsx
+++ b/src/components/Section/Foreign/Passport/Passport.jsx
@@ -219,7 +219,7 @@ export default class Passport extends SubsectionElement {
                     `foreign.passport.placeholder.bookNumber`
                   )}
                   pattern={this.props.reBook}
-                  maxlength="9"
+                  maxlength="10"
                   className="number passport-number"
                   ref="number"
                   prefix="passport"

--- a/src/components/Section/Foreign/Passport/Passport.jsx
+++ b/src/components/Section/Foreign/Passport/Passport.jsx
@@ -14,6 +14,7 @@ import {
   Radio,
   RadioGroup
 } from '../../../Form'
+import { extractDate } from '../../History/dateranges'
 
 export default class Passport extends SubsectionElement {
   constructor(props) {
@@ -133,7 +134,23 @@ export default class Passport extends SubsectionElement {
     return this.props.suggestedNames.length
   }
 
+  passportBeforeCutoff() {
+    if (this.props.Issued) {
+      const cutoffDate = new Date('1/1/1990 00:00')
+      const issueDate = extractDate(this.props.Issued)
+
+      if (issueDate < cutoffDate) {
+        return true
+      }
+    }
+
+    return false
+  }
+
   render() {
+    const numberLength = this.passportBeforeCutoff() ? '255' : '9'
+    const numberRegEx = this.passportBeforeCutoff() ? '^[a-zA-Z0-9]*$' : this.props.reBook
+
     return (
       <div
         className="section-content passport"
@@ -202,35 +219,6 @@ export default class Passport extends SubsectionElement {
             </Field>
 
             <Field
-              title={i18n.t('foreign.passport.number')}
-              help="foreign.passport.help.number"
-              errorPrefix="passport"
-              adjustFor="buttons"
-              shrink={true}
-              scrollIntoView={this.props.scrollIntoView}>
-              <div>
-                <Text
-                  name="number"
-                  {...this.props.Number}
-                  label={i18n.t(
-                    `foreign.passport.label.bookNumber`
-                  )}
-                  placeholder={i18n.t(
-                    `foreign.passport.placeholder.bookNumber`
-                  )}
-                  pattern={this.props.reBook}
-                  maxlength="9"
-                  className="number passport-number"
-                  ref="number"
-                  prefix="passport"
-                  onUpdate={this.updateNumber}
-                  onError={this.handleError}
-                  required={this.props.required}
-                />
-              </div>
-            </Field>
-
-            <Field
               title={i18n.t('foreign.passport.issued')}
               help="foreign.passport.help.issued"
               adjustFor="labels"
@@ -261,6 +249,35 @@ export default class Passport extends SubsectionElement {
                 onError={this.handleError}
                 required={this.props.required}
               />
+            </Field>
+
+            <Field
+              title={i18n.t('foreign.passport.number')}
+              help="foreign.passport.help.number"
+              errorPrefix="passport"
+              adjustFor="buttons"
+              shrink={true}
+              scrollIntoView={this.props.scrollIntoView}>
+              <div>
+                <Text
+                  name="number"
+                  {...this.props.Number}
+                  label={i18n.t(
+                    `foreign.passport.label.bookNumber`
+                  )}
+                  placeholder={i18n.t(
+                    `foreign.passport.placeholder.bookNumber`
+                  )}
+                  pattern={numberRegEx}
+                  maxlength={numberLength}
+                  className="number passport-number"
+                  ref="number"
+                  prefix="passport"
+                  onUpdate={this.updateNumber}
+                  onError={this.handleError}
+                  required={this.props.required}
+                />
+              </div>
             </Field>
           </div>
         </Show>

--- a/src/components/Section/Foreign/Passport/Passport.jsx
+++ b/src/components/Section/Foreign/Passport/Passport.jsx
@@ -134,12 +134,6 @@ export default class Passport extends SubsectionElement {
   }
 
   render() {
-    const passportType = (this.props.Card || {}).value || 'Book'
-    let re = this.props.reBook
-    if (passportType === 'Card') {
-      re = this.props.reCard
-    }
-
     return (
       <div
         className="section-content passport"
@@ -215,38 +209,16 @@ export default class Passport extends SubsectionElement {
               shrink={true}
               scrollIntoView={this.props.scrollIntoView}>
               <div>
-                <RadioGroup
-                  className="option-list"
-                  onError={this.handleError}
-                  required={this.props.required}
-                  selectedValue={(this.props.Card || {}).value}>
-                  <Radio
-                    name="passport-book"
-                    className="passport-book"
-                    label={i18n.t('foreign.passport.label.book')}
-                    value="Book"
-                    onUpdate={this.updateCard}
-                    onError={this.handleError}
-                  />
-                  <Radio
-                    name="passport-card"
-                    className="passport-card"
-                    label={i18n.t('foreign.passport.label.card')}
-                    value="Card"
-                    onUpdate={this.updateCard}
-                    onError={this.handleError}
-                  />
-                </RadioGroup>
                 <Text
                   name="number"
                   {...this.props.Number}
                   label={i18n.t(
-                    `foreign.passport.label.${passportType.toLowerCase()}Number`
+                    `foreign.passport.label.bookNumber`
                   )}
                   placeholder={i18n.t(
-                    `foreign.passport.placeholder.${passportType.toLowerCase()}Number`
+                    `foreign.passport.placeholder.bookNumber`
                   )}
-                  pattern={re}
+                  pattern={this.props.reBook}
                   maxlength="9"
                   className="number passport-number"
                   ref="number"
@@ -311,7 +283,6 @@ Passport.defaultProps = {
   HasPassports: {},
   suggestedNames: [],
   reBook: '^[a-zA-Z]{1}[0-9]{6,9}$',
-  reCard: '^[cC]{1}[0-9]{8}$',
   onUpdate: queue => {},
   onError: (value, arr) => {
     return arr

--- a/src/components/Section/Foreign/Passport/Passport.test.jsx
+++ b/src/components/Section/Foreign/Passport/Passport.test.jsx
@@ -8,7 +8,6 @@ describe('The passport component', () => {
       name: 'passport'
     }
     const component = mount(<Passport name={expected.name} />)
-    expect(component.find('.passport-card').length).toEqual(0)
     expect(component.find('.first input').length).toEqual(0)
     expect(component.find('.number input').length).toEqual(0)
     expect(component.find('.month input').length).toEqual(0)
@@ -21,7 +20,6 @@ describe('The passport component', () => {
       HasPassports: { value: 'Yes' }
     }
     const component = mount(<Passport {...expected} />)
-    expect(component.find('.passport-card').length).toEqual(1)
     expect(component.find('.number input').length).toEqual(1)
     expect(component.find('.month input').length).toEqual(2)
     expect(component.find('.usa-input-error-label').length).toEqual(0)
@@ -33,7 +31,6 @@ describe('The passport component', () => {
       HasPassports: { value: 'No' }
     }
     const component = mount(<Passport name={expected.name} HasPassport="No" />)
-    expect(component.find('.passport-card').length).toEqual(0)
     expect(component.find('.first input').length).toEqual(0)
     expect(component.find('.number input').length).toEqual(0)
     expect(component.find('.month input').length).toEqual(0)
@@ -104,21 +101,16 @@ describe('The passport component', () => {
     expect(component.find('.usa-input-error-label').length).toEqual(0)
     component.find('.branch .yes input').simulate('change')
     component.find('.name .first input').simulate('change')
-    component.find('.passport-book input').simulate('change')
     component.find('.passport-number input').simulate('change')
     component.find('.passport-issued .day input').simulate('change')
     component.find('.passport-expiration .day input').simulate('change')
-    component.find('.passport-card input').simulate('change')
-    expect(component.find('.passport-book input').hasClass('selected')).toBe(
-      true
-    )
   })
 
   it('can render with regular expression for passport card', () => {
     const props = {
       HasPassports: { value: 'Yes' },
-      Card: { value: 'Card' },
-      reCard: 'test'
+      Card: { value: 'Book' },
+      reBook: 'test'
     }
     const component = mount(<Passport {...props} />)
     expect(component.find('.number').length).toBe(1)

--- a/src/components/Section/Foreign/Passport/Passport.test.jsx
+++ b/src/components/Section/Foreign/Passport/Passport.test.jsx
@@ -106,7 +106,7 @@ describe('The passport component', () => {
     component.find('.passport-expiration .day input').simulate('change')
   })
 
-  it('can render with regular expression for passport card', () => {
+  it('can render with regular expression for passport book', () => {
     const props = {
       HasPassports: { value: 'Yes' },
       Issued: {

--- a/src/components/Section/Foreign/Passport/Passport.test.jsx
+++ b/src/components/Section/Foreign/Passport/Passport.test.jsx
@@ -109,6 +109,13 @@ describe('The passport component', () => {
   it('can render with regular expression for passport card', () => {
     const props = {
       HasPassports: { value: 'Yes' },
+      Issued: {
+        day: '1',
+        estimated: false,
+        month: '1',
+        name: 'issued',
+        year: '2003'
+      },
       Card: { value: 'Book' },
       reBook: 'test'
     }

--- a/src/components/Section/Foreign/Passport/Passport.test.jsx
+++ b/src/components/Section/Foreign/Passport/Passport.test.jsx
@@ -94,7 +94,7 @@ describe('The passport component', () => {
       },
       Number: {
         name: 'number',
-        value: 'C1234567'
+        value: '123456789'
       }
     }
     const component = mount(<Passport {...data} name={'passport'} />)

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -783,8 +783,7 @@ export const error = {
     pattern: {
       title: 'There is a problem with the passport number',
       message: [
-        'For passport books the number will start with a letter and then 6 to 9 digits.',
-        'For passport cards the number begins with a "C" and followed by 8 digits.'
+        'For passport books the number will start with a letter and then 6 to 9 digits.'
       ],
       note: ''
     },

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -776,6 +776,9 @@ export const error = {
     }
   },
   passport: {
+    length: {
+      title: ''
+    },
     required: {
       title: 'Your response is required',
       message: ''

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -786,7 +786,7 @@ export const error = {
     pattern: {
       title: 'There is a problem with the passport number',
       message: [
-        'U.S. Passport numbers must be between six and nine alphanumeric characters (letters and numbers).'
+        'U.S. Passport numbers must be nine alphanumeric characters (letters and numbers).'
       ],
       note: ''
     },

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -783,7 +783,7 @@ export const error = {
     pattern: {
       title: 'There is a problem with the passport number',
       message: [
-        'For passport books the number will start with a letter and then 6 to 9 digits.'
+        'U.S. Passport numbers must be between six and nine alphanumeric characters (letters and numbers).'
       ],
       note: ''
     },

--- a/src/config/locales/en/foreign.js
+++ b/src/config/locales/en/foreign.js
@@ -58,10 +58,6 @@ export const foreign = {
       book: 'Passport',
       card: 'Passport card'
     },
-    placeholder: {
-      bookNumber: 'A########',
-      cardNumber: 'C########'
-    },
     name: 'Provide the name in which passport was first issued',
     number: 'Provide your U.S. passport number',
     card: 'Passport card',

--- a/src/config/locales/en/foreign.js
+++ b/src/config/locales/en/foreign.js
@@ -76,7 +76,7 @@ export const foreign = {
       number: {
         title: 'Passport',
         message:
-          'Passports will start with the letter A.',
+          'U.S. Passport numbers must be between six and nine alphanumeric characters (letters and numbers).',
         note: ''
       },
       issued: {

--- a/src/config/locales/en/foreign.js
+++ b/src/config/locales/en/foreign.js
@@ -54,13 +54,10 @@ export const foreign = {
     },
     label: {
       bookNumber: 'Passport number',
-      cardNumber: 'Passport card number',
-      book: 'Passport',
-      card: 'Passport card'
+      book: 'Passport'
     },
     name: 'Provide the name in which passport was first issued',
     number: 'Provide your U.S. passport number',
-    card: 'Passport card',
     issued: 'Provide the issue date of the passport',
     expiration: 'Provide the expiration date of the passport',
     comment: {
@@ -77,12 +74,12 @@ export const foreign = {
       },
       issued: {
         title: 'Use the exact date',
-        message: 'Enter the date on your passport or passport card.',
+        message: 'Enter the date on your passport.',
         note: ''
       },
       expiration: {
         title: 'Use the exact date',
-        message: 'Enter the date on your passport or passport card.',
+        message: 'Enter the date on your passport.',
         note: ''
       }
     },

--- a/src/config/locales/en/foreign.js
+++ b/src/config/locales/en/foreign.js
@@ -72,7 +72,7 @@ export const foreign = {
       number: {
         title: 'Passport',
         message:
-          'U.S. Passport numbers must be between six and nine alphanumeric characters (letters and numbers).',
+          'U.S. Passport numbers must be nine alphanumeric characters (letters and numbers).',
         note: ''
       },
       issued: {

--- a/src/config/locales/en/foreign.js
+++ b/src/config/locales/en/foreign.js
@@ -74,9 +74,9 @@ export const foreign = {
     },
     help: {
       number: {
-        title: 'Passport or Passport Card',
+        title: 'Passport',
         message:
-          'Passports will start with the letter A. Passport Cards will start with the letter C. For Passport Cards select the Passport card option first.',
+          'Passports will start with the letter A.',
         note: ''
       },
       issued: {

--- a/src/validators/passport.js
+++ b/src/validators/passport.js
@@ -2,7 +2,6 @@ import NameValidator from './name'
 import DateRangeValidator from './daterange'
 
 const reBook = '^[a-zA-Z]{1}[0-9]{6,9}$'
-const reCard = '^[cC]{1}[0-9]{8}$'
 
 export default class PassportValidator {
   constructor(data = {}) {
@@ -45,7 +44,7 @@ export default class PassportValidator {
       return false
     }
 
-    let re = this.card === 'Card' ? new RegExp(reCard) : new RegExp(reBook)
+    let re = new RegExp(reBook)
     if (!re.test(this.number.value)) {
       return false
     }

--- a/src/validators/passport.js
+++ b/src/validators/passport.js
@@ -52,7 +52,7 @@ export default class PassportValidator {
       let re = new RegExp(reBook)
 
       // Before 1/1/1990 allow alphanumeric of any length
-      if (issueDate < cutoffDate) {
+      if (issueDate && issueDate < cutoffDate) {
         re = new RegExp('^[a-zA-Z0-9]*$')
         if (!re.test(this.number.value)) {
           return false

--- a/src/validators/passport.js
+++ b/src/validators/passport.js
@@ -1,7 +1,7 @@
 import NameValidator from './name'
 import DateRangeValidator from './daterange'
 
-const reBook = '^[a-zA-Z]{1}[0-9]{6,9}$'
+const reBook = '^[a-zA-Z0-9]{6,9}$'
 
 export default class PassportValidator {
   constructor(data = {}) {

--- a/src/validators/passport.js
+++ b/src/validators/passport.js
@@ -2,7 +2,7 @@ import NameValidator from './name'
 import DateRangeValidator from './daterange'
 import { extractDate } from '../components/Section/History/dateranges'
 
-const reBook = '^[a-zA-Z0-9]{6,9}$'
+const reBook = '^[a-zA-Z0-9]{9}$'
 
 export default class PassportValidator {
   constructor(data = {}) {

--- a/src/validators/passport.js
+++ b/src/validators/passport.js
@@ -1,5 +1,6 @@
 import NameValidator from './name'
 import DateRangeValidator from './daterange'
+import { extractDate } from '../components/Section/History/dateranges'
 
 const reBook = '^[a-zA-Z0-9]{6,9}$'
 
@@ -44,9 +45,24 @@ export default class PassportValidator {
       return false
     }
 
-    let re = new RegExp(reBook)
-    if (!re.test(this.number.value)) {
-      return false
+    if (this.issued) {
+      const cutoffDate = new Date('1/1/1990 00:00')
+      const issueDate = extractDate(this.issued)
+
+      let re = new RegExp(reBook)
+
+      // Before 1/1/1990 allow alphanumeric of any length
+      if (issueDate < cutoffDate) {
+        re = new RegExp('^[a-zA-Z0-9]*$')
+        if (!re.test(this.number.value)) {
+          return false
+        }
+      }
+
+      // After 1/1/1990 enforce default regex
+      if (!re.test(this.number.value)) {
+        return false
+      }
     }
 
     return true

--- a/src/validators/passport.test.js
+++ b/src/validators/passport.test.js
@@ -40,8 +40,66 @@ describe('Passport component validation', function() {
     const tests = [
       {
         data: {
+          Number: '',
+          Card: 'Book'
+        },
+        expected: false
+      },
+      {
+        data: {
+          Issued: {
+            date: new Date('1/1/2015'),
+            day: '1',
+            month: '1',
+            year: '2015',
+            estimated: false
+          },
+          Number: '',
+          Card: 'Book'
+        },
+        expected: false
+      },
+      {
+        data: {
+          Issued: {
+            date: new Date('1/1/1989'),
+            day: '1',
+            month: '1',
+            year: '1989',
+            estimated: false
+          },
+          Number: '',
+          Card: 'Book'
+        },
+        expected: false
+      },
+      {
+        data: {
+          Issued: {
+            date: new Date('1/1/2015'),
+            day: '1',
+            month: '1',
+            year: '2015',
+            estimated: false
+          },
           Number: {
-            value: 'A1234567'
+            value: '123456789abcdefg'
+          },
+          Card: 'Book'
+        },
+        expected: false
+      },
+      {
+        data: {
+          Issued: {
+            date: new Date('1/1/2015'),
+            day: '1',
+            month: '1',
+            year: '2015',
+            estimated: false
+          },
+          Number: {
+            value: '123456789'
           },
           Card: 'Book'
         },
@@ -49,11 +107,20 @@ describe('Passport component validation', function() {
       },
       {
         data: {
-          Number: '',
+          Issued: {
+            date: new Date('1/1/1989'),
+            day: '1',
+            month: '1',
+            year: '1989',
+            estimated: false
+          },
+          Number: {
+            value: '123456789abcdefg'
+          },
           Card: 'Book'
         },
-        expected: false
-      }
+        expected: true
+      },
     ]
 
     tests.forEach(test => {

--- a/src/validators/passport.test.js
+++ b/src/validators/passport.test.js
@@ -41,29 +41,11 @@ describe('Passport component validation', function() {
       {
         data: {
           Number: {
-            value: 'C1234567'
+            value: 'A1234567'
           },
           Card: 'Book'
         },
         expected: true
-      },
-      {
-        data: {
-          Number: {
-            value: 'C12345678'
-          },
-          Card: 'Card'
-        },
-        expected: true
-      },
-      {
-        data: {
-          Number: {
-            value: 'C1234567'
-          },
-          Card: 'Card'
-        },
-        expected: false
       },
       {
         data: {

--- a/src/validators/passport.test.js
+++ b/src/validators/passport.test.js
@@ -256,7 +256,7 @@ describe('Passport component validation', function() {
           },
           HasPassports: { value: 'Yes' },
           Number: {
-            value: 'C1234567'
+            value: '123456789'
           },
           Card: 'Book',
           Issued: {


### PR DESCRIPTION
Fixes #818

This removes the `Passport Card` option from the `Foreign associations > U.S. passport information` UI, also updates the validation and i18n files to reflect the changes. The database field for Passport Card still remains and will be documented in a [separate issue](https://github.com/18F/e-QIP-prototype/issues/840) should it need to be reenabled in the future.

**Before:**
<img width="697" alt="screen shot 2018-09-20 at 2 28 15 pm" src="https://user-images.githubusercontent.com/1178494/45839065-45d43a00-bce1-11e8-83ed-46703a9cce57.png">

**After:**
<img width="691" alt="screen shot 2018-09-20 at 2 24 38 pm" src="https://user-images.githubusercontent.com/1178494/45839012-20473080-bce1-11e8-9dd8-3927b8e26b09.png">
