### PR TITLE
Fix length of required history based on age

### DIFF
--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -44,6 +44,9 @@ export const sort = (a, b) => {
   return 0
 }
 
+/**
+ * Figure the total amount of years to collect for the timeline
+ */
 export const totalYears = birthdate => {
   let total = 10
   if (!birthdate) {
@@ -133,31 +136,6 @@ class History extends SectionElement {
         new HistoryEducationValidator(education, education).isValid()
       )
     )
-  }
-
-  /**
-   * Figure the total amount of years to collect for the timeline
-   */
-  totalYears() {
-    let total = 10
-    if (!this.props.Birthdate) {
-      return total
-    }
-
-    const eighteen = daysAgo(this.props.Birthdate, 365 * -18)
-    total = Math.ceil(daysBetween(eighteen, today) / 365)
-
-    // A maximum of 10 years is required
-    if (total > 10) {
-      total = 10
-    }
-
-    // A minimum of two years is required
-    if (total < 2) {
-      total = 2
-    }
-
-    return total
   }
 
   /**
@@ -267,7 +245,7 @@ class History extends SectionElement {
         List={this.residenceRangeList}
         title={i18n.t('history.residence.summary.title')}
         unit={i18n.t('history.residence.summary.unit')}
-        total={this.totalYears()}>
+        total={totalYears(this.props.Birthdate)}>
         <div className="summary-icon">
           <Svg
             src="/img/residence-house.svg"
@@ -285,7 +263,7 @@ class History extends SectionElement {
         List={this.employmentRangesList}
         title={i18n.t('history.employment.summary.title')}
         unit={i18n.t('history.employment.summary.unit')}
-        total={this.totalYears()}>
+        total={totalYears(this.props.Birthdate)}>
         <div className="summary-icon">
           <Svg
             src="/img/employer-briefcase.svg"
@@ -305,7 +283,7 @@ class History extends SectionElement {
         diplomas={this.diplomaRangesList}
         schoolsLabel={i18n.t('history.education.summary.schools')}
         diplomasLabel={i18n.t('history.education.summary.diplomas')}
-        total={this.totalYears()}>
+        total={totalYears(this.props.Birthdate)}>
         <div className="summary-icon">
           <Svg
             src="/img/school-cap.svg"
@@ -320,7 +298,7 @@ class History extends SectionElement {
     let holes = 0
 
     if (this.props.History) {
-      const start = daysAgo(today, 365 * this.totalYears())
+      const start = daysAgo(today, 365 * totalYears())
 
       for (const t of types) {
         let items = []
@@ -419,7 +397,7 @@ class History extends SectionElement {
               defaultState={false}
               realtime={true}
               sort={sort}
-              totalYears={this.totalYears()}
+              totalYears={totalYears(this.props.Birthdate)}
               overrideInitial={this.overrideInitial}
               onUpdate={this.updateResidence}
               onError={this.handleError}
@@ -444,7 +422,7 @@ class History extends SectionElement {
               defaultState={false}
               realtime={true}
               sort={sort}
-              totalYears={this.totalYears()}
+              totalYears={totalYears(this.props.Birthdate)}
               overrideInitial={this.overrideInitial}
               onUpdate={this.updateEmployment}
               onError={this.handleError}
@@ -505,7 +483,7 @@ class History extends SectionElement {
                   defaultState={false}
                   realtime={true}
                   sort={sort}
-                  totalYears={this.totalYears()}
+                  totalYears={totalYears(this.props.Birthdate)}
                   overrideInitial={this.overrideInitial}
                   onUpdate={this.updateEducation}
                   onError={this.handleError}
@@ -569,7 +547,7 @@ class History extends SectionElement {
               scrollToTop="scrollToHistory"
               realtime={true}
               sort={sort}
-              totalYears={this.totalYears()}
+              totalYears={totalYears(this.props.Birthdate)}
               overrideInitial={this.overrideInitial}
               onUpdate={this.updateResidence}
               onError={this.handleError}
@@ -612,7 +590,7 @@ class History extends SectionElement {
               {...this.props.Employment}
               scrollToTop="scrollToHistory"
               sort={sort}
-              totalYears={this.totalYears()}
+              totalYears={totalYears(this.props.Birthdate)}
               overrideInitial={this.overrideInitial}
               onUpdate={this.updateEmployment}
               onError={this.handleError}
@@ -680,7 +658,7 @@ class History extends SectionElement {
                   {...this.props.Education}
                   scrollToTop="scrollToHistory"
                   sort={sort}
-                  totalYears={this.totalYears()}
+                  totalYears={totalYears(this.props.Birthdate)}
                   overrideInitial={this.overrideInitial}
                   onUpdate={this.updateEducation}
                   onError={this.handleError}
@@ -718,7 +696,7 @@ const processDate = date => {
   }
 
   let d = null
-  const { month, day, year } = date
+  const { month, day, year } = date.Date
   if (month && day && year) {
     d = utc(new Date(year, month - 1, day))
   }

--- a/src/components/Section/History/History.test.jsx
+++ b/src/components/Section/History/History.test.jsx
@@ -4,6 +4,7 @@ import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import { Provider } from 'react-redux'
 import History, { totalYears } from './History'
+import Employment from './Employment'
 import { mount } from 'enzyme'
 
 const applicationState = {
@@ -74,24 +75,55 @@ describe('The History section', () => {
     })
   })
 
-  it('can count total years', () => {
-    const tests = [
-      {
-        data: new Date('1/1/2010'),
-        expect: 10
-      },
-      {
-        data: new Date('1/1/2000'),
-        expect: 2
-      },
-      {
-        data: new Date('1/1/1980'),
-        expect: 10
+  it('sets totalYears to proper value if applicant has less than 10 years of history', () => {
+    const store = mockStore({
+      authentication: { authenticated: true },
+      application: {
+        Identification: {
+          ApplicantBirthDate: {
+            Date: {
+              month: `${new Date().getMonth() + 1}`,
+              day: `${new Date().getDate()}`,
+              year: `${new Date().getFullYear() - 18}`,
+              estimated: false
+            }
+          }
+        }
       }
-    ]
-
-    tests.forEach(test => {
-      expect(totalYears(test.data)).toBe(test.expect)
     })
+
+    const component = mount(
+      <Provider store={store}>
+        <History subsection="employment" />
+      </Provider>
+    )
+
+    expect(component.find(Employment).props().totalYears).toEqual(2)
+  })
+
+  it('sets totalYears to proper value if applicant has more than 10 years of history', () => {
+    const store = mockStore({
+      authentication: { authenticated: true },
+      application: {
+        Identification: {
+          ApplicantBirthDate: {
+            Date: {
+              month: `${new Date().getMonth() + 1}`,
+              day: `${new Date().getDate()}`,
+              year: `${new Date().getFullYear() - 30}`,
+              estimated: false
+            }
+          }
+        }
+      }
+    })
+
+    const component = mount(
+      <Provider store={store}>
+        <History subsection="employment" />
+      </Provider>
+    )
+
+    expect(component.find(Employment).props().totalYears).toEqual(10)
   })
 })


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/914

The `History` component looks at the applicant's birthdate to determine how many years of history (employment, residence, employment) is required. This fixes the function that was processing the birthdate to use the correct value (`identification.ApplicantBirthDate.Date` rather than`identification.ApplicantBirthDate`). The function was also included twice, so this removes one instance of the function.