### PR TITLE
Provide complete date for delinquent payment

### DIFF
--- a/api/testdata/complete-scenarios/test2.json
+++ b/api/testdata/complete-scenarios/test2.json
@@ -898,7 +898,7 @@
                     "type": "datecontrol",
                     "props": {
                       "month": "01",
-                      "day": "",
+                      "day": "1",
                       "year": "1999",
                       "estimated": false
                     }


### PR DESCRIPTION
One of the date entries for `Delinquent payments` was missing the day portion of the date field. In this particular case, only the month and year are asked for, but the UI will send a hidden value of `1` for the day portion along with the month/year, but for whatever reason it doesn't look like that made it into the test json. This relates to https://github.com/18F/e-QIP-prototype/issues/824