### PR TITLE
Allow present button to be disabled on date range component

### DIFF
--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -4,6 +4,7 @@ import DateControl from '../DateControl'
 import Checkbox from '../Checkbox'
 import Svg from '../Svg'
 import { now } from '../../Section/History/dateranges'
+import Show from '../Show'
 
 export default class DateRange extends ValidationElement {
   constructor(props) {
@@ -260,21 +261,23 @@ export default class DateRange extends ValidationElement {
               this.props.required && !this.state.present && !this.props.disabled
             }
           />
-          <div className="from-present">
-            <span className="or"> or </span>
-          </div>
-          <div className="from-present">
-            <Checkbox
-              name="present"
-              className="present"
-              label="Present"
-              value="present"
-              disabled={this.props.disabled}
-              checked={this.state.present}
-              onUpdate={this.updatePresent}
-              onError={this.handleErrorPresent}
-            />
-          </div>
+          <Show when={this.props.showPresent}>
+            <div className="from-present">
+              <span className="or"> or </span>
+            </div>
+            <div className="from-present">
+              <Checkbox
+                name="present"
+                className="present"
+                label="Present"
+                value="present"
+                disabled={this.props.disabled}
+                checked={this.state.present}
+                onUpdate={this.updatePresent}
+                onError={this.handleErrorPresent}
+              />
+            </div>
+          </Show>
         </div>
       </div>
     )
@@ -290,6 +293,7 @@ DateRange.defaultProps = {
   minDateEqualTo: false,
   maxDate: new Date(),
   maxDateEqualTo: false,
+  showPresent: true,
   onError: (value, arr) => {
     return arr
   },

--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -261,7 +261,7 @@ export default class DateRange extends ValidationElement {
               this.props.required && !this.state.present && !this.props.disabled
             }
           />
-          <Show when={this.props.showPresent}>
+          <Show when={this.props.allowPresent}>
             <div className="from-present">
               <span className="or"> or </span>
             </div>
@@ -293,7 +293,7 @@ DateRange.defaultProps = {
   minDateEqualTo: false,
   maxDate: new Date(),
   maxDateEqualTo: false,
-  showPresent: true,
+  allowPresent: true,
   onError: (value, arr) => {
     return arr
   },

--- a/src/components/Form/DateRange/DateRange.test.jsx
+++ b/src/components/Form/DateRange/DateRange.test.jsx
@@ -83,4 +83,12 @@ describe('The date range component', () => {
     component.find('.present input').simulate('change')
     expect(updates).toBeGreaterThan(0)
   })
+
+  it('hides the present button', () => {
+    const expected = {
+      showPresent: false
+    }
+    const component = mount(<DateRange {...expected} />)
+    expect(component.find('.present').length).toBe(0)
+  })
 })

--- a/src/components/Form/DateRange/DateRange.test.jsx
+++ b/src/components/Form/DateRange/DateRange.test.jsx
@@ -86,7 +86,7 @@ describe('The date range component', () => {
 
   it('hides the present button', () => {
     const expected = {
-      showPresent: false
+      allowPresent: false
     }
     const component = mount(<DateRange {...expected} />)
     expect(component.find('.present').length).toBe(0)

--- a/src/components/Section/History/Employment/AdditionalActivity.jsx
+++ b/src/components/Section/History/Employment/AdditionalActivity.jsx
@@ -89,7 +89,7 @@ export default class AdditionalActivity extends ValidationElement {
               <DateRange
                 name="DatesEmployed"
                 bind={true}
-                showPresent={false}
+                allowPresent={false}
                 required={this.props.required}
               />
             </Field>

--- a/src/components/Section/History/Employment/AdditionalActivity.jsx
+++ b/src/components/Section/History/Employment/AdditionalActivity.jsx
@@ -89,6 +89,7 @@ export default class AdditionalActivity extends ValidationElement {
               <DateRange
                 name="DatesEmployed"
                 bind={true}
+                showPresent={false}
                 required={this.props.required}
               />
             </Field>


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/860

Adds new prop to toggle the `Present` button on date ranges, specifically on additional periods of employment.

**Before:**
![screen shot 2018-10-04 at 3 34 01 pm](https://user-images.githubusercontent.com/1178494/46498213-c9fee500-c7ea-11e8-9248-f1d2f7734714.png)

**After:**
![screen shot 2018-10-04 at 3 32 49 pm](https://user-images.githubusercontent.com/1178494/46498180-ae93da00-c7ea-11e8-91c6-2799b35b6cb9.png)
