### PR TITLE
Fix vertical scrolling on introduction modal

### DIFF
--- a/src/components/Form/Modal/Modal.jsx
+++ b/src/components/Form/Modal/Modal.jsx
@@ -1,26 +1,6 @@
 import React from 'react'
 import Svg from '../Svg'
 
-export const applyFixedModal = (open = false) => {
-  if (!window || !window.document || !window.document.body) {
-    return
-  }
-
-  let klassBody = window.document.body.className
-
-  if (open) {
-    if (klassBody.indexOf('modal-open') === -1) {
-      klassBody += ' modal-open'
-    }
-  } else {
-    if (klassBody.indexOf('modal-open') !== -1) {
-      klassBody = klassBody.replace('modal-open', '')
-    }
-  }
-
-  window.document.body.className = klassBody.trim()
-}
-
 export default class Modal extends React.Component {
   constructor(props) {
     super(props)
@@ -28,6 +8,28 @@ export default class Modal extends React.Component {
     this.update = this.update.bind(this)
     this.doNothing = this.doNothing.bind(this)
     this.dismiss = this.dismiss.bind(this)
+  }
+
+  componentDidMount() {
+    if (this.props.show) {
+      window.document.body.classList.add('modal-open')
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const body = window.document.body
+    if (!this.props.show && prevProps.show) {
+      body.classList.remove('modal-open')
+    }
+
+    if (this.props.show && !prevProps.show) {
+      body.classList.add('modal-open')
+    }
+  }
+
+  componentWillUnmount() {
+    const body = window.document.body
+    body.classList.remove('modal-open')
   }
 
   update(queue) {
@@ -83,8 +85,6 @@ export default class Modal extends React.Component {
   }
 
   render() {
-    applyFixedModal(this.props.show)
-
     if (!this.props.show) {
       return null
     }

--- a/src/sass/phone.scss
+++ b/src/sass/phone.scss
@@ -61,7 +61,8 @@
     z-index: 9999;
 
     .modal {
-      overflow-y: visible;
+      overflow-y: auto;
+      overflow-x: hidden;
       background-color: rgba(255, 255, 255, 1) !important;
 
       .modal-wrap {


### PR DESCRIPTION
This allows the introduction modal to be scrolled vertically using the browser's scroll bar. The cause of the issue was the `modal-open` class being unintentionally removed when the timeout modal is initialized behind the scenes.

This will address the original issue, but it's only a workaround for the fact that there is currently no way for modals to be aware if another modal is already open. In the future, it may be worth refactoring this implementation and creating a shared state so multiple concurrent modals can be handled more appropriately.

Also, there seemed to be an unrelated issue with the introduction modal on mobile devices where the modal would be full screen but would not scroll at all. I made a slight tweak to the css to address that issue as well.