### PR TITLE
Set lastRefresh on initial form load

### DIFF
--- a/src/views/Form/Form.jsx
+++ b/src/views/Form/Form.jsx
@@ -41,6 +41,10 @@ class Form extends React.Component {
     }
   }
 
+  componentDidMount() {
+    this.refreshToken()
+  }
+
   getParams() {
     return this.props.params || this.props.match.params
   }


### PR DESCRIPTION
Fixes #895 

The form looks for route changes to update the `lastRefresh` value (by way of `onRouteChanged()` > `refreshToken()` > `updateApplication()`: https://github.com/18F/e-QIP-prototype/blob/develop/src/views/Form/Form.jsx#L116-L127) however on initial load of the app this normal handling is skipped and instead simply redirects users to the intro page: https://github.com/18F/e-QIP-prototype/blob/develop/src/views/Form/Form.jsx#L51, never setting a value for `lastRefresh`. This uses React's `componentDidMount()` to run the `refreshToken()` method on initial render, setting an initial value for `lastRefresh`. 