### PR TITLE
Persist tax year field

### DIFF
--- a/src/schema/section/financial-taxes.js
+++ b/src/schema/section/financial-taxes.js
@@ -6,7 +6,7 @@ export const financialTaxes = (data = {}) => {
     return {
       Item: {
         Failure: form.radio(xitem.Failure),
-        Year: form.number(xitem.Year),
+        Year: form.datecontrol(xitem.Year),
         YearEstimated: form.checkbox(xitem.YearEstimated),
         Reason: form.textarea(xitem.Reason),
         Agency: form.text(xitem.Agency),


### PR DESCRIPTION
Fixes #1055

This fixes the year field to use `datecontrol` in the schema rather than `number` so the date is properly saved to the database.