### PR TITLE
add minDate and minDateEqualTo props to CitizenshipItem's DateRange component

### DIFF
--- a/src/components/Section/Citizenship/Multiple/CitizenshipItem.jsx
+++ b/src/components/Section/Citizenship/Multiple/CitizenshipItem.jsx
@@ -85,8 +85,6 @@ export default class CitizenshipItem extends ValidationElement {
     const from = d.from || {}
     const showCurrentQuestion = to.date && from.date && !d.present
 
-    const applicantBirthday = new Date(`${from.month}/${from.day}/${from.year}`)
-
     return (
       <div className="citizenship-item">
         <Field
@@ -118,7 +116,6 @@ export default class CitizenshipItem extends ValidationElement {
             name="Dates"
             {...this.props.Dates}
             className="citizenship-dates"
-            minDate={applicantBirthday}
             minDateEqualTo
             onUpdate={this.updateDates}
             onError={this.props.onError}

--- a/src/components/Section/Citizenship/Multiple/CitizenshipItem.jsx
+++ b/src/components/Section/Citizenship/Multiple/CitizenshipItem.jsx
@@ -85,6 +85,8 @@ export default class CitizenshipItem extends ValidationElement {
     const from = d.from || {}
     const showCurrentQuestion = to.date && from.date && !d.present
 
+    const applicantBirthday = new Date(`${from.month}/${from.day}/${from.year}`)
+
     return (
       <div className="citizenship-item">
         <Field
@@ -116,6 +118,8 @@ export default class CitizenshipItem extends ValidationElement {
             name="Dates"
             {...this.props.Dates}
             className="citizenship-dates"
+            minDate={applicantBirthday}
+            minDateEqualTo
             onUpdate={this.updateDates}
             onError={this.props.onError}
             required={this.props.required}


### PR DESCRIPTION
Fixes #836 

I added the `minDate` prop with the applicant's birthday. In addition to that, I added `minDateEqualTo` , so that it allows the the citizenship beginning date to be equal to the applicant's birthday.