### PR TITLE
Check min and max dates in date validator

### DIFF
--- a/src/validators/datecontrol.js
+++ b/src/validators/datecontrol.js
@@ -93,7 +93,7 @@ export default class DateControlValidator {
     return date > this.minDate
   }
 
-  isValid() {
+  validDate() {
     if (
       (!this.day && !this.hideDay) ||
       (!this.month && !this.hideMonth) ||
@@ -101,8 +101,11 @@ export default class DateControlValidator {
     ) {
       return false
     }
-
     return true
+  }
+
+  isValid() {
+    return this.validDate() && this.validMaxDate() && this.validMinDate()
   }
 }
 

--- a/src/validators/datecontrol.test.js
+++ b/src/validators/datecontrol.test.js
@@ -51,7 +51,9 @@ describe('date control validator', function() {
     ]
 
     tests.forEach(test => {
-      expect(new DateControlValidator(test.data).isValid()).toBe(test.expected)
+      expect(new DateControlValidator(test.data).validDate()).toBe(
+        test.expected
+      )
     })
   })
 

--- a/src/validators/daterange.js
+++ b/src/validators/daterange.js
@@ -19,11 +19,11 @@ export default class DateRangeValidator {
    * Validates the date ranges
    */
   isValid() {
-    if (!new DateControlValidator(this.from || {}).validDate()) {
+    if (!new DateControlValidator(this.from).validDate()) {
       return false
     }
 
-    if (!new DateControlValidator(this.to || {}).validDate()) {
+    if (!new DateControlValidator(this.to).validDate()) {
       return false
     }
 

--- a/src/validators/daterange.js
+++ b/src/validators/daterange.js
@@ -19,11 +19,11 @@ export default class DateRangeValidator {
    * Validates the date ranges
    */
   isValid() {
-    if (!new DateControlValidator(this.from || {}).isValid()) {
+    if (!new DateControlValidator(this.from || {}).validDate()) {
       return false
     }
 
-    if (!new DateControlValidator(this.to || {}).isValid()) {
+    if (!new DateControlValidator(this.to || {}).validDate()) {
       return false
     }
 

--- a/src/validators/gambling.test.js
+++ b/src/validators/gambling.test.js
@@ -101,7 +101,7 @@ describe('gambling debt component validation', function() {
                     value: 'Some action'
                   },
                   Dates: {
-                    from: null,
+                    from: {},
                     to: {
                       month: '1',
                       day: '1',

--- a/src/validators/identificationbirthdate.js
+++ b/src/validators/identificationbirthdate.js
@@ -3,10 +3,10 @@ import DateControlValidator from './datecontrol'
 export default class IdentificationBirthDateValidator {
   constructor(data = {}) {
     this.date = data.Date || {}
-    this.confirmed = data.Confirmed || {}
   }
 
   isValid() {
+    this.date.minDateEqualTo = true
     return new DateControlValidator(this.date).isValid()
   }
 }

--- a/src/validators/passport.test.js
+++ b/src/validators/passport.test.js
@@ -120,7 +120,7 @@ describe('Passport component validation', function() {
           Card: 'Book'
         },
         expected: true
-      },
+      }
     ]
 
     tests.forEach(test => {
@@ -184,7 +184,7 @@ describe('Passport component validation', function() {
       },
       {
         data: {
-          Issued: null
+          Issued: {}
         },
         expected: false
       },


### PR DESCRIPTION
Fixes #632 

On the final review, as the app loops through the various sections and calls the validator of each subsection to check validity. In the case of the applicant's birthdate it was ultimately calling `DateControlValidator.isValid()` which only checks that there is a month, day, and year (https://github.com/18F/e-QIP-prototype/blob/develop/src/validators/datecontrol.js#L96-L106). However the `DateControl` component itself has some validation itself that does the min/max checks: https://github.com/18F/e-QIP-prototype/blob/develop/src/components/Form/DateControl/DateControl.jsx#L484-L512 which is why errors are displayed on the actual subsection. So calling `DateControlValidator.isValid()` directly, as the final review page does, bypasses those checks giving the impression that it's valid.

This incorporates the min/max checks into `DateControlValidator.isValid()` which should allow incorrect dates to be flagged everywhere, and hopefully catch other similar cases in which invalid dates are not being caught in the final review.