### PR TITLE
Fix margins on archival PDF, button sizes

### DIFF
--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -762,7 +762,7 @@ export class HistorySections extends React.Component {
       return false
     }
     return (
-      <div>
+      <div className="history">
         <Residence
           {...this.props.Residence}
           defaultState={false}

--- a/src/components/Section/Package/Print.scss
+++ b/src/components/Section/Package/Print.scss
@@ -1,7 +1,6 @@
 @import 'eqip-colors';
 
 .pre-print-view {
-  padding: 0 10%;
 
   .print-btn {
     padding: 3rem 6rem 3rem 6rem;

--- a/src/components/Section/Package/__snapshots__/Print.test.jsx.snap
+++ b/src/components/Section/Package/__snapshots__/Print.test.jsx.snap
@@ -4135,7 +4135,9 @@ exports[`The print section renders properly 1`] = `
       >
         Your history
       </h3>
-      <div>
+      <div
+        className="history"
+      >
         <div
           className="section-content residence"
           data-section="history"

--- a/src/sass/print.scss
+++ b/src/sass/print.scss
@@ -1,5 +1,8 @@
 // Override the default styling of TABLE applied from
 // USWDS.
+.pre-print-view {
+  padding: 0 1rem;
+}
 .print-table {
   display: block;
   margin: 0;
@@ -269,6 +272,36 @@
     opacity: 1;
     outline: 3px solid #000;
   }
+
+/* Hiding options that were not selected and only showing the selection */
+// .option-list {
+//   .block label {
+//     display: none;
+//   }
+//   .block label.checked {
+//     display: block;
+//   }
+// }
+
+input[type='text'].usa-input-success,
+input[type='number'].usa-input-success,
+input[type='email'].usa-input-success,
+textarea.usa-input-success, select.usa-input-success {
+  background-image: none;
+}
+
+/* Adjusting accoridon spacing for print */
+.accordion {
+  padding: 0;
+  .summary .left {
+    padding-left: 0;
+    width: 100%;
+  }
+  .item .details {
+    padding: 0 1rem;
+  }
+}
+
 
   /* Get rid of left blue border within accordion */
   .accordion .summary .left.open,

--- a/src/sass/print.scss
+++ b/src/sass/print.scss
@@ -3,6 +3,7 @@
 .pre-print-view {
   padding: 0 1rem;
 }
+
 .print-table {
   display: block;
   margin: 0;
@@ -273,35 +274,34 @@
     outline: 3px solid #000;
   }
 
-/* Hiding options that were not selected and only showing the selection */
-// .option-list {
-//   .block label {
-//     display: none;
-//   }
-//   .block label.checked {
-//     display: block;
-//   }
-// }
+  /* Hiding options that were not selected and only showing the selection */
+  // .option-list {
+  //   .block label {
+  //     display: none;
+  //   }
+  //   .block label.checked {
+  //     display: block;
+  //   }
+  // }
 
-input[type='text'].usa-input-success,
-input[type='number'].usa-input-success,
-input[type='email'].usa-input-success,
-textarea.usa-input-success, select.usa-input-success {
-  background-image: none;
-}
-
-/* Adjusting accoridon spacing for print */
-.accordion {
-  padding: 0;
-  .summary .left {
-    padding-left: 0;
-    width: 100%;
+  input[type='text'].usa-input-success,
+  input[type='number'].usa-input-success,
+  input[type='email'].usa-input-success,
+  textarea.usa-input-success, select.usa-input-success {
+    background-image: none;
   }
-  .item .details {
-    padding: 0 1rem;
-  }
-}
 
+  /* Adjusting accoridon spacing for print */
+  .accordion {
+    padding: 0;
+    .summary .left {
+      padding-left: 0;
+      width: 100%;
+    }
+    .item .details {
+      padding: 0 1rem;
+    }
+  }
 
   /* Get rid of left blue border within accordion */
   .accordion .summary .left.open,


### PR DESCRIPTION
This Fixes #874 
- The margins have been updated 
- Button sizes look good
- Fixed side margin 
- Removed green checkboxes from fields
- Fixing the spacing of accordions to allow for a wider content area



The button sizing is off because there are specific sizes that are used for certain sections for example in `EducationItem.scss` the following is used...

```CSS
.history {
  .type,
  .diploma {
    label {
      width: 25rem !important;
    }
  }
```

This width is not applied on the final print because there is no `.history` class wrapping that on the final print page like their is earlier in the application. 😢 
