### PR TITLE
fix spacing of navigation when sticky

### DIFF
--- a/src/components/Form/Accordion/Accordion.scss
+++ b/src/components/Form/Accordion/Accordion.scss
@@ -390,7 +390,7 @@ button.usa-button-outline {
         z-index: 1001;
         box-shadow: 0 2px 6px -1px rgba(0, 0, 0, 0.4);
         position: fixed;
-        top: 5.7rem;
+        top: 6.7rem;
         background-color: #fff;
 
         .left.close,

--- a/src/sass/eqip.scss
+++ b/src/sass/eqip.scss
@@ -201,8 +201,8 @@ a:focus {
 
       .usa-header,
       .usa-header > .eapp-structure-wrap {
-        height: 5rem;
-        min-height: 5rem;
+        height: 6rem;
+        min-height: 6rem;
       }
 
       .usa-header.usa-header-basic {


### PR DESCRIPTION
Fixes #959 
Fixes overlap of navigation with breadcrumb text. 