### PR TITLE
Update to accordion for test case 7

### DIFF
--- a/src/components/Form/Accordion/Accordion.jsx
+++ b/src/components/Form/Accordion/Accordion.jsx
@@ -534,8 +534,11 @@ export default class Accordion extends ValidationElement {
   }
 
   hasNoErrors(uuid) {
-    const element = document.getElementById(uuid)
-    const errors = element.querySelectorAll('.field .messages .message.error')
+    const el = document.getElementById(uuid)
+    if (!el) {
+      return true
+    }
+    const errors = el.querySelectorAll('.field .messages .message.error')
 
     return errors.length < 1
   }


### PR DESCRIPTION
Fixes #1038

Do not run `querySelectorAll` unless the element exists.