### PR TITLE
Show foreign doc fields after re-logging in

### DIFF
--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -186,10 +186,8 @@ export default class CivilUnion extends ValidationElement {
   }
 
   render() {
-    const birthCountry = ((this.props.BirthPlace || {}).country || {}).value
-    const showForeignBornDocumentation = birthCountry
-      ? birthCountry !== 'United States'
-      : false
+    const showForeignBornDocumentation =
+      ((this.props.BirthPlace || {}).country || {}) !== 'United States'
     return (
       <div className="civil-union">
         <div>

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.test.jsx
@@ -88,4 +88,20 @@ describe('The civil union component', () => {
       component.find('.current-address.button label.checked').length
     ).toEqual(0)
   })
+
+  it('should not ask for foreign born documentation if from the United States', () => {
+    const expected = {
+      BirthPlace: { country: 'United States' }
+    }
+    const component = mount(<CivilUnion {...expected} />)
+    expect(component.find('.foreign-born-documents').length).toEqual(0)
+  })
+
+  it('should ask for foreign born documentation if not from the United States', () => {
+    const expected = {
+      BirthPlace: { country: 'Canada' }
+    }
+    const component = mount(<CivilUnion {...expected} />)
+    expect(component.find('.foreign-born-documents').length).toEqual(1)
+  })
 })

--- a/src/components/Section/Relationships/RelationshipStatus/Cohabitant.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Cohabitant.jsx
@@ -146,10 +146,8 @@ export default class Cohabitant extends ValidationElement {
   }
 
   render() {
-    const birthCountry = ((this.props.BirthPlace || {}).country || {}).value
-    const showForeignBornDocumentation = birthCountry
-      ? birthCountry !== 'United States'
-      : false
+    const showForeignBornDocumentation =
+      ((this.props.BirthPlace || {}).country || {}) !== 'United States'
     return (
       <div className="cohabitant">
         <Suggestions

--- a/src/components/Section/Relationships/RelationshipStatus/Cohabitant.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Cohabitant.test.jsx
@@ -110,4 +110,20 @@ describe('The cohabitant component', () => {
     expect(component.find('.spouse-suggestion .suggestion-btn').length).toBe(1)
     component.find('.spouse-suggestion a').simulate('click')
   })
+
+  it('should not ask for foreign born documentation if from the United States', () => {
+    const expected = {
+      BirthPlace: { country: 'United States' }
+    }
+    const component = mount(<Cohabitant {...expected} />)
+    expect(component.find('.foreign-born-documents').length).toEqual(0)
+  })
+
+  it('should ask for foreign born documentation if not from the United States', () => {
+    const expected = {
+      BirthPlace: { country: 'Canada' }
+    }
+    const component = mount(<Cohabitant {...expected} />)
+    expect(component.find('.foreign-born-documents').length).toEqual(1)
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/865

Similar to https://github.com/18F/e-QIP-prototype/pull/880, the foreign document fields for cohabitants (and also civil union) were relying on a value that is not initially available after re-logging in. This updates the logic to use a value that will always be present.