### PR TITLE
Fix IE11 nav menu slideout issue

### DIFF
--- a/src/sass/phone.scss
+++ b/src/sass/phone.scss
@@ -205,8 +205,6 @@
     width: 100%;
 
     .form-navigation {
-      transform: translateX(-100%);
-      -webkit-transform: translateX(-100%);
 
       .section-name {
         max-width: 88%;
@@ -242,19 +240,19 @@
       }
 
       .form-navigation {
-        animation: slide-out 0.5s forwards;
         -webkit-animation: slide-out 0.5s forwards;
+        animation: slide-out 0.5s forwards;
 
-        @keyframes slide-out {
+        @-webkit-keyframes slide-out {
           0% {
-            transform: translateX(-100%);
+            -webkit-transform: translateX(-100%);
           }
           100% {
-            transform: translateX(0%);
+            -webkit-transform: translateX(0%);
           }
         }
 
-        @-webkit-keyframes slide-out {
+        @keyframes slide-out {
           0% {
             transform: translateX(-100%);
           }


### PR DESCRIPTION
Fixes #1025 

I believe this issue is fixed. I've learned that testing IE11 fan be finicky, so please take some time to make sure this works.

Previously, in IE11 on tablet/mobile devices, when clicking on the hamburger icon to expand the navigation menu, the navigation menu would not display.

After the fix, the navigation menu displays as expected.

Tested on Chrome, Firefox, Safari, and IE11