### PR TITLE
Resolve phantom error caused by relatives validator

### DIFF
--- a/src/validators/relatives.js
+++ b/src/validators/relatives.js
@@ -381,7 +381,7 @@ export class RelativeValidator {
       this.frequency.length > 0 &&
       ((this.frequency === 'Other' &&
         !!this.frequencyComments &&
-        this.frequencyComments.length > 0 &&
+        this.frequencyComments.value.length > 0 &&
         this.validAddress(this.address)) ||
         this.frequency !== 'Other')
     )

--- a/src/validators/relatives.test.js
+++ b/src/validators/relatives.test.js
@@ -1578,6 +1578,42 @@ describe('Relatives validation', function() {
           }
         },
         expected: true
+      },
+      {
+        data: {
+          IsDeceased: { value: 'No' },
+          Address: {
+            street: '1234 Some Rd',
+            city: 'Munich',
+            country: { value: 'Germany' },
+            layout: Location.ADDRESS
+          },
+          Frequency: {
+            value: 'Other'
+          },
+          FrequencyComments: {
+            value: ''
+          }
+        },
+        expected: false
+      },
+      {
+        data: {
+          IsDeceased: { value: 'No' },
+          Address: {
+            street: '1234 Some Rd',
+            city: 'Munich',
+            country: { value: 'Germany' },
+            layout: Location.ADDRESS
+          },
+          Frequency: {
+            value: 'Other'
+          },
+          FrequencyComments: {
+            value: 'foo'
+          }
+        },
+        expected: true
       }
     ]
 


### PR DESCRIPTION
Fixes #943 

Properly evaluates the length of the text entered into `FrequencyComments`.