### PR TITLE
Fail zip code validation for state codes without zips

### DIFF
--- a/src/validators/location.js
+++ b/src/validators/location.js
@@ -170,12 +170,10 @@ export default class LocationValidator {
 
   validZipcodeState() {
     if (!zipcodes[this.state] || !this.validZipcode()) {
-      return true
+      return false
     }
 
     return isZipcodeState(this.state, this.zipcode)
-    // const zip3Digit = this.zipcode.substring(0, 3)
-    // return zipcodes[this.state].includes(zip3Digit)
   }
 
   validCounty() {

--- a/src/validators/location.test.js
+++ b/src/validators/location.test.js
@@ -423,13 +423,13 @@ describe('the location component', function() {
       },
       {
         state: {
-          country: { value: 'Outside US' },
+          country: { value: 'United States' },
           street: '1234 Some Rd',
           city: 'City',
-          state: 'NOTUS',
+          state: 'DQ',
           zipcode: '12321'
         },
-        expected: true
+        expected: false
       }
     ]
 


### PR DESCRIPTION
Closes #851

Fails the zip code validation if the state code provided is not in the zip code key values.