### PR TITLE
Add version number place holder

### DIFF
--- a/src/components/Form/Introduction/__snapshots__/Introduction.test.jsx.snap
+++ b/src/components/Form/Introduction/__snapshots__/Introduction.test.jsx.snap
@@ -41,6 +41,11 @@ exports[`The Introduction component renders properly 1`] = `
             </div>
             <div>
               <p>
+                National Background Investigation System (NBIS) eApp version MAJOR.MINOR.PATCH-IDENTIFIER
+              </p>
+            </div>
+            <div>
+              <p>
                 <strong>
                   Follow instructions completely or your form will be unable to be processed. If you have any questions, contact the office that provided you the form.
                 </strong>

--- a/src/components/Main/__snapshots__/App.test.jsx.snap
+++ b/src/components/Main/__snapshots__/App.test.jsx.snap
@@ -31,6 +31,11 @@ exports[`Renders homepage 1`] = `
               </div>
               <div>
                 <p>
+                  National Background Investigation System (NBIS) eApp version MAJOR.MINOR.PATCH-IDENTIFIER
+                </p>
+              </div>
+              <div>
+                <p>
                   <strong>
                     Follow instructions completely or your form will be unable to be processed. If you have any questions, contact the office that provided you the form.
                   </strong>

--- a/src/config/locales/en/introduction.js
+++ b/src/config/locales/en/introduction.js
@@ -1,6 +1,7 @@
 export const introduction = {
   contents: [
     '# Questionnaire for National Security Positions',
+    'National Background Investigation System (NBIS) eApp version MAJOR.MINOR.PATCH-IDENTIFIER',
     '**Follow instructions completely or your form will be unable to be processed. If you have any questions, contact the office that provided you the form.**',
     '## Instructions for completing this form ',
     '1. **Follow the instructions provided to you by the office that gave you this form** and any other clarifying instructions, provided by that office, to assist you with completion of this form. You should retain a copy of the completed form for your records.',


### PR DESCRIPTION
We need a place where testers can easily find the version number of eApp under test. Using placeholder text for now until an automated mechanism can be put into place for the downstream NBIS build process.