### PR TITLE
Zip code validator upper cases state codes

### DIFF
--- a/src/config/zipcodes.js
+++ b/src/config/zipcodes.js
@@ -901,17 +901,19 @@ const crossStateZips = {
 }
 
 export const isZipcodeState = (stateCode = '', zipCode = '') => {
-  if (!zipcodes[stateCode]) return false
+  const code = stateCode.toUpperCase()
+
+  if (!zipcodes[code]) return false
 
   const zip3Digit = zipCode.substring(0, 3)
   const zip5Digit = zipCode.substring(0, 5)
 
   if (
-    crossStateZips[stateCode] &&
-    crossStateZips[stateCode].includes(zip5Digit)
+    crossStateZips[code] &&
+    crossStateZips[code].includes(zip5Digit)
   ) {
     return true
   }
 
-  return zipcodes[stateCode].includes(zip3Digit)
+  return zipcodes[code].includes(zip3Digit)
 }

--- a/src/config/zipcodes.test.js
+++ b/src/config/zipcodes.test.js
@@ -24,6 +24,11 @@ describe('The zipcodes lookup', () => {
         expected: true
       },
       {
+        state: 'ct',
+        zipcode: '06389',
+        expected: true
+      },
+      {
         state: 'CA',
         zipcode: '06389',
         expected: false


### PR DESCRIPTION
Closes #845 

The validator now upper cases state codes to search the available zip code key value data.