### PR TITLE
Fix education summary counter

### DIFF
--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -248,7 +248,7 @@ class History extends SectionElement {
 
       if (i.Item.Diplomas.items) {
         for (const d of i.Item.Diplomas.items) {
-          if (!d.Item || !d.Item.Date || !d.Item.Date.date) {
+          if (!d.Item || !d.Item.Date) {
             continue
           }
 

--- a/src/components/Section/History/SummaryCounter/SummaryCounter.jsx
+++ b/src/components/Section/History/SummaryCounter/SummaryCounter.jsx
@@ -9,13 +9,9 @@ const scan = items => {
   let counter = 0
 
   for (const dates of items.sort(rangeSorter)) {
-    if (
-      dates.from &&
-      dates.from.date &&
-      (dates.present || (dates.to && dates.to.date))
-    ) {
+    if (dates.from && (dates.present || dates.to)) {
       counter++
-    } else if (dates.date) {
+    } else if (dates.month && dates.day && dates.year) {
       counter++
     }
   }

--- a/src/components/Section/History/SummaryCounter/SummaryCounter.test.jsx
+++ b/src/components/Section/History/SummaryCounter/SummaryCounter.test.jsx
@@ -19,18 +19,26 @@ describe('The SummaryCounter component', () => {
         return [
           {
             to: {
-              date: new Date()
+              month: '6',
+              day: '1',
+              year: '1982'
             },
             from: {
-              date: new Date(new Date() - 2)
+              month: '6',
+              day: '1',
+              year: '1980'
             }
           },
           {
             to: {
-              date: new Date(new Date() - 6)
+              month: '6',
+              day: '1',
+              year: '1984'
             },
             from: {
-              date: new Date(new Date() - 12)
+              month: '6',
+              day: '1',
+              year: '1982'
             }
           }
         ]
@@ -47,7 +55,9 @@ describe('The SummaryCounter component', () => {
       diplomas: () => {
         return [
           {
-            date: new Date(new Date() - 6)
+            month: '6',
+            day: '1',
+            year: '1982'
           }
         ]
       }


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/889

Based on the design of the `DateControl` component the prop `date` is only set in the state after an update https://github.com/18F/e-QIP-prototype/blob/develop/src/components/Form/DateControl/DateControl.jsx#L138-L181, so when a component that relies on that prop tries to access the value after logging out and logging back in it doesn't exist (since `date` is not saved to the database). This updates the logic to rely on props that will always be present rather than the `date` property.

**Before:**
<img width="797" alt="screen shot 2018-10-09 at 11 17 14 am" src="https://user-images.githubusercontent.com/1178494/46679620-66433600-cbb5-11e8-9726-b2abb7e9917f.png">

**After:**
<img width="799" alt="screen shot 2018-10-09 at 11 16 06 am" src="https://user-images.githubusercontent.com/1178494/46679633-6ba08080-cbb5-11e8-95ef-3a14bbaef37d.png">
