### PR TITLE
Persist other document field for US residence

### DIFF
--- a/api/testdata/relationships-relatives.json
+++ b/api/testdata/relationships-relatives.json
@@ -218,7 +218,7 @@
                   "checked": true
                 }
               },
-              "OtherDocument": {
+              "DocumentComments": {
                 "type": "textarea",
                 "props": {
                   "value": "other doc type"

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -981,7 +981,7 @@ export default class Relative extends ValidationElement {
                     <Show when={(this.props.Document || {}).value === 'Other'}>
                       <Textarea
                         name="DocumentComments"
-                        className="document-comments"
+                        className="relative-document-other-comments"
                         {...this.props.DocumentComments}
                         onValidate={this.props.onValidate}
                         onUpdate={this.updateDocumentComments}

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -49,7 +49,7 @@ export default class Relative extends ValidationElement {
     this.updateCourtName = this.updateCourtName.bind(this)
     this.updateCourtAddress = this.updateCourtAddress.bind(this)
     this.updateDocument = this.updateDocument.bind(this)
-    this.updateOtherDocument = this.updateOtherDocument.bind(this)
+    this.updateDocumentComments = this.updateDocumentComments.bind(this)
     this.updateResidenceDocumentNumber = this.updateResidenceDocumentNumber.bind(
       this
     )
@@ -93,7 +93,6 @@ export default class Relative extends ValidationElement {
       CourtName: this.props.CourtName,
       CourtAddress: this.props.CourtAddress,
       Document: this.props.Document,
-      OtherDocument: this.props.OtherDocument,
       DocumentComments: this.props.DocumentComments,
       ResidenceDocumentNumber: this.props.ResidenceDocumentNumber,
       Expiration: this.props.Expiration,
@@ -211,9 +210,9 @@ export default class Relative extends ValidationElement {
     })
   }
 
-  updateOtherDocument(value) {
+  updateDocumentComments(value) {
     this.update({
-      OtherDocument: value
+      DocumentComments: value
     })
   }
 
@@ -981,11 +980,11 @@ export default class Relative extends ValidationElement {
 
                     <Show when={(this.props.Document || {}).value === 'Other'}>
                       <Textarea
-                        name="OtherDocument"
-                        className="relative-other-documentnumber"
-                        {...this.props.OtherDocument}
+                        name="DocumentComments"
+                        className="document-comments"
+                        {...this.props.DocumentComments}
                         onValidate={this.props.onValidate}
-                        onUpdate={this.updateOtherDocument}
+                        onUpdate={this.updateDocumentComments}
                         required={this.props.required}
                       />
                     </Show>

--- a/src/components/Section/Relationships/Relatives/Relative.test.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.test.jsx
@@ -31,9 +31,9 @@ describe('The relative component', () => {
     expect(component.find('.relative-residence-documentnumber').length).toEqual(
       0
     )
-    expect(
-      component.find('.relative-residence-other-documentnumber').length
-    ).toEqual(0)
+    expect(component.find('.relative-document-other-comments ').length).toEqual(
+      0
+    )
     expect(component.find('.relative-expiration').length).toEqual(0)
     expect(component.find('.relative-first-contact').length).toEqual(0)
     expect(component.find('.relative-last-contact').length).toEqual(0)
@@ -433,8 +433,8 @@ describe('The relative component', () => {
       .find('.relative-document .document-other input')
       .simulate('change')
     component
-      .find('.relative-other-documentnumber textarea')
-      .simulate('change', { target: { value: 'documentnumber' } })
+      .find('.relative-document-other-comments textarea')
+      .simulate('change', { target: { value: 'explanation' } })
     component
       .find('.relative-residence-documentnumber input')
       .simulate('change', { target: { value: '00000000' } })

--- a/src/validators/relatives.js
+++ b/src/validators/relatives.js
@@ -104,7 +104,7 @@ export class RelativeValidator {
     this.courtName = data.CourtName
     this.courtAddress = data.CourtAddress
     this.document = (data.Document || {}).value
-    this.otherDocument = data.OtherDocument
+    this.documentComments = data.DocumentComments
     this.residenceDocumentNumber = data.ResidenceDocumentNumber
     this.expiration = data.Expiration
     this.firstContact = data.FirstContact
@@ -334,7 +334,7 @@ export class RelativeValidator {
 
     switch (this.document) {
       case 'Other':
-        return validGenericTextfield(this.otherDocument)
+        return validGenericTextfield(this.documentComments)
       case 'Permanent':
       case 'Employment':
       case 'Arrival':

--- a/src/validators/relatives.test.js
+++ b/src/validators/relatives.test.js
@@ -80,7 +80,7 @@ describe('Relatives validation', function() {
           Document: {
             value: 'Other'
           },
-          OtherDocument: {
+          DocumentComments: {
             value: 'Other stuff'
           }
         },


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/870

It appears two different key names were used for this particular field, `OtherDocument` on the frontend and `DocumentComments` in the backend. This standardizes the name to `DocumentComments` (which was what was already being used in the backend and within the test data).