### PR TITLE
Remove question from existing conditions

### DIFF
--- a/src/components/Section/Psychological/Diagnoses/Diagnosis.jsx
+++ b/src/components/Section/Psychological/Diagnoses/Diagnosis.jsx
@@ -79,20 +79,10 @@ export default class Diagnosis extends ValidationElement {
     const applicantBirthdate = getContext().applicantBirthdate
     return (
       <div className="diagnosis">
-        <Field
-          title={i18n.t(`psychological.${prefix}.heading.condition`)}
-          scrollIntoView={this.props.scrollIntoView}>
-          <Show when={this.props.prefix === 'existingConditions.diagnosis'}>
-            <Text
-              name="Condition"
-              className="diagnosis-condition"
-              {...this.props.Condition}
-              onUpdate={this.updateCondition}
-              onError={this.props.onError}
-              required={this.props.required}
-            />
-          </Show>
-          <Show when={this.props.prefix === 'diagnosis'}>
+        <Show when={this.props.prefix !== 'existingConditions.diagnosis'}>
+          <Field
+            title={i18n.t(`psychological.diagnosis.heading.condition`)}
+            scrollIntoView={this.props.scrollIntoView}>
             <RadioGroup
               className="diagnosis-condition"
               onError={this.props.onError}
@@ -155,8 +145,8 @@ export default class Diagnosis extends ValidationElement {
                 onError={this.props.onError}
               />
             </RadioGroup>
-          </Show>
-        </Field>
+          </Field>
+        </Show>
 
         <Field
           title={i18n.t(`psychological.${prefix}.heading.diagnosed`)}

--- a/src/components/Section/Psychological/ExistingConditions/ExistingConditions.test.jsx
+++ b/src/components/Section/Psychological/ExistingConditions/ExistingConditions.test.jsx
@@ -70,4 +70,15 @@ describe('The ExistingConditions component', () => {
         .length
     ).toBe(0)
   })
+
+  it('Does not ask to identify existing conditions', () => {
+    const props = {
+      HasCondition: { value: 'Yes' },
+      ReceivedTreatment: { value: 'Yes' },
+      DidNotFollow: { value: 'No' },
+      prefix: { value: 'existingConditions.diagnosis' }
+    }
+    const component = mount(<ExistingConditions {...props} />)
+    expect(component.find('.diagnosis-condition').length).toBe(0)
+  })
 })

--- a/src/config/locales/en/psychological.js
+++ b/src/config/locales/en/psychological.js
@@ -485,7 +485,6 @@ export const psychological = {
     },
     diagnosis: {
       heading: {
-        condition: 'Identify the diagnosis or health condition',
         diagnosed: 'Provide the dates of counseling or treatment',
         healthcareProfessional: 'Health care professional info',
         effective:
@@ -494,11 +493,6 @@ export const psychological = {
         explanation: 'Provide explanation'
       },
       help: {
-        condition: {
-          title: 'Need help with health condition',
-          message: 'Provide the name of the diagnosis or health condition',
-          note: ''
-        },
         diagnosed: {
           title:
             'Provide the full date range (start to finish) of your counseling or treatment',

--- a/src/validators/diagnosis.js
+++ b/src/validators/diagnosis.js
@@ -13,6 +13,18 @@ export default class DiagnosisValidator {
     this.prefix = (data || {}).prefix
   }
 
+  validCondition() {
+    if (this.prefix === 'existingConditions.diagnosis') {
+      return true
+    }
+
+    if (!this.condition) {
+      return false
+    }
+
+    return true
+  }
+
   validEffective() {
     if (this.prefix === 'existingConditions.diagnosis') {
       return true
@@ -31,7 +43,7 @@ export default class DiagnosisValidator {
 
   isValid() {
     return (
-      !!this.condition &&
+      this.validCondition() &&
       new DateRangeValidator(this.diagnosed).isValid() &&
       new TreatmentValidator(this.treatment).isValid() &&
       new TreatmentValidator(this.treatmentFacility).isValid() &&
@@ -43,7 +55,6 @@ export default class DiagnosisValidator {
 export class ExistingConditionsDiagnosisValidator extends DiagnosisValidator {
   constructor(data = {}) {
     super(data)
-    this.condition = data.Condition || ''
     this.diagnosed = data.Diagnosed || {}
     this.treatment = data.Treatment || {}
     this.effective = data.Effective || {}

--- a/src/validators/diagnosis.test.js
+++ b/src/validators/diagnosis.test.js
@@ -2,6 +2,41 @@ import DiagnosisValidator from './diagnosis'
 import Location from '../components/Form/Location'
 
 describe('Diagnosis validation', function() {
+  it('validates condition', () => {
+    const tests = [
+      {
+        data: {
+          prefix: 'existingConditions.diagnosis'
+        },
+        expected: true
+      },
+      {
+        data: {
+          prefix: 'existingConditions.diagnosis',
+          Condition: {}
+        },
+        expected: true
+      },
+      {
+        data: {
+          Condition: {}
+        },
+        expected: false
+      },
+      {
+        data: {
+          Condition: { value: 'Test' }
+        },
+        expected: true
+      }
+    ]
+    tests.forEach(test => {
+      expect(new DiagnosisValidator(test.data).validCondition()).toBe(
+        test.expected
+      )
+    })
+  })
+
   it('validates effective', () => {
     const tests = [
       {

--- a/src/validators/existingconditions.test.js
+++ b/src/validators/existingconditions.test.js
@@ -52,7 +52,6 @@ describe('Diagnosis validation', function() {
             items: [
               {
                 Item: {
-                  Condition: 'Test',
                   Effective: { value: 'Yes' },
                   Explanation: {
                     value: null
@@ -195,9 +194,6 @@ describe('Diagnosis validation', function() {
             items: [
               {
                 Item: {
-                  Condition: {
-                    value: 'Test'
-                  },
                   Effective: { value: 'Yes' },
                   Explanation: {
                     value: null


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/915

Removes the question `Identify the diagnosis or health condition` asked within Existing Conditions, as it does not exist on the SF-86.

**Before:**
![screen shot 2018-10-03 at 4 46 35 pm](https://user-images.githubusercontent.com/1178494/46438440-e0923700-c72b-11e8-8d3f-18d2e49d5e65.png)

**After:**
![screen shot 2018-10-03 at 4 43 22 pm](https://user-images.githubusercontent.com/1178494/46438966-51861e80-c72d-11e8-94e5-46270c3c640b.png)

