### PR TITLE
Remove allowNotApplicable from reference phone number

### DIFF
--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -492,6 +492,8 @@ export default class EmploymentItem extends ValidationElement {
                   name="ReferencePhone"
                   className="reference-phone"
                   {...this.props.ReferencePhone}
+                  allowNotApplicable={false}
+                  showNumberType={true}
                   onUpdate={this.updateReferencePhone}
                   onError={this.props.onError}
                   required={this.props.required}

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -493,7 +493,6 @@ export default class EmploymentItem extends ValidationElement {
                   className="reference-phone"
                   {...this.props.ReferencePhone}
                   allowNotApplicable={false}
-                  showNumberType={true}
                   onUpdate={this.updateReferencePhone}
                   onError={this.props.onError}
                   required={this.props.required}

--- a/src/validators/employment.js
+++ b/src/validators/employment.js
@@ -164,7 +164,7 @@ export class EmploymentValidator {
   validReference() {
     return (
       new NameValidator(this.referenceName).isValid() &&
-      validPhoneNumber(this.referencePhone) &&
+      validPhoneNumber(this.referencePhone, { numberType: false }) &&
       new LocationValidator(this.referenceAddress).isValid()
     )
   }

--- a/src/validators/employment.js
+++ b/src/validators/employment.js
@@ -164,7 +164,7 @@ export class EmploymentValidator {
   validReference() {
     return (
       new NameValidator(this.referenceName).isValid() &&
-      validPhoneNumber(this.referencePhone, { numberType: false }) &&
+      validPhoneNumber(this.referencePhone) &&
       new LocationValidator(this.referenceAddress).isValid()
     )
   }

--- a/src/validators/employment.test.js
+++ b/src/validators/employment.test.js
@@ -612,7 +612,6 @@ describe('Employment component validation', function() {
           ReferencePhone: {
             noNumber: '',
             number: '7031112222',
-            numberType: 'Home',
             type: 'Domestic',
             timeOfDay: 'Both',
             extension: ''
@@ -700,7 +699,6 @@ describe('Employment component validation', function() {
           ReferencePhone: {
             noNumber: '',
             number: '7031112222',
-            numberType: 'Home',
             timeOfDay: 'Both',
             type: 'Domestic',
             extension: ''

--- a/src/validators/employment.test.js
+++ b/src/validators/employment.test.js
@@ -44,7 +44,7 @@ describe('Employment component validation', function() {
           Telephone: {
             noNumber: '',
             number: '2028675309',
-            numberType: 'Cell',
+            numberType: '',
             type: 'Domestic',
             timeOfDay: 'Day'
           },
@@ -66,7 +66,7 @@ describe('Employment component validation', function() {
             Telephone: {
               noNumber: '',
               number: '2021112222',
-              numberType: 'Cell',
+              numberType: '',
               timeOfDay: 'Day',
               type: 'Domestic'
             },
@@ -156,7 +156,7 @@ describe('Employment component validation', function() {
           Telephone: {
             noNumber: '',
             number: '2028675309',
-            numberType: 'Cell',
+            numberType: '',
             type: 'Domestic',
             timeOfDay: 'Day'
           },
@@ -178,7 +178,7 @@ describe('Employment component validation', function() {
             Telephone: {
               noNumber: '',
               number: '2021112222',
-              numberType: 'Cell',
+              numberType: '',
               type: 'Domestic',
               timeOfDay: 'Day'
             },
@@ -289,7 +289,7 @@ describe('Employment component validation', function() {
           Telephone: {
             noNumber: '',
             number: '2028675309',
-            numberType: 'Cell',
+            numberType: '',
             type: 'Domestic',
             timeOfDay: 'Day'
           },
@@ -311,7 +311,7 @@ describe('Employment component validation', function() {
             Telephone: {
               noNumber: '',
               number: '2021112222',
-              numberType: 'Cell',
+              numberType: '',
               type: 'Domestic',
               timeOfDay: 'Day'
             },
@@ -412,7 +412,7 @@ describe('Employment component validation', function() {
           Telephone: {
             noNumber: '',
             number: '2028675309',
-            numberType: 'Cell',
+            numberType: '',
             type: 'Domestic',
             timeOfDay: 'Day'
           },
@@ -434,7 +434,7 @@ describe('Employment component validation', function() {
             Telephone: {
               noNumber: '',
               number: '2021112222',
-              numberType: 'Cell',
+              numberType: '',
               type: 'Domestic',
               timeOfDay: 'Day'
             },
@@ -574,7 +574,7 @@ describe('Employment component validation', function() {
           Telephone: {
             noNumber: '',
             number: '2028675309',
-            numberType: 'Cell',
+            numberType: '',
             type: 'Domestic',
             timeOfDay: 'Day'
           },
@@ -1000,7 +1000,7 @@ describe('Employment component validation', function() {
           Telephone: {
             noNumber: '',
             number: '2028675309',
-            numberType: 'Cell',
+            numberType: '',
             type: 'Domestic',
             timeOfDay: 'Day'
           }
@@ -1043,7 +1043,7 @@ describe('Employment component validation', function() {
             Telephone: {
               noNumber: '',
               number: '2028675309',
-              numberType: 'Cell',
+              numberType: '',
               type: 'Domestic',
               timeOfDay: 'Day'
             }
@@ -1558,7 +1558,7 @@ describe('Employment component validation', function() {
             Telephone: {
               noNumber: '',
               number: '2028675309',
-              numberType: 'Cell',
+              numberType: '',
               type: 'Domestic',
               timeOfDay: 'Day'
             },
@@ -1580,7 +1580,7 @@ describe('Employment component validation', function() {
               Telephone: {
                 noNumber: '',
                 number: '2021112222',
-                numberType: 'Cell',
+                numberType: '',
                 type: 'Domestic',
                 timeOfDay: 'Day'
               },

--- a/src/validators/helpers.js
+++ b/src/validators/helpers.js
@@ -58,14 +58,14 @@ export const anyHasStatus = completed => (properties, status, val) => {
 /**
  * Validates a phone number
  */
-export const validPhoneNumber = phone => {
+export const validPhoneNumber = (phone, opts = { numberType: true }) => {
   if (!phone) {
     return false
   }
   if (phone.noNumber) {
     return true
   }
-  if (!phone.numberType) {
+  if (!phone.numberType && opts.numberType) {
     return false
   }
   if (!phone.timeOfDay) {

--- a/src/validators/helpers.js
+++ b/src/validators/helpers.js
@@ -58,7 +58,8 @@ export const anyHasStatus = completed => (properties, status, val) => {
 /**
  * Validates a phone number
  */
-export const validPhoneNumber = (phone, opts = { numberType: true }) => {
+export const validPhoneNumber = (phone, opts = { numberType: false }) => {
+  // console.log(phone)
   if (!phone) {
     return false
   }

--- a/src/validators/helpers.test.js
+++ b/src/validators/helpers.test.js
@@ -248,6 +248,19 @@ describe('Helpers for validators', function() {
         phone: {
           noNumber: '',
           number: '1234567',
+          timeOfDay: 'Both',
+          type: 'DSN',
+          extension: ''
+        },
+        options: {
+          numberType: false
+        },
+        expected: true
+      },
+      {
+        phone: {
+          noNumber: '',
+          number: '1234567',
           numberType: 'Home',
           timeOfDay: 'Both',
           type: 'Unknown',
@@ -291,7 +304,7 @@ describe('Helpers for validators', function() {
     ]
 
     tests.forEach(test => {
-      expect(validPhoneNumber(test.phone)).toBe(test.expected)
+      expect(validPhoneNumber(test.phone, test.options)).toBe(test.expected)
     })
   })
 

--- a/src/validators/identificationcontacts.js
+++ b/src/validators/identificationcontacts.js
@@ -54,6 +54,6 @@ export class ContactPhoneNumberValidator {
   }
 
   isValid() {
-    return validPhoneNumber(this.phoneNumber)
+    return validPhoneNumber(this.phoneNumber, { numberType: true })
   }
 }

--- a/src/validators/identificationcontacts.test.js
+++ b/src/validators/identificationcontacts.test.js
@@ -83,6 +83,30 @@ describe('Contact Information validation', function() {
       },
       {
         state: {
+          PhoneNumbers: {
+            items: [
+              {
+                Item: {
+                  Telephone: {
+                    noNumber: false,
+                    number: '7031112222',
+                    numberType: '',
+                    type: 'Domestic',
+                    timeOfDay: 'Both',
+                    extension: ''
+                  }
+                }
+              },
+              {
+                Telephone: {}
+              }
+            ]
+          }
+        },
+        expected: false
+      },
+      {
+        state: {
           PhoneNumbers: { items: [] }
         },
         expected: false


### PR DESCRIPTION
This updates the reference phone number for all employment activities to be required (not just unemployment).

Closes #654 

**Before**
<img width="656" alt="screen shot 2018-09-20 at 3 17 24 pm" src="https://user-images.githubusercontent.com/693815/45849748-27257180-bce8-11e8-9a92-2675abe79bfd.png">

**After**
<img width="504" alt="screen shot 2018-09-20 at 3 03 42 pm" src="https://user-images.githubusercontent.com/693815/45849686-cac25200-bce7-11e8-9809-d70bbf366281.png">


