### PR TITLE
History/Residence: Display explanation field only when "Other" is selected

### DIFF
--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -332,8 +332,7 @@ export default class ResidenceItem extends ValidationElement {
         </Field>
         <Show
           when={
-            (this.props.Role || {}).value &&
-            !['Own', 'Rent', 'Military'].includes((this.props.Role || {}).value)
+            this.props.Role && this.props.Role.value === 'Other'
           }>
           <Field
             title={i18n.t('history.residence.label.role.explanation')}

--- a/src/components/Section/History/Residence/ResidenceItem.test.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.test.jsx
@@ -1,8 +1,12 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import ResidenceItem from './ResidenceItem'
 
 describe('The residence component', () => {
+  it('renders without crashing', () => {
+    shallow(<ResidenceItem />)
+  })
+
   it('no error on empty', () => {
     const expected = {
       name: 'residence'


### PR DESCRIPTION
Fixes #576 

This PR also simplifies the logic that displays the explanation field. If `this.props.Role` is truthy, it will check its `value`. If `value` is equal to "Other", then it will display the explanation field. The explanation field ONLY shows up when "Other" is selected.

The `|| {}` and `includes` seems unnecessary.

![screen shot 2018-10-09 at 12 26 02 pm](https://user-images.githubusercontent.com/8367504/46693398-8297a080-cbbe-11e8-8a0f-7ca26d66304e.png)

![screen shot 2018-10-09 at 12 26 38 pm](https://user-images.githubusercontent.com/8367504/46693421-93e0ad00-cbbe-11e8-9d3e-516e4aef4901.png)
