### PR TITLE
Add year only option to datecontrol component

### DIFF
--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -68,7 +68,7 @@ export default class DateControl extends ValidationElement {
       error: props.error,
       valid: props.valid,
       maxDate: props.maxDate,
-      month: props.month || datePart('m', props.value),
+      month: props.hideMonth ? '1' : props.month || datePart('m', props.value),
       day: props.hideDay ? '1' : props.day || datePart('d', props.value),
       year: props.year || datePart('y', props.value),
       errors: []
@@ -325,15 +325,20 @@ export default class DateControl extends ValidationElement {
   }
 
   render() {
-    let klass = `datecontrol ${
+    let klass = `${
+      this.props.hideMonth && this.props.hideDay ? '' : 'datecontrol'
+    } ${
       this.state.error && !this.props.overrideError ? 'usa-input-error' : ''
     } ${this.props.className || ''} ${
-      this.props.hideDay ? 'day-hidden' : ''
-    }`.trim()
+      this.props.hideMonth ? 'month-hidden' : ''
+    } ${this.props.hideDay ? 'day-hidden' : ''}`.trim()
     return (
       <div className={klass}>
         <div>
-          <div className="usa-form-group month">
+          <div
+            className={`usa-form-group month ${
+              this.props.hideMonth === true ? 'hidden' : ''
+            }`.trim()}>
             <Number
               id="month"
               name="month"
@@ -345,7 +350,7 @@ export default class DateControl extends ValidationElement {
               maxlength="2"
               min="1"
               readonly={this.props.readonly}
-              required={this.props.required}
+              required={!this.props.hideMonth && this.props.required}
               step="1"
               receiveProps="true"
               value={this.state.month}
@@ -443,6 +448,7 @@ DateControl.defaultProps = {
   error: false,
   valid: false,
   hideDay: false,
+  hideMonth: false,
   month: '',
   day: '',
   year: '',

--- a/src/components/Form/DateControl/DateControl.scss
+++ b/src/components/Form/DateControl/DateControl.scss
@@ -32,3 +32,9 @@
     display: none;
   }
 }
+
+.datecontrol.month-hidden {
+  .month {
+    display: none;
+  }
+}

--- a/src/components/Section/Financial/Taxes/Taxes.test.jsx
+++ b/src/components/Section/Financial/Taxes/Taxes.test.jsx
@@ -47,7 +47,7 @@ describe('The taxes component', () => {
       .simulate('change')
     component.find('.failure-file input').simulate('change')
     component
-      .find('.taxes-year input[type="text"]')
+      .find('.taxes-year .year input')
       .simulate('change', { target: { value: '2000' } })
     component
       .find('.taxes-reason textarea')

--- a/src/components/Section/Financial/Taxes/TaxesItem.jsx
+++ b/src/components/Section/Financial/Taxes/TaxesItem.jsx
@@ -136,12 +136,13 @@ export default class TaxesItem extends ValidationElement {
         <Field
           title={i18n.t('financial.taxes.heading.year')}
           scrollIntoView={this.props.scrollIntoView}>
-          <Number
+          <DateControl
             name="Year"
             {...this.props.Year}
             className="taxes-year"
-            placeholder={i18n.t('date.placeholder.year')}
-            prefix="date"
+            hideMonth={true}
+            hideDay={true}
+            showEstimated={false}
             min={minYearFiled.minDate.getFullYear()}
             required={this.props.required}
             onUpdate={this.updateYear}

--- a/src/components/Section/Financial/Taxes/TaxesItem.test.jsx
+++ b/src/components/Section/Financial/Taxes/TaxesItem.test.jsx
@@ -13,7 +13,7 @@ describe('The taxes item component', () => {
     }
     const component = mount(<TaxesItem {...expected} />)
     component
-      .find('.taxes-year input[type="text"]')
+      .find('.taxes-year .year input')
       .simulate('change', { target: { value: '2000' } })
     component
       .find('.taxes-reason textarea')

--- a/src/validators/datecontrol.js
+++ b/src/validators/datecontrol.js
@@ -19,6 +19,7 @@ export default class DateControlValidator {
     this.month = data.month
     this.day = data.day
     this.year = data.year
+    this.hideMonth = data.hideMonth
     this.hideDay = data.hideDay
     this.maxDate = data.maxDate
     this.maxDateEqualTo = data.maxDateEqualTo || false
@@ -38,12 +39,16 @@ export default class DateControlValidator {
     }
 
     // For month/year fields, we compare from the start of the month
-    if (this.hideDay) {
+    if (this.hideMonth || this.hideDay) {
       this.maxDate = new Date(
-        `${this.maxDate.getMonth() + 1}/1/${this.maxDate.getFullYear()}`
+        `${this.hideMonth ? '1' : this.maxDate.getMonth() + 1}/${
+          this.hideDay ? '1' : this.maxDate.getDate()
+        }/${this.maxDate.getFullYear()}`
       )
       this.minDate = new Date(
-        `${this.minDate.getMonth() + 1}/1/${this.minDate.getFullYear()}`
+        `${this.hideMonth ? '1' : this.minDate.getMonth() + 1}/${
+          this.hideDay ? '1' : this.minDate.getDate()
+        }/${this.minDate.getFullYear()}`
       )
     }
   }
@@ -89,7 +94,11 @@ export default class DateControlValidator {
   }
 
   isValid() {
-    if ((!this.day && !this.hideDay) || !this.month || !this.year) {
+    if (
+      (!this.day && !this.hideDay) ||
+      (!this.month && !this.hideMonth) ||
+      !this.year
+    ) {
       return false
     }
 

--- a/src/validators/datecontrol.test.js
+++ b/src/validators/datecontrol.test.js
@@ -28,6 +28,25 @@ describe('date control validator', function() {
           hideDay: true
         },
         expected: true
+      },
+      {
+        data: {
+          month: '',
+          day: '1',
+          year: '2005',
+          hideMonth: true
+        },
+        expected: true
+      },
+      {
+        data: {
+          month: '',
+          day: '',
+          year: '2005',
+          hideMonth: true,
+          hideDay: true
+        },
+        expected: true
       }
     ]
 
@@ -166,6 +185,50 @@ describe('date control validator', function() {
           year: '2004',
           minDate: new Date('1/1/2004'),
           minDateEqualTo: true,
+          hideDay: true
+        },
+        expected: true
+      },
+      {
+        data: {
+          month: '1',
+          day: '1',
+          year: '2004',
+          minDate: new Date('1/1/2004'),
+          hideMonth: true
+        },
+        expected: false
+      },
+      {
+        data: {
+          month: '1',
+          day: '1',
+          year: '2004',
+          minDate: new Date('1/1/2004'),
+          minDateEqualTo: true,
+          hideMonth: true
+        },
+        expected: true
+      },
+      {
+        data: {
+          month: '1',
+          day: '1',
+          year: '2004',
+          minDate: new Date('1/1/2004'),
+          hideMonth: true,
+          hideDay: true
+        },
+        expected: false
+      },
+      {
+        data: {
+          month: '1',
+          day: '1',
+          year: '2004',
+          minDate: new Date('1/1/2004'),
+          minDateEqualTo: true,
+          hideMonth: true,
           hideDay: true
         },
         expected: true


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/859

This enables the `datecontrol` component to collect the year only as in the case of the question `Provide the year you failed to file or pay your federal, state, or other taxes (Estimated)`, inheriting all of the date validation logic rather than being forced to use a text input.

**Before:**
<img width="523" alt="screen shot 2018-09-28 at 1 43 39 pm" src="https://user-images.githubusercontent.com/1178494/46224459-72f99b80-c324-11e8-8230-8926dacd0c5a.png">

**After:**
<img width="519" alt="screen shot 2018-09-28 at 1 42 22 pm" src="https://user-images.githubusercontent.com/1178494/46224476-7b51d680-c324-11e8-8e9e-34b029fb5d53.png">
