### PR TITLE
Provide feedback to user if form fails to save

### DIFF
--- a/src/components/Form/TimeoutWarning/TimeoutWarning.jsx
+++ b/src/components/Form/TimeoutWarning/TimeoutWarning.jsx
@@ -68,7 +68,11 @@ export class TimeoutWarning extends React.Component {
           },
           () => {
             // Save the form
-            saveSection(application, section, subsection, dispatcher)
+            saveSection(application, section, subsection, dispatcher).catch(
+              error => {
+                alert(error)
+              }
+            )
             // Change the timer interval
             this.resetInterval()
           }

--- a/src/components/SavedIndicator/SavedIndicator.scss
+++ b/src/components/SavedIndicator/SavedIndicator.scss
@@ -94,6 +94,29 @@ $border-size: 5px;
     display: block;
   }
 
+  &.error {
+    i {
+      background-color: $eapp-red;
+
+      &.invert {
+        background-color: transparent;
+        color: $eapp-red;
+      }
+    }
+
+    &.active,
+    &:active,
+    &:hover {
+      color: $eapp-red;
+    }
+
+    .spinner-label {
+      .one-line {
+        color: $eapp-red;
+      }
+    }
+  }
+
   .spinner {
     position: relative;
     top: -1rem;

--- a/src/components/SavedIndicator/SavedIndicator.test.jsx
+++ b/src/components/SavedIndicator/SavedIndicator.test.jsx
@@ -5,6 +5,7 @@ import thunk from 'redux-thunk'
 import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
 import SavedIndicator from './SavedIndicator'
+import { i18n } from '../../config'
 
 describe('The saved indicator component', () => {
   // Setup
@@ -24,81 +25,76 @@ describe('The saved indicator component', () => {
     window.token = 'fake-token'
   })
 
-  it('visible when authenticated', () => {
-    const store = mockStore({ authentication: { authenticated: true } })
+  it('catches failed save', () => {
+    const store = mockStore({
+      authentication: {
+        authenticated: true
+      },
+      application: {
+        Settings: {
+          saveError: true
+        }
+      }
+    })
     const component = mount(
       <Provider store={store}>
         <SavedIndicator />
       </Provider>
     )
-    expect(component.find('button').length).toEqual(1)
+    expect(component.find('strong').text()).toContain(
+      i18n.t('saved.error.title')
+    )
   })
 
-  it('displays in seconds if under a minute', () => {
-    const elapsed = 10 * 1000
-    const store = mockStore({ authentication: { authenticated: true } })
-    const component = mount(
-      <Provider store={store}>
-        <SavedIndicator elapsed={elapsed} />
-      </Provider>
-    )
-    expect(component.find('.time').text()).toContain('sec')
-  })
+  describe('when authenticated', () => {
+    let createComponent
 
-  it('displays in minutes if under an hour', () => {
-    const elapsed = 60 * 1000
-    const store = mockStore({ authentication: { authenticated: true } })
-    const component = mount(
-      <Provider store={store}>
-        <SavedIndicator elapsed={elapsed} />
-      </Provider>
-    )
-    expect(component.find('.time').text()).toContain('min')
-  })
+    beforeEach(() => {
+      const store = mockStore({ authentication: { authenticated: true } })
+      createComponent = (elapsed = 0) =>
+        mount(
+          <Provider store={store}>
+            <SavedIndicator elapsed={elapsed} />
+          </Provider>
+        )
+    })
 
-  it('displays in hours if under a day', () => {
-    const elapsed = 60 * 60 * 1000
-    const store = mockStore({ authentication: { authenticated: true } })
-    const component = mount(
-      <Provider store={store}>
-        <SavedIndicator elapsed={elapsed} />
-      </Provider>
-    )
-    expect(component.find('.time').text()).toContain('hour')
-  })
+    it('visible when authenticated', () => {
+      const component = createComponent()
+      expect(component.find('button').length).toEqual(1)
+    })
 
-  it('displays in days if greater than 24 hours', () => {
-    const elapsed = 24 * 60 * 60 * 1000
-    const store = mockStore({ authentication: { authenticated: true } })
-    const component = mount(
-      <Provider store={store}>
-        <SavedIndicator elapsed={elapsed} />
-      </Provider>
-    )
-    expect(component.find('.time').text()).toContain('day')
-  })
+    it('displays in seconds if under a minute', () => {
+      const elapsed = 10 * 1000
+      const component = createComponent(elapsed)
+      expect(component.find('.time').text()).toContain('sec')
+    })
 
-  it('triggers save', () => {
-    const elapsed = 24 * 60 * 60 * 1000
-    const store = mockStore({ authentication: { authenticated: true } })
-    const component = mount(
-      <Provider store={store}>
-        <SavedIndicator elapsed={elapsed} />
-      </Provider>
-    )
-    component.find('button').simulate('click')
-  })
+    it('displays in minutes if under an hour', () => {
+      const elapsed = 60 * 1000
+      const component = createComponent(elapsed)
+      expect(component.find('.time').text()).toContain('min')
+    })
 
-  it('mouse in and out', () => {
-    const store = mockStore({ authentication: { authenticated: true } })
-    const component = mount(
-      <Provider store={store}>
-        <SavedIndicator interval={1} />
-      </Provider>
-    )
-    component.find('button').simulate('mouseenter')
-    expect(component.find('SavedIndicator').getNode().state.hover).toBe(true)
-    component.find('button').simulate('mouseleave')
-    expect(component.find('SavedIndicator').getNode().state.hover).toBe(false)
+    it('displays in hours if under a day', () => {
+      const elapsed = 60 * 60 * 1000
+      const component = createComponent(elapsed)
+      expect(component.find('.time').text()).toContain('hour')
+    })
+
+    it('displays in days if greater than 24 hours', () => {
+      const elapsed = 24 * 60 * 60 * 1000
+      const component = createComponent(elapsed)
+      expect(component.find('.time').text()).toContain('day')
+    })
+
+    it('mouse in and out', () => {
+      const store = mockStore({ authentication: { authenticated: true } })
+      const component = createComponent()
+      component.find('button').simulate('mouseenter')
+      expect(component.find('SavedIndicator').getNode().state.hover).toBe(true)
+      component.find('button').simulate('mouseleave')
+      expect(component.find('SavedIndicator').getNode().state.hover).toBe(false)
+    })
   })
 })

--- a/src/components/SavedIndicator/persistence-helpers.js
+++ b/src/components/SavedIndicator/persistence-helpers.js
@@ -3,36 +3,22 @@ import { updateApplication } from '../../actions/ApplicationActions'
 import { sectionData } from '../Section/sectionData'
 import schema from '../../schema'
 import { api } from '../../services'
+import { i18n } from '../../config'
 
-export const saveSection = (
-  application,
-  section,
-  subsection,
-  dispatch,
-  done
-) => {
+export const saveSection = (application, section, subsection, dispatch) => {
   const pending = sectionData(section, subsection, application) || []
-  if (pending.length === 0) {
-    if (done) {
-      done()
-    }
-    return
-  }
 
   let requests = []
   for (const p of pending) {
     requests.push(api.save(schema(p.path.replace(/\//g, '.'), p.data, false)))
   }
 
-  axios
+  return axios
     .all(requests)
     .then(() => {
       if (dispatch) {
         dispatch(updateApplication('Settings', 'saved', new Date()))
-      }
-
-      if (done) {
-        done()
+        dispatch(updateApplication('Settings', 'saveError', false))
       }
     })
     .catch(() => {
@@ -41,9 +27,9 @@ export const saveSection = (
           `Failed to save data for the "${section}" section and "${subsection}" subsection`
         )
       }
-
-      if (done) {
-        done()
+      if (dispatch) {
+        dispatch(updateApplication('Settings', 'saveError', true))
       }
+      throw new Error(i18n.t('saved.error.message'))
     })
 }

--- a/src/config/locales/en/saved.js
+++ b/src/config/locales/en/saved.js
@@ -11,5 +11,10 @@ export const saved = {
   hours: 'hours',
   day: 'day',
   days: 'days',
-  ago: 'ago'
+  ago: 'ago',
+  error: {
+    title: 'Error',
+    subtitle: 'Try again',
+    message: 'There was a problem saving your data, please try again.'
+  }
 }

--- a/src/views/Form/Form.jsx
+++ b/src/views/Form/Form.jsx
@@ -78,7 +78,9 @@ class Form extends React.Component {
       section,
       subsection,
       this.props.dispatch
-    )
+    ).catch(error => {
+      alert(error)
+    })
   }
 
   refreshToken() {


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/638

There are three different points at which the form is saved - when there is route change, when the timeout modal appears, and when the save button is manually clicked. In each of the events a call is made to the save API. This captures any non-successful post to the API, and displays an alert containing an error message and also updates the visual style of the save button.

While the alert is a bit ugly, I think it's necessary to make it clear to the user that there was a problem - the save button changing colors did not seem attention grabbing enough (especially if the error happened while changing pages vs clicking directly on the button). A future PR should improve the user experience of an error like this happening, by providing a more apparent alert banner or something along those lines.

**Preview:**
![screen shot 2018-10-12 at 3 59 29 pm](https://user-images.githubusercontent.com/1178494/46891753-f3e28800-ce38-11e8-98d9-e8560f6230de.png)
![screen shot 2018-10-12 at 4 03 16 pm](https://user-images.githubusercontent.com/1178494/46891754-f513b500-ce38-11e8-8a54-88f61f8a7775.png)
