### PR TITLE
Fix overlapping telephone fields

### DIFF
--- a/src/components/Form/Telephone/Telephone.jsx
+++ b/src/components/Form/Telephone/Telephone.jsx
@@ -387,7 +387,9 @@ export default class Telephone extends ValidationElement {
           className={[
             `${this.props.typeClass || ''}`,
             `${this.props.noNumber ? 'disabled' : ''}`
-          ].join(' ').trim()}>
+          ]
+            .join(' ')
+            .trim()}>
           {i18n.t('telephone.dsn.label')}
         </label>
         <div className="telephone-number-fields">
@@ -437,21 +439,22 @@ export default class Telephone extends ValidationElement {
               this.props.tab(this.refs.dsn_first.refs.text.refs.input)
             }}
           />
-        </div>
-        <Show when={this.props.allowNotApplicable}>
-          <span>
-            <span className="separator extension">or</span>
-            <Checkbox
-              name="nonumber"
-              className="nonumber"
-              label={i18n.t('telephone.noNumber.label')}
-              value="NA"
-              checked={this.props.noNumber}
-              onUpdate={this.updateNoNumber}
-              onError={this.handleErrorNoNumber}
-            />
+          <span
+            className={
+              this.props.allowNotApplicable ? 'separator extension' : 'hidden'
+            }>
+            or
           </span>
-        </Show>
+          <Checkbox
+            name="nonumber"
+            className={this.props.allowNotApplicable ? 'nonumber' : 'hidden'}
+            label={i18n.t('telephone.noNumber.label')}
+            value="NA"
+            checked={this.props.noNumber}
+            onUpdate={this.updateNoNumber}
+            onError={this.handleErrorNoNumber}
+          />
+        </div>
       </div>
     )
   }
@@ -463,7 +466,9 @@ export default class Telephone extends ValidationElement {
           className={[
             `${this.props.typeClass || ''}`,
             `${this.props.noNumber ? 'disabled' : ''}`
-          ].join(' ').trim()}>
+          ]
+            .join(' ')
+            .trim()}>
           {i18n.t('telephone.domestic.label')}
         </label>
         <div className="telephone-number-fields">
@@ -558,21 +563,22 @@ export default class Telephone extends ValidationElement {
               this.props.tab(this.refs.domestic_third.refs.text.refs.input)
             }}
           />
-        </div>
-        <Show when={this.props.allowNotApplicable}>
-          <span>
-            <span className="separator extension">or</span>
-            <Checkbox
-              name="nonumber"
-              className="nonumber"
-              label={i18n.t('telephone.noNumber.label')}
-              value="NA"
-              checked={this.props.noNumber}
-              onUpdate={this.updateNoNumber}
-              onError={this.handleErrorNoNumber}
-            />
+          <span
+            className={
+              this.props.allowNotApplicable ? 'separator extension' : 'hidden'
+            }>
+            or
           </span>
-        </Show>
+          <Checkbox
+            name="nonumber"
+            className={this.props.allowNotApplicable ? 'nonumber' : 'hidden'}
+            label={i18n.t('telephone.noNumber.label')}
+            value="NA"
+            checked={this.props.noNumber}
+            onUpdate={this.updateNoNumber}
+            onError={this.handleErrorNoNumber}
+          />
+        </div>
       </div>
     )
   }
@@ -584,7 +590,9 @@ export default class Telephone extends ValidationElement {
           className={[
             `${this.props.typeClass || ''}`,
             `${this.props.noNumber ? 'disabled' : ''}`
-          ].join(' ').trim()}>
+          ]
+            .join(' ')
+            .trim()}>
           {i18n.t('telephone.international.label')}
         </label>
         <span className="separator">+</span>
@@ -653,20 +661,21 @@ export default class Telephone extends ValidationElement {
             this.props.tab(this.refs.int_second.refs.text.refs.input)
           }}
         />
-        <Show when={this.props.allowNotApplicable}>
-          <span>
-            <span className="separator extension">or</span>
-            <Checkbox
-              name="nonumber"
-              className="nonumber"
-              label={i18n.t('telephone.noNumber.label')}
-              value="NA"
-              checked={this.props.noNumber}
-              onUpdate={this.updateNoNumber}
-              onError={this.handleErrorNoNumber}
-            />
-          </span>
-        </Show>
+        <span
+          className={
+            this.props.allowNotApplicable ? 'separator extension' : 'hidden'
+          }>
+          or
+        </span>
+        <Checkbox
+          name="nonumber"
+          className={this.props.allowNotApplicable ? 'nonumber' : 'hidden'}
+          label={i18n.t('telephone.noNumber.label')}
+          value="NA"
+          checked={this.props.noNumber}
+          onUpdate={this.updateNoNumber}
+          onError={this.handleErrorNoNumber}
+        />
       </div>
     )
   }

--- a/src/components/Form/Telephone/Telephone.scss
+++ b/src/components/Form/Telephone/Telephone.scss
@@ -37,6 +37,15 @@
     }
   }
 
+  .nonumber {
+    position: relative;
+
+    label {
+      margin-right: 0;
+      width: 13rem;
+    }
+  }
+
   .separator {
     font-size: 2rem;
     line-height: 2rem;
@@ -52,6 +61,7 @@
   }
 
   .number,
+  .nonumber,
   .separator {
     display: table-cell;
     vertical-align: middle;
@@ -87,16 +97,5 @@
   .phonetype-option.block label {
     height: auto !important;
     width: 8.7rem !important;
-  }
-
-  .nonumber {
-    display: inline-block;
-    vertical-align: top;
-    margin-bottom: -2rem;
-
-    label {
-      width: 13rem;
-      margin-top: 2.5rem;
-    }
   }
 }


### PR DESCRIPTION
Fixes #1061 

Building off of https://github.com/18F/e-QIP-prototype/pull/973, this integrates the `I don't know` button in with the other refactored fields. Due to a limitation of React 15, our `<Show>` component has to insert a wrapper `<span>` around elements which was conflicting with the `display: table` that was used in the previous fix. This relies on css classes instead of the `<Show>` component. Tested in Chrome/IE11.

IE11:
<img width="572" alt="screen shot 2018-10-26 at 3 29 50 pm" src="https://user-images.githubusercontent.com/1178494/47589438-227f5900-d937-11e8-9a8f-0c6d92b705c5.png">
<img width="604" alt="screen shot 2018-10-26 at 3 29 59 pm" src="https://user-images.githubusercontent.com/1178494/47589443-24e1b300-d937-11e8-8bfd-05a37d3ea586.png">
<img width="502" alt="screen shot 2018-10-26 at 3 30 18 pm" src="https://user-images.githubusercontent.com/1178494/47589447-26ab7680-d937-11e8-9ccd-6333719476d9.png">


