### PR TITLE
Catch lowercase states in location validator

### DIFF
--- a/src/validators/location.js
+++ b/src/validators/location.js
@@ -169,7 +169,9 @@ export default class LocationValidator {
   }
 
   validZipcodeState() {
-    if (!zipcodes[this.state] || !this.validZipcode()) {
+    const code = (this.state || '').toUpperCase()
+
+    if (!zipcodes[code] || !this.validZipcode()) {
       return false
     }
 

--- a/src/validators/location.test.js
+++ b/src/validators/location.test.js
@@ -414,6 +414,16 @@ describe('the location component', function() {
       {
         state: {
           country: { value: 'United States' },
+          street: '1 Great Teen Drama Dr.',
+          city: 'Beverly Hills',
+          state: 'ca',
+          zipcode: '90210'
+        },
+        expected: true
+      },
+      {
+        state: {
+          country: { value: 'United States' },
           street: '1234 Some Rd',
           city: 'Arlington',
           state: 'VA',


### PR DESCRIPTION
The lowercase states were throwing off the initial validation when trying to find the state in the object of zip codes.