### PR TITLE
Removes --coverage option from jest tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: Run React tests
           command: |
             TESTFILES=$(circleci tests glob "./src/**/*.test.js*" | circleci tests split)
-            make test-react FILES="$(echo ${TESTFILES})"
+            make test-react COVERAGE=--coverage FILES="$(echo ${TESTFILES})"
       - run:
           name: Run Go tests
           command: make test-go

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ lint-go:
 test: test-react test-go
 test-react:
 	$(info Running React test suite)
-	@docker-compose run --rm js yarn test $(FILES)
+	@docker-compose run --rm js yarn test $(COVERAGE) $(FILES)
 test-go:
 	$(info Running Go test suite)
 	@docker-compose run --rm api make test

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     ]
   },
   "scripts": {
-    "test": "NODE_ENV=test jest --ci --coverage --silent",
+    "test": "NODE_ENV=test jest --ci --silent",
     "lint-css": "gulp lint",
     "lint-js": "eslint --ext .js,.jsx src/",
     "lint": "npm run lint-css && npm run lint-js",


### PR DESCRIPTION
Fixes #955 

* We already collect code coverage information from codecov, having the
jest reporter is redundant, and also slows down the tests considerably

This runs the front end tests in about 8.5 minutes, as opposed to the 13 minutes it took previously. Not amazing, but an improvement.