### PR TITLE
Make mother and father-in-law required when married or separated

### DIFF
--- a/src/components/Section/Package/__snapshots__/Print.test.jsx.snap
+++ b/src/components/Section/Package/__snapshots__/Print.test.jsx.snap
@@ -5699,6 +5699,49 @@ exports[`The print section renders properly 1`] = `
               </span>
             </div>
           </div>
+          <div
+            aria-label=""
+            className="field required  hidden"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                />
+              </span>
+            </div>
+          </div>
           <div>
             <div
               className="accordion"

--- a/src/components/Section/Relationships/Relatives/Relatives.jsx
+++ b/src/components/Section/Relationships/Relatives/Relatives.jsx
@@ -49,6 +49,10 @@ export default class Relatives extends SubsectionElement {
     })
   }
 
+  validMaritalRelations() {
+    return new RelativesValidator(this.props).validMaritalRelations()
+  }
+
   validRelations() {
     return new RelativesValidator(this.props).validMinimumRelations()
   }
@@ -69,6 +73,16 @@ export default class Relatives extends SubsectionElement {
         <Field
           errors={[{ code: 'validRelation', valid: this.validRelations() }]}
           className={this.validRelations() && 'hidden'}
+        />
+
+        <Field
+          errors={[
+            {
+              code: 'validMaritalRelation',
+              valid: this.validMaritalRelations()
+            }
+          ]}
+          className={this.validMaritalRelations() && 'hidden'}
         />
 
         <Accordion

--- a/src/components/Section/__snapshots__/Section.test.jsx.snap
+++ b/src/components/Section/__snapshots__/Section.test.jsx.snap
@@ -28603,6 +28603,49 @@ exports[`The section component renders relationships.relatives 1`] = `
                         </span>
                       </div>
                     </div>
+                    <div
+                      aria-label=""
+                      className="field required  hidden"
+                      data-uuid="field-MOCK-GUID"
+                    >
+                      <a
+                        aria-hidden="true"
+                        className="anchor"
+                        id="field-MOCK-GUID"
+                        name="field-MOCK-GUID"
+                      />
+                      <span
+                        className="icon"
+                      />
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages help-messages"
+                        />
+                      </div>
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages error-messages"
+                          role="alert"
+                        />
+                      </div>
+                      <div
+                        className="table"
+                      >
+                        <span
+                          className="content"
+                        >
+                          <span
+                            className="component"
+                          />
+                        </span>
+                      </div>
+                    </div>
                     <div>
                       <div
                         className="accordion"
