### PR TITLE
Use correct version of query-string npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jsdoc": "^3.5.5",
     "node-sass-chokidar": "^1.3.0",
     "prop-types": "^15.6.0",
-    "query-string": "^6.2.0",
+    "query-string": "^5.1.1",
     "react": "^15.6.1",
     "react-autosuggest": "^9.3.2",
     "react-dom": "^15.6.1",


### PR DESCRIPTION
As part of https://github.com/18F/e-QIP-prototype/pull/933, I added the `query-string` npm package to parse a query string value in what I thought was a cross-browser compatible way, but in testing IE11 I noticed there were console errors being caused by `query-string`. It looks like there is a version that specifically supports older browsers which I was not using, so this updates it to use the correct version.