### PR TITLE
Run react tests in parallel on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2
 jobs:
   test:
     machine: true
+    parallelism: 4
     steps:
       - checkout
       - run:
@@ -13,8 +14,13 @@ jobs:
           name: Lint
           command: make lint
       - run:
-          name: Test
-          command: make test
+          name: Run React tests
+          command: |
+            TESTFILES=$(circleci tests glob "./src/**/*.test.js*" | circleci tests split)
+            make test-react FILES="$(echo ${TESTFILES})"
+      - run:
+          name: Run Go tests
+          command: make test-go
       - run:
           name: Code coverage
           command: make coverage

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ lint-go:
 test: test-react test-go
 test-react:
 	$(info Running React test suite)
-	@docker-compose run --rm js yarn test
+	@docker-compose run --rm js yarn test $(FILES)
 test-go:
 	$(info Running Go test suite)
 	@docker-compose run --rm api make test


### PR DESCRIPTION
Uses CircleCI's parallelism to run react tests in parallel. Not mind blowing, but decreases test completion time down to around 7 minutes instead of 12-13 minutes. Example: https://circleci.com/gh/18F/e-QIP-prototype/1714