### PR TITLE
Handle residence dates properly when re-logging in

### DIFF
--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -19,14 +19,13 @@ import {
   Email
 } from '../../../Form'
 import { today, daysAgo } from '../dateranges'
+import { buildDate } from '../../../../validators/helpers'
 
 // We need to determine how far back 3 years ago was
 const threeYearsAgo = daysAgo(today, 365 * 3)
 const withinThreeYears = (from, to, present) => {
   return (
-    present ||
-    (from && from.date >= threeYearsAgo) ||
-    (to && to.date >= threeYearsAgo)
+    present || (from && from >= threeYearsAgo) || (to && to >= threeYearsAgo)
   )
 }
 
@@ -239,8 +238,8 @@ export default class ResidenceItem extends ValidationElement {
     // Certain elements are present if the date range of the residency was
     // within the last 3 years.
     const dates = this.props.Dates || {}
-    const from = dates.from
-    const to = dates.to
+    const from = buildDate(dates.from)
+    const to = buildDate(dates.to)
 
     return (
       <div className="residence">

--- a/src/components/Section/History/Residence/ResidenceItem.test.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.test.jsx
@@ -19,14 +19,12 @@ describe('The residence component', () => {
         from: {
           month: '1',
           day: '1',
-          year: '2000',
-          date: new Date('1/1/2000')
+          year: '2000'
         },
         to: {
-          month: `${new Date().getMonth() + 1}`,
+          month: `${new Date().getMonth()}`,
           day: `${new Date().getDate()}`,
-          year: `${new Date()}.getFullYear()}`,
-          date: new Date()
+          year: `${new Date().getFullYear()}`
         }
       },
       ReferenceEmail: {


### PR DESCRIPTION
This applies the same logic from https://github.com/18F/e-QIP-prototype/pull/880 to the residence section which is likely affected by the same issue.