@@ -29632,6 +29675,49 @@ exports[`The section component renders relationships.review 1`] = `
                               </p>
                             </div>
                           </span>
+                        </span>
+                      </div>
+                    </div>
+                    <div
+                      aria-label=""
+                      className="field required  hidden"
+                      data-uuid="field-MOCK-GUID"
+                    >
+                      <a
+                        aria-hidden="true"
+                        className="anchor"
+                        id="field-MOCK-GUID"
+                        name="field-MOCK-GUID"
+                      />
+                      <span
+                        className="icon"
+                      />
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages help-messages"
+                        />
+                      </div>
+                      <div
+                        className="table expand"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="messages error-messages"
+                          role="alert"
+                        />
+                      </div>
+                      <div
+                        className="table"
+                      >
+                        <span
+                          className="content"
+                        >
+                          <span
+                            className="component"
+                          />
                         </span>
                       </div>
                     </div>

--- a/src/components/Section/extractors.js
+++ b/src/components/Section/extractors.js
@@ -12,6 +12,15 @@ export const extractApplicantBirthdate = app => {
   return new Date(`${date.month}/${date.day}/${date.year}`)
 }
 
+export const extractMaritalStatus = app => {
+  const section = (app.Relationships || {}).Marital || {}
+  if (!section.Status) {
+    return null
+  }
+
+  return section.Status.value
+}
+
 export const extractOtherNames = app => {
   let names = []
   let identification = app.Identification

--- a/src/components/Section/extractors.test.js
+++ b/src/components/Section/extractors.test.js
@@ -1,4 +1,4 @@
-import { extractApplicantBirthdate } from './extractors'
+import { extractApplicantBirthdate, extractMaritalStatus } from './extractors'
 
 describe('Extractors', function() {
   it('should return a date', function() {
@@ -49,6 +49,45 @@ describe('Extractors', function() {
 
     tests.forEach(test => {
       expect(extractApplicantBirthdate(test.state)).toEqual(test.expected)
+    })
+  })
+
+  it('should return a marital status', function() {
+    const tests = [
+      {
+        state: {
+          Relationships: {
+            Marital: {
+              Status: null
+            }
+          }
+        },
+        expected: null
+      },
+      {
+        state: {
+          Relationships: {
+            Marital: null
+          }
+        },
+        expected: null
+      },
+      {
+        state: {
+          Relationships: {
+            Marital: {
+              Status: {
+                value: 'Married'
+              }
+            }
+          }
+        },
+        expected: 'Married'
+      }
+    ]
+
+    tests.forEach(test => {
+      expect(extractMaritalStatus(test.state)).toEqual(test.expected)
     })
   })
 })

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -1070,6 +1070,11 @@ export const error = {
     message:
       'There was a problem submitting your SF-86. Please contact support for additional information.'
   },
+  validMaritalRelation: {
+    title: 'Mother-in-law and father-in-law must be provided',
+    message:
+      'You indicated that you are married or separated, please provide entries for mother-in-law and father-in-law.'
+  },
   validRelation: {
     title: 'Mother and father must be provided',
     message:

--- a/src/validators/relatives.js
+++ b/src/validators/relatives.js
@@ -60,7 +60,7 @@ export default class RelativesValidator {
     const requiredRelations = ['Father', 'Mother']
 
     if ((this.list.branch || {}).value === 'No') {
-      if (this.list.items || {}.length > 0) {
+      if ((this.list.items || {}).length > 0) {
         let relations = []
         for (const item of this.list.items) {
           if (!item || !item.Item || !item.Item.Relation) {

--- a/src/validators/relatives.js
+++ b/src/validators/relatives.js
@@ -39,7 +39,7 @@ export default class RelativesValidator {
     }
 
     if ((this.list.branch || {}).value === 'No') {
-      if (this.list.items || {}.length > 0) {
+      if ((this.list.items || {}).length > 0) {
         let relations = []
         for (const item of this.list.items) {
           if (!item || !item.Item || !item.Item.Relation) {

--- a/src/validators/relatives.js
+++ b/src/validators/relatives.js
@@ -1,11 +1,20 @@
+import store from '../services/store'
 import NameValidator from './name'
 import LocationValidator, { isInternational, countryString } from './location'
+import { extractMaritalStatus } from '../components/Section/extractors'
 import DateRangeValidator from './daterange'
 import {
   validAccordion,
   validDateField,
   validGenericTextfield
 } from './helpers'
+
+export const getContext = () => {
+  const state = store.getState()
+  const app = state.application || {}
+
+  return extractMaritalStatus(app)
+}
 
 export default class RelativesValidator {
   constructor(data = {}) {
@@ -18,11 +27,40 @@ export default class RelativesValidator {
     })
   }
 
+  validMaritalRelations(context = null) {
+    const maritalStatuses = ['Married', 'Separated']
+    const requiredRelations = ['Father-in-law', 'Mother-in-law']
+    const maritalStatus = context || getContext()
+
+    console.log(maritalStatus)
+
+    if (!maritalStatus || !maritalStatuses.includes(maritalStatus)) {
+      return true
+    }
+
+    if ((this.list.branch || {}).value === 'No') {
+      if (this.list.items || {}.length > 0) {
+        let relations = []
+        for (const item of this.list.items) {
+          if (!item || !item.Item || !item.Item.Relation) {
+            continue
+          }
+          relations.push(item.Item.Relation.value)
+        }
+        if (relations.length > 0) {
+          return requiredRelations.every(r => relations.includes(r))
+        }
+      }
+      return false
+    }
+    return true
+  }
+
   validMinimumRelations() {
     const requiredRelations = ['Father', 'Mother']
 
     if ((this.list.branch || {}).value === 'No') {
-      if (this.list.items && this.list.items.length > 0) {
+      if (this.list.items || {}.length > 0) {
         let relations = []
         for (const item of this.list.items) {
           if (!item || !item.Item || !item.Item.Relation) {
@@ -40,7 +78,11 @@ export default class RelativesValidator {
   }
 
   isValid() {
-    return this.validItems() && this.validMinimumRelations()
+    return (
+      this.validItems() &&
+      this.validMaritalRelations() &&
+      this.validMinimumRelations()
+    )
   }
 }
 

--- a/src/validators/relatives.test.js
+++ b/src/validators/relatives.test.js
@@ -2081,4 +2081,101 @@ describe('Relatives validation', function() {
       )
     })
   })
+
+  it('validates that a mother-in-law and father-in-law have been provided if married', () => {
+    const tests = [
+      {
+        data: {
+          List: {
+            branch: { value: 'No' },
+            items: [
+              {
+                Item: {
+                  Relation: {
+                    value: 'Mother-in-law'
+                  }
+                }
+              },
+              {
+                Item: {
+                  Relation: {
+                    value: 'Father-in-law'
+                  }
+                }
+              }
+            ]
+          }
+        },
+        context: 'Married',
+        expected: true
+      },
+      {
+        data: {
+          List: {
+            branch: { value: 'No' },
+            items: [
+              {
+                Item: {
+                  Relation: {
+                    value: 'Mother-in-law'
+                  }
+                }
+              },
+              {
+                Item: {
+                  Relation: {
+                    value: 'Father-in-law'
+                  }
+                }
+              }
+            ]
+          }
+        },
+        context: 'Separated',
+        expected: true
+      },
+      {
+        data: {
+          List: {
+            branch: { value: 'No' },
+            items: [
+              {
+                Item: {
+                  Relation: {
+                    value: 'Mother-in-law'
+                  }
+                }
+              }
+            ]
+          }
+        },
+        context: 'Married',
+        expected: false
+      },
+      {
+        data: {
+          List: {
+            branch: { value: 'No' },
+            items: [
+              {
+                Item: {
+                  Relation: {
+                    value: 'Father-in-law'
+                  }
+                }
+              }
+            ]
+          }
+        },
+        context: 'Separated',
+        expected: false
+      }
+    ]
+
+    tests.forEach(test => {
+      expect(
+        new RelativesValidator(test.data).validMaritalRelations(test.context)
+      ).toBe(test.expected)
+    })
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/653

Integrates marriage status into relatives validator. If applicant indicates that they are `Married` or `Separated` they will be required to add a mother-in-law and father-in-law as relatives.

**After:**
![screen shot 2018-10-02 at 4 05 47 pm](https://user-images.githubusercontent.com/1178494/46376787-e96c0580-c664-11e8-9655-44fa35ac883c.png)

As with https://github.com/18F/e-QIP-prototype/pull/757 I think we will need to revisit how these collection based errors are handled so that they are all done in a consistent way. 