### PR TITLE
Update date logic for education

### DIFF
--- a/src/components/Section/History/Education/EducationItem.jsx
+++ b/src/components/Section/History/Education/EducationItem.jsx
@@ -18,6 +18,7 @@ import {
 } from '../../../Form'
 import { DiplomaItem } from './Diploma'
 import { today, daysAgo } from '../dateranges'
+import { buildDate } from '../../../../validators/helpers'
 
 // We need to determine how far back 3 years ago was
 const threeYearsAgo = daysAgo(today, 365 * 3)
@@ -189,8 +190,8 @@ export default class EducationItem extends ValidationElement {
     // Certain elements are present if the date range of the attendance was
     // within the last 3 years.
     const dates = this.props.Dates || {}
-    const from = (dates.from || {}).date
-    const to = (dates.to || {}).date
+    const from = buildDate(dates.from)
+    const to = buildDate(dates.to)
 
     return (
       <div className="education">

--- a/src/components/Section/History/Education/EducationItem.test.jsx
+++ b/src/components/Section/History/Education/EducationItem.test.jsx
@@ -26,10 +26,14 @@ describe('The education component', () => {
       name: 'education',
       Dates: {
         from: {
-          date: new Date()
+          month: '1',
+          day: '1',
+          year: '2015'
         },
         to: {
-          date: new Date()
+          month: `${new Date().getMonth()}`,
+          day: `${new Date().getDate()}`,
+          year: `${new Date().getFullYear()}`
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/826

It looks like when using the `DateControl` component on the frontend, one of the properties it keeps track of is a `date` object which can be used in different date calculations. The problem is, that the date object itself is not stored in the db, just individual strings for `day`, `month`, and `year`. So when someone logs out and logs back in, the component is missing the date object until it's state is updated, so anything referencing it will get an `undefined` until that happens. This update uses the `day`, `month`, and `year` strings in calculations instead, which are more reliable.