### PR TITLE
Update identifying document numbers to set max number and make alphanumeric

### DIFF
--- a/src/components/Form/ForeignBornDocuments/ForeignBornDocuments.jsx
+++ b/src/components/Form/ForeignBornDocuments/ForeignBornDocuments.jsx
@@ -290,6 +290,9 @@ export default class ForeignBornDocuments extends ValidationElement {
             label="Document Number"
             {...this.props.DocumentNumber}
             className="foreign-born-document-number"
+            maxlength="30"
+            pattern="^[a-zA-Z0-9]*$"
+            prefix={"alphanumeric"}
             onUpdate={this.updateDocumentNumber}
             onError={this.props.onError}
             required={this.props.required}

--- a/src/components/Form/ForeignBornDocuments/ForeignBornDocuments.jsx
+++ b/src/components/Form/ForeignBornDocuments/ForeignBornDocuments.jsx
@@ -293,7 +293,7 @@ export default class ForeignBornDocuments extends ValidationElement {
             className="foreign-born-document-number"
             maxlength="30"
             pattern={alphaNumericRegEx}
-            prefix={"alphanumeric"}
+            prefix="alphanumeric"
             onUpdate={this.updateDocumentNumber}
             onError={this.props.onError}
             required={this.props.required}

--- a/src/components/Form/ForeignBornDocuments/ForeignBornDocuments.jsx
+++ b/src/components/Form/ForeignBornDocuments/ForeignBornDocuments.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ValidationElement from '../ValidationElement'
 import { i18n } from '../../../config'
+import { alphaNumericRegEx } from '../../../validators/helpers'
 import RadioGroup from '../RadioGroup'
 import Radio from '../Radio'
 import Textarea from '../Textarea'
@@ -291,7 +292,7 @@ export default class ForeignBornDocuments extends ValidationElement {
             {...this.props.DocumentNumber}
             className="foreign-born-document-number"
             maxlength="30"
-            pattern="^[a-zA-Z0-9]*$"
+            pattern={alphaNumericRegEx}
             prefix={"alphanumeric"}
             onUpdate={this.updateDocumentNumber}
             onError={this.props.onError}

--- a/src/components/Section/Citizenship/Status/Status.jsx
+++ b/src/components/Section/Citizenship/Status/Status.jsx
@@ -386,6 +386,9 @@ export default class Status extends SubsectionElement {
               <Text
                 name="DocumentNumber"
                 className="document-number"
+                maxlength="30"
+                pattern="^[a-zA-Z0-9]*$"
+                prefix={"alphanumeric"}
                 {...this.props.DocumentNumber}
                 onUpdate={this.updateDocumentNumber}
                 onError={this.handleError}
@@ -448,6 +451,9 @@ export default class Status extends SubsectionElement {
                 name="CertificateNumber"
                 className="certificate-number"
                 {...this.props.CertificateNumber}
+                maxlength="30"
+                pattern="^[a-zA-Z0-9]*$"
+                prefix={"alphanumeric"}
                 onUpdate={this.updateCertificateNumber}
                 onError={this.handleError}
                 required={this.props.required}
@@ -592,6 +598,9 @@ export default class Status extends SubsectionElement {
                 <Text
                   name="AlienRegistrationNumber"
                   className="alien-registration-number"
+                  maxlength="30"
+                  pattern="^[a-zA-Z0-9]*$"
+                  prefix={"alphanumeric"}
                   {...this.props.AlienRegistrationNumber}
                   onUpdate={this.updateAlienRegistrationNumber}
                   onError={this.handleError}
@@ -608,6 +617,9 @@ export default class Status extends SubsectionElement {
               <Text
                 name="CertificateNumber"
                 className="certificate-number"
+                maxlength="30"
+                pattern="^[a-zA-Z0-9]*$"
+                prefix={"alphanumeric"}
                 {...this.props.CertificateNumber}
                 onUpdate={this.updateCertificateNumber}
                 onError={this.handleError}
@@ -740,6 +752,9 @@ export default class Status extends SubsectionElement {
               <Text
                 name="AlienRegistrationNumber"
                 className="alien-registration-number"
+                maxlength="30"
+                pattern="^[a-zA-Z0-9]*$"
+                prefix={"alphanumeric"}
                 {...this.props.AlienRegistrationNumber}
                 onUpdate={this.updateAlienRegistrationNumber}
                 onError={this.handleError}
@@ -755,6 +770,9 @@ export default class Status extends SubsectionElement {
               <Text
                 name="PermanentResidentCardNumber"
                 className="permanent-resident-card-number"
+                maxlength="30"
+                pattern="^[a-zA-Z0-9]*$"
+                prefix={"alphanumeric"}
                 {...this.props.PermanentResidentCardNumber}
                 onUpdate={this.updatePermanentResidentCardNumber}
                 onError={this.handleError}
@@ -771,6 +789,9 @@ export default class Status extends SubsectionElement {
                 name="CertificateNumber"
                 className="certificate-number"
                 {...this.props.CertificateNumber}
+                maxlength="30"
+                pattern="^[a-zA-Z0-9]*$"
+                prefix={"alphanumeric"}
                 onUpdate={this.updateCertificateNumber}
                 onError={this.handleError}
                 required={this.props.required}
@@ -929,6 +950,9 @@ export default class Status extends SubsectionElement {
               <Text
                 name="AlienRegistrationNumber"
                 className="alien-registration-number"
+                maxlength="30"
+                pattern="^[a-zA-Z0-9]*$"
+                prefix={"alphanumeric"}
                 {...this.props.AlienRegistrationNumber}
                 onUpdate={this.updateAlienRegistrationNumber}
                 onError={this.handleError}
@@ -1030,6 +1054,9 @@ export default class Status extends SubsectionElement {
               <Text
                 name="DocumentNumber"
                 className="document-number"
+                maxlength="30"
+                pattern="^[a-zA-Z0-9]*$"
+                prefix={"alphanumeric"}
                 {...this.props.DocumentNumber}
                 onUpdate={this.updateDocumentNumber}
                 onError={this.handleError}

--- a/src/components/Section/Citizenship/Status/Status.jsx
+++ b/src/components/Section/Citizenship/Status/Status.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { i18n } from '../../../../config'
+import { alphaNumericRegEx } from '../../../../validators/helpers'
 import schema from '../../../../schema'
 import validate from '../../../../validators'
 import SubsectionElement from '../../SubsectionElement'
@@ -387,7 +388,7 @@ export default class Status extends SubsectionElement {
                 name="DocumentNumber"
                 className="document-number"
                 maxlength="30"
-                pattern="^[a-zA-Z0-9]*$"
+                pattern={alphaNumericRegEx}
                 prefix="alphanumeric"
                 {...this.props.DocumentNumber}
                 onUpdate={this.updateDocumentNumber}
@@ -452,7 +453,7 @@ export default class Status extends SubsectionElement {
                 className="certificate-number"
                 {...this.props.CertificateNumber}
                 maxlength="30"
-                pattern="^[a-zA-Z0-9]*$"
+                pattern={alphaNumericRegEx}
                 prefix="alphanumeric"
                 onUpdate={this.updateCertificateNumber}
                 onError={this.handleError}
@@ -599,7 +600,7 @@ export default class Status extends SubsectionElement {
                   name="AlienRegistrationNumber"
                   className="alien-registration-number"
                   maxlength="30"
-                  pattern="^[a-zA-Z0-9]*$"
+                  pattern={alphaNumericRegEx}
                   prefix="alphanumeric"
                   {...this.props.AlienRegistrationNumber}
                   onUpdate={this.updateAlienRegistrationNumber}
@@ -618,7 +619,7 @@ export default class Status extends SubsectionElement {
                 name="CertificateNumber"
                 className="certificate-number"
                 maxlength="30"
-                pattern="^[a-zA-Z0-9]*$"
+                pattern={alphaNumericRegEx}
                 prefix="alphanumeric"
                 {...this.props.CertificateNumber}
                 onUpdate={this.updateCertificateNumber}
@@ -753,7 +754,7 @@ export default class Status extends SubsectionElement {
                 name="AlienRegistrationNumber"
                 className="alien-registration-number"
                 maxlength="30"
-                pattern="^[a-zA-Z0-9]*$"
+                pattern={alphaNumericRegEx}
                 prefix="alphanumeric"
                 {...this.props.AlienRegistrationNumber}
                 onUpdate={this.updateAlienRegistrationNumber}
@@ -771,7 +772,7 @@ export default class Status extends SubsectionElement {
                 name="PermanentResidentCardNumber"
                 className="permanent-resident-card-number"
                 maxlength="30"
-                pattern="^[a-zA-Z0-9]*$"
+                pattern={alphaNumericRegEx}
                 prefix="alphanumeric"
                 {...this.props.PermanentResidentCardNumber}
                 onUpdate={this.updatePermanentResidentCardNumber}
@@ -790,7 +791,7 @@ export default class Status extends SubsectionElement {
                 className="certificate-number"
                 {...this.props.CertificateNumber}
                 maxlength="30"
-                pattern="^[a-zA-Z0-9]*$"
+                pattern={alphaNumericRegEx}
                 prefix="alphanumeric"
                 onUpdate={this.updateCertificateNumber}
                 onError={this.handleError}
@@ -951,7 +952,7 @@ export default class Status extends SubsectionElement {
                 name="AlienRegistrationNumber"
                 className="alien-registration-number"
                 maxlength="30"
-                pattern="^[a-zA-Z0-9]*$"
+                pattern={alphaNumericRegEx}
                 prefix="alphanumeric"
                 {...this.props.AlienRegistrationNumber}
                 onUpdate={this.updateAlienRegistrationNumber}
@@ -1055,7 +1056,7 @@ export default class Status extends SubsectionElement {
                 name="DocumentNumber"
                 className="document-number"
                 maxlength="30"
-                pattern="^[a-zA-Z0-9]*$"
+                pattern={alphaNumericRegEx}
                 prefix="alphanumeric"
                 {...this.props.DocumentNumber}
                 onUpdate={this.updateDocumentNumber}

--- a/src/components/Section/Citizenship/Status/Status.jsx
+++ b/src/components/Section/Citizenship/Status/Status.jsx
@@ -388,7 +388,7 @@ export default class Status extends SubsectionElement {
                 className="document-number"
                 maxlength="30"
                 pattern="^[a-zA-Z0-9]*$"
-                prefix={"alphanumeric"}
+                prefix="alphanumeric"
                 {...this.props.DocumentNumber}
                 onUpdate={this.updateDocumentNumber}
                 onError={this.handleError}
@@ -453,7 +453,7 @@ export default class Status extends SubsectionElement {
                 {...this.props.CertificateNumber}
                 maxlength="30"
                 pattern="^[a-zA-Z0-9]*$"
-                prefix={"alphanumeric"}
+                prefix="alphanumeric"
                 onUpdate={this.updateCertificateNumber}
                 onError={this.handleError}
                 required={this.props.required}
@@ -600,7 +600,7 @@ export default class Status extends SubsectionElement {
                   className="alien-registration-number"
                   maxlength="30"
                   pattern="^[a-zA-Z0-9]*$"
-                  prefix={"alphanumeric"}
+                  prefix="alphanumeric"
                   {...this.props.AlienRegistrationNumber}
                   onUpdate={this.updateAlienRegistrationNumber}
                   onError={this.handleError}
@@ -619,7 +619,7 @@ export default class Status extends SubsectionElement {
                 className="certificate-number"
                 maxlength="30"
                 pattern="^[a-zA-Z0-9]*$"
-                prefix={"alphanumeric"}
+                prefix="alphanumeric"
                 {...this.props.CertificateNumber}
                 onUpdate={this.updateCertificateNumber}
                 onError={this.handleError}
@@ -754,7 +754,7 @@ export default class Status extends SubsectionElement {
                 className="alien-registration-number"
                 maxlength="30"
                 pattern="^[a-zA-Z0-9]*$"
-                prefix={"alphanumeric"}
+                prefix="alphanumeric"
                 {...this.props.AlienRegistrationNumber}
                 onUpdate={this.updateAlienRegistrationNumber}
                 onError={this.handleError}
@@ -772,7 +772,7 @@ export default class Status extends SubsectionElement {
                 className="permanent-resident-card-number"
                 maxlength="30"
                 pattern="^[a-zA-Z0-9]*$"
-                prefix={"alphanumeric"}
+                prefix="alphanumeric"
                 {...this.props.PermanentResidentCardNumber}
                 onUpdate={this.updatePermanentResidentCardNumber}
                 onError={this.handleError}
@@ -791,7 +791,7 @@ export default class Status extends SubsectionElement {
                 {...this.props.CertificateNumber}
                 maxlength="30"
                 pattern="^[a-zA-Z0-9]*$"
-                prefix={"alphanumeric"}
+                prefix="alphanumeric"
                 onUpdate={this.updateCertificateNumber}
                 onError={this.handleError}
                 required={this.props.required}
@@ -952,7 +952,7 @@ export default class Status extends SubsectionElement {
                 className="alien-registration-number"
                 maxlength="30"
                 pattern="^[a-zA-Z0-9]*$"
-                prefix={"alphanumeric"}
+                prefix="alphanumeric"
                 {...this.props.AlienRegistrationNumber}
                 onUpdate={this.updateAlienRegistrationNumber}
                 onError={this.handleError}
@@ -1056,7 +1056,7 @@ export default class Status extends SubsectionElement {
                 className="document-number"
                 maxlength="30"
                 pattern="^[a-zA-Z0-9]*$"
-                prefix={"alphanumeric"}
+                prefix="alphanumeric"
                 {...this.props.DocumentNumber}
                 onUpdate={this.updateDocumentNumber}
                 onError={this.handleError}

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -836,6 +836,9 @@ export default class Relative extends ValidationElement {
               <Text
                 name="DocumentNumber"
                 className="relative-documentnumber"
+                maxlength="30"
+                pattern="^[a-zA-Z0-9]*$"
+                prefix={"alphanumeric"}
                 {...this.props.DocumentNumber}
                 onError={this.props.onError}
                 onUpdate={this.updateDocumentNumber}

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { i18n } from '../../../../config'
+import { alphaNumericRegEx } from '../../../../validators/helpers'
 import {
   ValidationElement,
   Branch,
@@ -837,7 +838,7 @@ export default class Relative extends ValidationElement {
                 name="DocumentNumber"
                 className="relative-documentnumber"
                 maxlength="30"
-                pattern="^[a-zA-Z0-9]*$"
+                pattern={alphaNumericRegEx}
                 prefix="alphanumeric"
                 {...this.props.DocumentNumber}
                 onError={this.props.onError}

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -838,7 +838,7 @@ export default class Relative extends ValidationElement {
                 className="relative-documentnumber"
                 maxlength="30"
                 pattern="^[a-zA-Z0-9]*$"
-                prefix={"alphanumeric"}
+                prefix="alphanumeric"
                 {...this.props.DocumentNumber}
                 onError={this.props.onError}
                 onUpdate={this.updateDocumentNumber}

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -1095,5 +1095,11 @@ export const error = {
   validMinimumCitizenships: {
     title: 'There is a problem with your entry',
     message: 'Please provide a minimum of two countries.'
+  },
+  alphanumeric: {
+    pattern: {
+      title: 'There is a problem with your entry',
+      message: 'Only use letters and numbers'
+    }
   }
 }

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -1097,9 +1097,13 @@ export const error = {
     message: 'Please provide a minimum of two countries.'
   },
   alphanumeric: {
+    required: {
+      title: 'Your response is required',
+      message: ''
+    },
     pattern: {
       title: 'There is a problem with your entry',
-      message: 'Only use letters and numbers'
+      message: 'Only use letters and numbers.'
     }
   }
 }

--- a/src/validators/helpers.js
+++ b/src/validators/helpers.js
@@ -311,3 +311,5 @@ export const buildDate = date => {
     return null
   }
 }
+
+export const alphaNumericRegEx = "^[a-zA-Z0-9]*$"


### PR DESCRIPTION
This fixes #922 

Example of the fields throwing errors when encountering a special character
![screen shot 2018-10-22 at 11 22 19 am](https://user-images.githubusercontent.com/1449852/47301560-2df81a80-d5ed-11e8-9683-700d876bbcab.png)
