### PR TITLE
Require multiple citizenship entries

### DIFF
--- a/api/testdata/complete-scenarios/test6.json
+++ b/api/testdata/complete-scenarios/test6.json
@@ -145,19 +145,19 @@
                   "How": {
                     "type": "textarea",
                     "props": {
-                      "value": "Should not be submitted"
+                      "value": ""
                     }
                   },
                   "Renounced": {
                     "type": "branch",
                     "props": {
-                      "value": "No"
+                      "value": ""
                     }
                   },
                   "RenouncedExplanation": {
                     "type": "textarea",
                     "props": {
-                      "value": "Should not be submitted"
+                      "value": ""
                     }
                   }
                 }

--- a/src/components/Section/Citizenship/Multiple/CitizenshipItem.jsx
+++ b/src/components/Section/Citizenship/Multiple/CitizenshipItem.jsx
@@ -85,6 +85,9 @@ export default class CitizenshipItem extends ValidationElement {
     const from = d.from || {}
     const showCurrentQuestion = to.date && from.date && !d.present
 
+    const country = this.props.Country.value || []
+    const showNonUSQuestions = !country.includes('United States')
+
     return (
       <div className="citizenship-item">
         <Field
@@ -122,46 +125,48 @@ export default class CitizenshipItem extends ValidationElement {
           />
         </Field>
 
-        <Field
-          title={i18n.t('citizenship.multiple.heading.citizenship.how')}
-          scrollIntoView={this.props.scrollIntoView}>
-          <Textarea
-            name="How"
-            {...this.props.How}
-            className="citizenship-how"
-            onUpdate={this.updateHow}
+        <Show when={showNonUSQuestions}>
+          <Field
+            title={i18n.t('citizenship.multiple.heading.citizenship.how')}
+            scrollIntoView={this.props.scrollIntoView}>
+            <Textarea
+              name="How"
+              {...this.props.How}
+              className="citizenship-how"
+              onUpdate={this.updateHow}
+              onError={this.props.onError}
+              required={this.props.required}
+            />
+          </Field>
+
+          <Branch
+            name="Renounced"
+            label={i18n.t('citizenship.multiple.heading.citizenship.renounced')}
+            labelSize="h3"
+            className="citizenship-renounced no-margin-bottom"
+            {...this.props.Renounced}
+            onUpdate={this.updateRenounced}
             onError={this.props.onError}
             required={this.props.required}
+            scrollIntoView={this.props.scrollIntoView}
           />
-        </Field>
 
-        <Branch
-          name="Renounced"
-          label={i18n.t('citizenship.multiple.heading.citizenship.renounced')}
-          labelSize="h3"
-          className="citizenship-renounced no-margin-bottom"
-          {...this.props.Renounced}
-          onUpdate={this.updateRenounced}
-          onError={this.props.onError}
-          required={this.props.required}
-          scrollIntoView={this.props.scrollIntoView}
-        />
-
-        <Field
-          title={i18n.t(
-            'citizenship.multiple.heading.citizenship.renouncedexplanation'
-          )}
-          titleSize="label"
-          scrollIntoView={this.props.scrollIntoView}>
-          <Textarea
-            name="RenouncedExplanation"
-            {...this.props.RenouncedExplanation}
-            className="citizenship-renounced-explanation"
-            onUpdate={this.updateRenouncedExplanation}
-            onError={this.props.onError}
-            required={this.props.required}
-          />
-        </Field>
+          <Field
+            title={i18n.t(
+              'citizenship.multiple.heading.citizenship.renouncedexplanation'
+            )}
+            titleSize="label"
+            scrollIntoView={this.props.scrollIntoView}>
+            <Textarea
+              name="RenouncedExplanation"
+              {...this.props.RenouncedExplanation}
+              className="citizenship-renounced-explanation"
+              onUpdate={this.updateRenouncedExplanation}
+              onError={this.props.onError}
+              required={this.props.required}
+            />
+          </Field>
+        </Show>
 
         <Show when={showCurrentQuestion}>
           <div>

--- a/src/components/Section/Citizenship/Multiple/Multiple.jsx
+++ b/src/components/Section/Citizenship/Multiple/Multiple.jsx
@@ -56,6 +56,12 @@ export default class Multiple extends SubsectionElement {
     })
   }
 
+  validMinimumCitizenships() {
+    return new CitizenshipMultipleValidator(
+      this.props
+    ).validMinimumCitizenships()
+  }
+
   render() {
     return (
       <div
@@ -82,6 +88,16 @@ export default class Multiple extends SubsectionElement {
         />
 
         <Show when={this.props.HasMultiple.value === 'Yes'}>
+          <Field
+            errors={[
+              {
+                code: 'validMinimumCitizenships',
+                valid: this.validMinimumCitizenships()
+              }
+            ]}
+            className={this.validMinimumCitizenships() && 'hidden'}
+          />
+
           <Accordion
             {...this.props.List}
             defaultState={this.props.defaultState}

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -1083,5 +1083,9 @@ export const error = {
   validPhoneTypes: {
     title: 'There is a problem with your phone numbers',
     message: 'Please provide only one of each phone number type.'
+  },
+  validMinimumCitizenships: {
+    title: 'There is a problem with your entry',
+    message: 'Please provide a minimum of two countries.'
   }
 }

--- a/src/validators/citizenship-multiple.js
+++ b/src/validators/citizenship-multiple.js
@@ -14,6 +14,19 @@ export default class CitizenshipMultipleValidator {
     )
   }
 
+  validMinimumCitizenships() {
+    if (this.hasMultiple !== 'Yes') {
+      return true
+    }
+
+    // Must provide a minimum of two countries
+    if (this.list.items && this.list.items.length < 2) {
+      return false
+    }
+
+    return true
+  }
+
   validCitizenships() {
     if (this.hasMultiple !== 'Yes') {
       return true
@@ -25,7 +38,11 @@ export default class CitizenshipMultipleValidator {
   }
 
   isValid() {
-    return this.validHasMultiple() && this.validCitizenships()
+    return (
+      this.validHasMultiple() &&
+      this.validMinimumCitizenships() &&
+      this.validCitizenships()
+    )
   }
 }
 
@@ -40,6 +57,14 @@ export class CitizenshipItemValidator {
     this.currentExplanation = data.CurrentExplanation
   }
 
+  isUnitedStates() {
+    if (!this.country || !this.country.value) {
+      return true
+    }
+
+    return (this.country.value || []).includes('United States')
+  }
+
   validCountry() {
     return validGenericTextfield(this.country)
   }
@@ -49,10 +74,18 @@ export class CitizenshipItemValidator {
   }
 
   validHow() {
+    if (this.isUnitedStates()) {
+      return true
+    }
+
     return !!this.how && validGenericTextfield(this.how)
   }
 
   validRenounced() {
+    if (this.isUnitedStates()) {
+      return true
+    }
+
     return (
       !!this.renounced &&
       (this.renounced === 'No' || this.renounced === 'Yes') &&

--- a/src/validators/citizenship-multiple.test.js
+++ b/src/validators/citizenship-multiple.test.js
@@ -62,12 +62,18 @@ describe('citizenship multiple component validation', function() {
     const tests = [
       {
         state: {
+          Country: {
+            value: 'Germany'
+          },
           How: null
         },
         expected: false
       },
       {
         state: {
+          Country: {
+            value: 'Germany'
+          },
           How: {
             value: 'Birth'
           }
@@ -83,30 +89,45 @@ describe('citizenship multiple component validation', function() {
     const tests = [
       {
         state: {
+          Country: {
+            value: 'Germany'
+          },
           Renounced: { value: null }
         },
         expected: false
       },
       {
         state: {
+          Country: {
+            value: 'Germany'
+          },
           Renounced: { value: 'Yuppers' }
         },
         expected: false
       },
       {
         state: {
+          Country: {
+            value: 'Germany'
+          },
           Renounced: { value: 'No' }
         },
         expected: false
       },
       {
         state: {
+          Country: {
+            value: 'Germany'
+          },
           Renounced: { value: 'Yes' }
         },
         expected: false
       },
       {
         state: {
+          Country: {
+            value: 'Germany'
+          },
           Renounced: { value: 'Yes' },
           RenouncedExplanation: {
             value: 'explanation'
@@ -311,6 +332,127 @@ describe('citizenship multiple component validation', function() {
     battery(tests, CitizenshipMultipleValidator, 'validCitizenships')
   })
 
+  it('can validate minimum number of citizenships provided', () => {
+    const tests = [
+      {
+        state: {
+          HasMultiple: { value: 'Yes' },
+          List: {
+            branch: { value: 'No' },
+            items: [
+              {
+                Item: {
+                  Country: {
+                    value: 'Germany'
+                  },
+                  Dates: {
+                    from: {
+                      month: '1',
+                      day: '1',
+                      year: '2010',
+                      date: new Date('1/1/2010')
+                    },
+                    to: {
+                      month: '1',
+                      day: '1',
+                      year: '2012',
+                      date: new Date('1/1/2012')
+                    },
+                    present: false
+                  },
+                  How: {
+                    value: 'Birth'
+                  },
+                  Renounced: { value: 'Yes' },
+                  RenouncedExplanation: {
+                    value: 'explanation'
+                  },
+                  Current: { value: 'Yes' },
+                  CurrentExplanation: {
+                    value: 'explanation'
+                  }
+                }
+              }
+            ]
+          }
+        },
+        expected: false
+      },
+      {
+        state: {
+          HasMultiple: { value: 'Yes' },
+          List: {
+            branch: { value: 'No' },
+            items: [
+              {
+                Item: {
+                  Country: {
+                    value: 'United States'
+                  },
+                  Dates: {
+                    from: {
+                      month: '1',
+                      day: '1',
+                      year: '2010',
+                      date: new Date('1/1/2010')
+                    },
+                    to: {
+                      month: '1',
+                      day: '1',
+                      year: '2012',
+                      date: new Date('1/1/2012')
+                    },
+                    present: false
+                  },
+                  Current: { value: 'Yes' },
+                  CurrentExplanation: {
+                    value: 'explanation'
+                  }
+                }
+              },
+              {
+                Item: {
+                  Country: {
+                    value: 'Germany'
+                  },
+                  Dates: {
+                    from: {
+                      month: '1',
+                      day: '1',
+                      year: '2010',
+                      date: new Date('1/1/2010')
+                    },
+                    to: {
+                      month: '1',
+                      day: '1',
+                      year: '2012',
+                      date: new Date('1/1/2012')
+                    },
+                    present: false
+                  },
+                  How: {
+                    value: 'Birth'
+                  },
+                  Renounced: { value: 'Yes' },
+                  RenouncedExplanation: {
+                    value: 'explanation'
+                  },
+                  Current: { value: 'Yes' },
+                  CurrentExplanation: {
+                    value: 'explanation'
+                  }
+                }
+              }
+            ]
+          }
+        },
+        expected: true
+      }
+    ]
+
+    battery(tests, CitizenshipMultipleValidator, 'validMinimumCitizenships')
+  })
+
   it('can validate entire multiple citizenships and passports', () => {
     const tests = [
       {
@@ -348,6 +490,32 @@ describe('citizenship multiple component validation', function() {
                       date: new Date('1/1/2012')
                     },
                     present: true
+                  },
+                  Current: { value: 'Yes' },
+                  CurrentExplanation: {
+                    value: 'explanation'
+                  }
+                }
+              },
+              {
+                Item: {
+                  Country: {
+                    value: 'Germany'
+                  },
+                  Dates: {
+                    from: {
+                      month: '1',
+                      day: '1',
+                      year: '2010',
+                      date: new Date('1/1/2010')
+                    },
+                    to: {
+                      month: '1',
+                      day: '1',
+                      year: '2012',
+                      date: new Date('1/1/2012')
+                    },
+                    present: false
                   },
                   How: {
                     value: 'Birth'


### PR DESCRIPTION
Adds the requirement that at least two countries are added to the Dual/multiple citizenship section based on the validation matrix. Also removes the following questions if the country added is the United States:

- How did you acquire this non-U.S. citizenship you now have or previously had?
- Have you taken any action to renounce your foreign citizenship?
  - Provide explanation

**Preview:**
<img width="834" alt="screen shot 2018-10-11 at 8 39 09 am" src="https://user-images.githubusercontent.com/1178494/46804662-34ef7500-cd31-11e8-9011-afc7808dc2d1.png">
