### PR TITLE
Add current git tag version to introduction modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,10 @@
     "clearMocks": true,
     "roots": [
       "<rootDir>/src"
-    ]
+    ],
+    "globals": {
+      "EAPP_VERSION": "MAJOR.MINOR.PATCH-IDENTIFIER"
+    }
   },
   "scripts": {
     "test": "NODE_ENV=test jest --ci --coverage --silent",
@@ -77,6 +80,7 @@
     "eslint-import-resolver-webpack": "^0.10.1",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-react": "^7.10.0",
+    "git-revision-webpack-plugin": "^3.0.3",
     "gulp": "^4.0.0",
     "jest": "^23.1.0",
     "redux-devtools-extension": "^2.13.2",

--- a/src/config/locales/en/introduction.js
+++ b/src/config/locales/en/introduction.js
@@ -1,7 +1,9 @@
+/*global EAPP_VERSION*/
+
 export const introduction = {
   contents: [
     '# Questionnaire for National Security Positions',
-    'National Background Investigation System (NBIS) eApp version MAJOR.MINOR.PATCH-IDENTIFIER',
+    `National Background Investigation System (NBIS) eApp version ${EAPP_VERSION}`,
     '**Follow instructions completely or your form will be unable to be processed. If you have any questions, contact the office that provided you the form.**',
     '## Instructions for completing this form ',
     '1. **Follow the instructions provided to you by the office that gave you this form** and any other clarifying instructions, provided by that office, to assist you with completion of this form. You should retain a copy of the completed form for your records.',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const staging = process.env.NODE_ENV === 'staging'
 const debug = !production && !staging
 const webpack = require('webpack')
 const path = require('path')
+const GitRevisionPlugin = require('git-revision-webpack-plugin')
 
 module.exports = {
   mode: production ? 'production' : 'development',
@@ -22,19 +23,29 @@ module.exports = {
       {
         test: /\.jsx?$/,
         include: path.resolve(__dirname, 'src'),
-        use: [
-          'cache-loader',
-          'babel-loader'
-        ]
+        use: ['cache-loader', 'babel-loader']
       }
     ]
   },
   devtool: debug ? 'cheap-module-source-map' : 'source-map',
   plugins: [
     new webpack.EnvironmentPlugin([
-      'API_BASE_URL', 'COOKIE_DOMAIN', 'HASH_ROUTING',
-      'BASIC_ENABLED', 'SAML_ENABLED', 'SESSION_TIMEOUT',
-      'ATTACHMENTS_ENABLED', 'FILE_MAXIMUM_SIZE', 'FILE_TYPES'
-    ])
+      'API_BASE_URL',
+      'COOKIE_DOMAIN',
+      'HASH_ROUTING',
+      'BASIC_ENABLED',
+      'SAML_ENABLED',
+      'SESSION_TIMEOUT',
+      'ATTACHMENTS_ENABLED',
+      'FILE_MAXIMUM_SIZE',
+      'FILE_TYPES'
+    ]),
+    new webpack.DefinePlugin({
+      EAPP_VERSION: JSON.stringify(
+        new GitRevisionPlugin({
+          versionCommand: 'describe --tags --always'
+        }).version()
+      )
+    })
   ]
 }


### PR DESCRIPTION
Fixes #844 

Uses webpack to set latest Git tag to a constant available to the app. Uses commit hash as a fallback if no tag is available. 

<img width="777" alt="screen shot 2018-10-25 at 4 19 59 pm" src="https://user-images.githubusercontent.com/1178494/47528001-05cd1d80-d872-11e8-9c9d-38fd76fc4f6b.png">
