### PR TITLE
Catch all validation errors in accordion summary

### DIFF
--- a/src/components/Form/Accordion/Accordion.jsx
+++ b/src/components/Form/Accordion/Accordion.jsx
@@ -535,12 +535,9 @@ export default class Accordion extends ValidationElement {
 
   hasNoErrors(uuid) {
     const element = document.getElementById(uuid)
+    const errors = element.querySelectorAll('.field .messages .message.error')
 
-    if (element) {
-      const errors = element.querySelectorAll('.field .messages .message.error')
-      return errors.length < 1
-    }
-    return true
+    return errors.length < 1
   }
 
   render() {

--- a/src/components/Form/Accordion/Accordion.jsx
+++ b/src/components/Form/Accordion/Accordion.jsx
@@ -345,7 +345,7 @@ export default class Accordion extends ValidationElement {
     }
 
     const closedAndIncomplete =
-      !item.open && !this.isValid(this.props.transformer(item))
+      !item.open && !this.isValid(this.props.transformer(item), item.uuid)
     const svg = closedAndIncomplete ? (
       <Svg
         src="/img/exclamation-point.svg"
@@ -526,9 +526,19 @@ export default class Accordion extends ValidationElement {
    * Determines if current item is valid. By default, this
    * utilizes the validator that is passed in.
    * */
-  isValid(item) {
+  isValid(item, uuid) {
     if (this.props.required) {
-      return new this.props.validator(item).isValid()
+      return new this.props.validator(item).isValid() && this.hasNoErrors(uuid)
+    }
+    return true
+  }
+
+  hasNoErrors(uuid) {
+    const element = document.getElementById(uuid)
+
+    if (element) {
+      const errors = element.querySelectorAll('.field .messages .message.error')
+      return errors.length < 1
     }
     return true
   }


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/907
Fixes #1016

@line47 and I paired on this issue and uncovered some oversights in the logic when an accordion validates itself on the review page. As it stands, the `Accordion` component allows a validator to be passed in and it's used to determine whether the accordion item is valid: https://github.com/18F/e-QIP-prototype/blob/develop/src/components/Form/Accordion/Accordion.jsx#L529-L534. The issue with this approach is that it only checks the validation that is defined within the corresponding validator file and not all of the additional validation that happens on the inputs themselves (like min/max length, pattern matching, etc).

So in the case of #907, the validator was simply checking fields against very basic validations like seeing if _any_ month and year was in the date input's: https://github.com/18F/e-QIP-prototype/blob/develop/src/validators/bankruptcy.js#L105. This created the situation where an invalid date could be entered (before your birthdate, or in the future) and the validator would mark is as ok, so it didn't display a top level error, but an error appeared on the actual input.

Rather than duplicating logic that is happening elsewhere in the validators, and since there is no shared state of the errors found in each accordion item, this is a quick hack to add an additional check to the accordion to see if any additional errors are visible (beyond what is caught by the validator). It uses the same approach as the `ErrorList` component: https://github.com/18F/e-QIP-prototype/blob/develop/src/components/ErrorList/ErrorList.jsx#L234-L248. The result is the top level error now being accurately reflected when there is any error in an accordion entry.

**Before:**
![screen shot 2018-10-16 at 3 16 45 pm](https://user-images.githubusercontent.com/1178494/47041632-54ced080-d157-11e8-8e80-470a8b603260.png)
![screen shot 2018-10-16 at 3 17 36 pm](https://user-images.githubusercontent.com/1178494/47041634-57312a80-d157-11e8-850c-fb6475586fe3.png)

**After:**
![screen shot 2018-10-16 at 3 16 45 pm](https://user-images.githubusercontent.com/1178494/47041703-847dd880-d157-11e8-826d-bb329dbfc490.png)

![screen shot 2018-10-16 at 3 22 31 pm](https://user-images.githubusercontent.com/1178494/47041646-5dbfa200-d157-11e8-8287-cbd834a7f984.png)
