### PR TITLE
Update addresses to display only APO/FPO when required

### DIFF
--- a/src/components/Form/Location/Address.jsx
+++ b/src/components/Form/Location/Address.jsx
@@ -697,7 +697,7 @@ Address.defaultProps = {
   onError: (value, arr) => {
     return arr
   },
-  showPostOffice: true,
+  showPostOffice: false,
   streetLabel: i18n.t('address.us.street.label'),
   postOfficeStreetPlaceholder: i18n.t('address.apoFpo.street.placeholder'),
   postOfficeStateLabel: i18n.t('address.apoFpo.apoFpo.label'),

--- a/src/components/Form/Location/Address.test.jsx
+++ b/src/components/Form/Location/Address.test.jsx
@@ -64,6 +64,7 @@ describe('The Address component', () => {
   it('Performs address type update', () => {
     let updates = 0
     const props = {
+      showPostOffice: true,
       onUpdate: () => {
         updates++
       }

--- a/src/components/Section/Financial/Delinquent/DelinquentItem.jsx
+++ b/src/components/Section/Financial/Delinquent/DelinquentItem.jsx
@@ -316,6 +316,7 @@ export default class DelinquentItem extends ValidationElement {
             layout={Location.ADDRESS}
             geocode={true}
             className="delinquent-courtaddress"
+            showPostOffice={true}
             dispatch={this.props.dispatch}
             addressBooks={this.props.addressBooks}
             addressBook="Court"

--- a/src/components/Section/Foreign/Activities/CoOwner.jsx
+++ b/src/components/Section/Foreign/Activities/CoOwner.jsx
@@ -87,6 +87,7 @@ export default class CoOwner extends ValidationElement {
             geocode={true}
             addressBooks={this.props.addressBooks}
             addressBook="ForeignNational"
+            showPostOffice={true}
             dispatch={this.props.dispatch}
             onUpdate={this.updateAddress}
             onError={this.props.onError}

--- a/src/components/Section/Foreign/Activities/SupportItem.jsx
+++ b/src/components/Section/Foreign/Activities/SupportItem.jsx
@@ -113,6 +113,7 @@ export default class SupportItem extends ValidationElement {
             layout={Location.ADDRESS}
             geocode={true}
             addressBook="ForeignNational"
+            showPostOffice={true}
             addressBooks={this.props.addressBooks}
             dispatch={this.props.dispatch}
             required={this.props.required}

--- a/src/components/Section/Foreign/Business/JobOffer.jsx
+++ b/src/components/Section/Foreign/Business/JobOffer.jsx
@@ -128,6 +128,7 @@ export default class JobOffer extends ValidationElement {
             label={i18n.t('foreign.business.employment.label.address')}
             layout={Location.US_CITY_STATE_ZIP_INTERNATIONAL_CITY}
             className="employment-address"
+            showPostOffice={true}
             onUpdate={this.updateAddress}
             onError={this.props.onError}
             required={this.props.required}

--- a/src/components/Section/Foreign/Business/SponsorshipItem.jsx
+++ b/src/components/Section/Foreign/Business/SponsorshipItem.jsx
@@ -229,6 +229,7 @@ export default class SponsorshipItem extends ValidationElement {
             className="foreign-business-sponsorship-address"
             layout={Location.ADDRESS}
             geocode={true}
+            showPostOffice={true}
             addressBooks={this.props.addressBooks}
             addressBook="ForeignNational"
             dispatch={this.props.dispatch}

--- a/src/components/Section/Foreign/Business/VenturesItem.jsx
+++ b/src/components/Section/Foreign/Business/VenturesItem.jsx
@@ -143,6 +143,7 @@ export default class VenturesItem extends ValidationElement {
             onError={this.props.onError}
             className="ventures-address"
             layout={Location.ADDRESS}
+            showPostOffice={true}
             addressBooks={this.props.addressBooks}
             addressBook="ForeignNational"
             dispatch={this.props.dispatch}

--- a/src/components/Section/Foreign/Contacts/ForeignNational.jsx
+++ b/src/components/Section/Foreign/Contacts/ForeignNational.jsx
@@ -671,6 +671,7 @@ export default class ForeignNational extends ValidationElement {
               geocode={true}
               addressBooks={this.props.addressBooks}
               addressBook="ForeignNational"
+              showPostOffice={true}
               dispatch={this.props.dispatch}
               onUpdate={this.updateAddress}
               onError={this.props.onError}

--- a/src/components/Section/Foreign/Contacts/ForeignNational.jsx
+++ b/src/components/Section/Foreign/Contacts/ForeignNational.jsx
@@ -725,6 +725,7 @@ export default class ForeignNational extends ValidationElement {
               geocode={true}
               addressBooks={this.props.addressBooks}
               addressBook="Company"
+              showPostOffice={true}
               dispatch={this.props.dispatch}
               onUpdate={this.updateEmployerAddress}
               onError={this.props.onError}

--- a/src/components/Section/History/Education/EducationItem.jsx
+++ b/src/components/Section/History/Education/EducationItem.jsx
@@ -252,6 +252,7 @@ export default class EducationItem extends ValidationElement {
               addressBooks={this.props.addressBooks}
               addressBook="Education"
               geocode={true}
+              showPostOffice={true}
               onUpdate={this.updateAddress}
               onError={this.props.onError}
               required={this.props.required}
@@ -404,6 +405,7 @@ export default class EducationItem extends ValidationElement {
                     geocode={true}
                     addressBooks={this.props.addressBooks}
                     addressBook="Reference"
+                    showPostOffice={true}
                     dispatch={this.props.dispatch}
                     onUpdate={this.updateReferenceAddress}
                     onError={this.props.onError}

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -402,6 +402,7 @@ export default class EmploymentItem extends ValidationElement {
               geocode={true}
               addressBooks={this.props.addressBooks}
               addressBook="Employment"
+              showPostOffice={true}
               dispatch={this.props.dispatch}
               onUpdate={this.updateAddress}
               onError={this.props.onError}
@@ -515,6 +516,7 @@ export default class EmploymentItem extends ValidationElement {
                   geocode={true}
                   addressBooks={this.props.addressBooks}
                   addressBook="Reference"
+                  showPostOffice={true}
                   dispatch={this.props.dispatch}
                   onUpdate={this.updateReferenceAddress}
                   onError={this.props.onError}

--- a/src/components/Section/History/Employment/PhysicalAddress.jsx
+++ b/src/components/Section/History/Employment/PhysicalAddress.jsx
@@ -99,6 +99,7 @@ export default class PhysicalAddress extends ValidationElement {
               geocode={true}
               addressBooks={this.props.addressBooks}
               addressBook={this.props.addressBook}
+              showPostOffice={true}
               dispatch={this.props.dispatch}
               onUpdate={this.updateAddress}
               onError={this.props.onError}

--- a/src/components/Section/History/Employment/Supervisor.jsx
+++ b/src/components/Section/History/Employment/Supervisor.jsx
@@ -149,6 +149,7 @@ export default class Supervisor extends ValidationElement {
             geocode={true}
             addressBooks={this.props.addressBooks}
             addressBook={this.props.addressBook}
+            showPostOffice={true}
             dispatch={this.props.dispatch}
             onUpdate={this.updateAddress}
             onError={this.props.onError}

--- a/src/components/Section/History/Federal/FederalItem.jsx
+++ b/src/components/Section/History/Federal/FederalItem.jsx
@@ -111,6 +111,7 @@ export default class FederalItem extends ValidationElement {
             geocode={true}
             addressBooks={this.props.addressBooks}
             addressBook="Agency"
+            showPostOffice={true}
             dispatch={this.props.dispatch}
             required={this.props.required}
           />

--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -264,6 +264,7 @@ export default class ResidenceItem extends ValidationElement {
             geocode={true}
             addressBook="Residence"
             addressBooks={this.props.addressBooks}
+            showPostOffice={true}
             dispatch={this.props.dispatch}
             onUpdate={this.updateAddress}
             onError={this.props.onError}
@@ -581,6 +582,7 @@ export default class ResidenceItem extends ValidationElement {
                   geocode={true}
                   addressBooks={this.props.addressBooks}
                   addressBook="Reference"
+                  showPostOffice={true}
                   dispatch={this.props.dispatch}
                   onUpdate={this.updateReferenceAddress}
                   onError={this.props.onError}

--- a/src/components/Section/Legal/NonCriminalCourtAction.jsx
+++ b/src/components/Section/Legal/NonCriminalCourtAction.jsx
@@ -102,6 +102,7 @@ export default class NonCriminalCourtAction extends ValidationElement {
             geocode={true}
             addressBooks={this.props.addressBooks}
             addressBook="Court"
+            showPostOffice={true}
             dispatch={this.props.dispatch}
             onUpdate={this.updateCourtAddress}
             onError={this.props.onError}

--- a/src/components/Section/Legal/Technology/ManipulatingItem.jsx
+++ b/src/components/Section/Legal/Technology/ManipulatingItem.jsx
@@ -98,6 +98,7 @@ export default class ManipulatingItem extends ValidationElement {
             className="legal-technology-manipulating-location"
             layout={Location.ADDRESS}
             geocode={true}
+            showPostOffice={true}
             addressBooks={this.props.addressBooks}
             addressBook="Incident"
             dispatch={this.props.dispatch}

--- a/src/components/Section/Legal/Technology/UnauthorizedItem.jsx
+++ b/src/components/Section/Legal/Technology/UnauthorizedItem.jsx
@@ -98,6 +98,7 @@ export default class UnauthorizedItem extends ValidationElement {
             className="legal-technology-unauthorized-location"
             layout={Location.ADDRESS}
             geocode={true}
+            showPostOffice={true}
             addressBooks={this.props.addressBooks}
             addressBook="Incident"
             dispatch={this.props.dispatch}

--- a/src/components/Section/Legal/Technology/UnlawfulItem.jsx
+++ b/src/components/Section/Legal/Technology/UnlawfulItem.jsx
@@ -98,6 +98,7 @@ export default class UnlawfulItem extends ValidationElement {
             className="legal-technology-unlawful-location"
             layout={Location.ADDRESS}
             geocode={true}
+            showPostOffice={true}
             addressBooks={this.props.addressBooks}
             addressBook="Incident"
             dispatch={this.props.dispatch}

--- a/src/components/Section/Psychological/AppealItem.jsx
+++ b/src/components/Section/Psychological/AppealItem.jsx
@@ -77,6 +77,7 @@ export class AppealItem extends ValidationElement {
             geocode={true}
             addressBooks={this.props.addressBooks}
             addressBook="Court"
+            showPostOffice={true}
             onUpdate={this.updateCourtAddress}
             onError={this.props.onError}
             required={this.props.required}

--- a/src/components/Section/Psychological/Hospitalizations/Hospitalization.jsx
+++ b/src/components/Section/Psychological/Hospitalizations/Hospitalization.jsx
@@ -158,6 +158,7 @@ export default class Hospitalization extends ValidationElement {
             label={i18n.t(`psychological.hospitalization.label.address`)}
             layout={Location.ADDRESS}
             geocode={true}
+            showPostOffice={true}
             onUpdate={this.updateFacilityAddress}
             onError={this.props.onError}
             required={this.props.required}

--- a/src/components/Section/Psychological/Order.jsx
+++ b/src/components/Section/Psychological/Order.jsx
@@ -114,6 +114,7 @@ export default class Order extends ValidationElement {
             geocode={true}
             addressBooks={this.props.addressBooks}
             addressBook="Court"
+            showPostOffice={true}
             dispatch={this.props.dispatch}
             onUpdate={this.updateCourtAddress}
             onError={this.props.onError}

--- a/src/components/Section/Psychological/Treatment.jsx
+++ b/src/components/Section/Psychological/Treatment.jsx
@@ -84,6 +84,7 @@ export default class Treatment extends ValidationElement {
             geocode={true}
             addressBooks={this.props.addressBooks}
             addressBook="Facility"
+            showPostOffice={true}
             dispatch={this.props.dispatch}
             onUpdate={this.updateAddress}
             onError={this.props.onError}

--- a/src/components/Section/Relationships/People/Person.jsx
+++ b/src/components/Section/Relationships/People/Person.jsx
@@ -362,6 +362,7 @@ export default class Person extends React.Component {
             dispatch={this.props.dispatch}
             layout={Location.ADDRESS}
             geocode={true}
+            showPostOffice={true}
             onUpdate={this.updateAddress}
             onError={this.props.onError}
             required={this.props.required}

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -405,6 +405,7 @@ export default class CivilUnion extends ValidationElement {
                   geocode={true}
                   addressBooks={this.props.addressBooks}
                   addressBook="Relative"
+                  showPostOffice={true}
                   dispatch={this.props.dispatch}
                   onUpdate={this.updateAddress}
                   onError={this.props.onError}
@@ -420,6 +421,7 @@ export default class CivilUnion extends ValidationElement {
                 geocode={true}
                 addressBooks={this.props.addressBooks}
                 addressBook="Relative"
+                showPostOffice={true}
                 dispatch={this.props.dispatch}
                 onUpdate={this.updateAddress}
                 onError={this.props.onError}
@@ -504,6 +506,7 @@ export default class CivilUnion extends ValidationElement {
                       'relationships.civilUnion.label.addressSeparated'
                     )}
                     layout={Location.US_CITY_STATE_ZIP_INTERNATIONAL_CITY}
+                    showPostOffice={true}
                     onUpdate={this.updateAddressSeparated}
                     onError={this.props.onError}
                     required={this.props.required}

--- a/src/components/Section/Relationships/RelationshipStatus/Divorce.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Divorce.jsx
@@ -378,6 +378,7 @@ export default class Divorce extends React.Component {
                     {...this.props.DeceasedAddress}
                     layout={Location.ADDRESS}
                     geocode={true}
+                    showPostOffice={true}
                     onUpdate={this.updateDeceasedAddress}
                     onError={this.props.onError}
                     required={this.props.required}

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -680,6 +680,7 @@ export default class Relative extends ValidationElement {
               dispatch={this.props.dispatch}
               layout={Location.ADDRESS}
               geocode={true}
+              showPostOffice={true}
               onUpdate={this.updateAddress}
               onError={this.props.onError}
               required={this.props.required}
@@ -1258,7 +1259,6 @@ export default class Relative extends ValidationElement {
                 <Location
                   name="EmployerAddress"
                   {...this.props.EmployerAddress}
-                  showPostOffice={false}
                   layout={Location.ADDRESS}
                   geocode={true}
                   className="relative-employer-address"

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -1262,6 +1262,7 @@ export default class Relative extends ValidationElement {
                   layout={Location.ADDRESS}
                   geocode={true}
                   className="relative-employer-address"
+                  showPostOffice={true}
                   onError={this.props.onError}
                   onUpdate={this.updateEmployerAddress}
                   required={this.props.required}

--- a/src/components/Section/SubstanceUse/Alcohol/OrderedCounseling.jsx
+++ b/src/components/Section/SubstanceUse/Alcohol/OrderedCounseling.jsx
@@ -282,6 +282,7 @@ export default class OrderedCounseling extends ValidationElement {
                 geocode={true}
                 addressBooks={this.props.addressBooks}
                 addressBook="Provider"
+                showPostOffice={true}
                 dispatch={this.props.dispatch}
                 onUpdate={this.updateTreatmentProviderAddress}
                 onError={this.props.onError}

--- a/src/components/Section/SubstanceUse/Alcohol/ReceivedCounseling.jsx
+++ b/src/components/Section/SubstanceUse/Alcohol/ReceivedCounseling.jsx
@@ -173,6 +173,7 @@ export default class ReceivedCounseling extends ValidationElement {
             {...this.props.TreatmentProviderAddress}
             layout={Location.ADDRESS}
             geocode={true}
+            showPostOffice={true}
             onUpdate={this.updateTreatmentProviderAddress}
             onError={this.props.onError}
             required={this.props.required}
@@ -221,6 +222,7 @@ export default class ReceivedCounseling extends ValidationElement {
               {...this.props.AgencyAddress}
               layout={Location.ADDRESS}
               geocode={true}
+              showPostOffice={true}
               onUpdate={this.updateAgencyAddress}
               required={this.props.required}
               onError={this.props.onError}

--- a/src/components/Section/SubstanceUse/Alcohol/VoluntaryCounseling.jsx
+++ b/src/components/Section/SubstanceUse/Alcohol/VoluntaryCounseling.jsx
@@ -123,6 +123,7 @@ export default class VoluntaryCounseling extends ValidationElement {
             geocode={true}
             addressBooks={this.props.addressBooks}
             addressBook="Provider"
+            showPostOffice={true}
             dispatch={this.props.dispatch}
             onUpdate={this.updateTreatmentProviderAddress}
             onError={this.props.onError}

--- a/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.jsx
+++ b/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.jsx
@@ -265,6 +265,7 @@ export default class OrderedTreatment extends ValidationElement {
                 geocode={true}
                 addressBooks={this.props.addressBooks}
                 addressBook="Provider"
+                showPostOffice={true}
                 dispatch={this.props.dispatch}
                 onUpdate={this.updateTreatmentProviderAddress}
                 onError={this.props.onError}

--- a/src/components/Section/SubstanceUse/Drugs/VoluntaryTreatment.jsx
+++ b/src/components/Section/SubstanceUse/Drugs/VoluntaryTreatment.jsx
@@ -123,6 +123,7 @@ export default class VoluntaryTreatment extends ValidationElement {
             geocode={true}
             addressBooks={this.props.addressBooks}
             addressBook="Provider"
+            showPostOffice={true}
             dispatch={this.props.dispatch}
             onUpdate={this.updateTreatmentProviderAddress}
             onError={this.props.onError}


### PR DESCRIPTION
Closes #861 
Closes #899 
Closes #863

Reviewed the validation matrix and sf86 form to verify all the applicable APO/FPO address fields.

List of effected sections and subsections.
```
- Where have you lived
- Employment Activities 
  - Employer Address
  - Supervisor Address
- Marital/Relationship Status
  - Civil union (together or separated) resident address
- Foreign Contacts
  - Resident address
- Relatives
  - Resident address not deceased living in the united states 
```