### PR TITLE
Do not show certain employment questions when unemployment is selected

### DIFF
--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -464,7 +464,6 @@ export default class EmploymentItem extends ValidationElement {
           <div className="reference">
             <Field
               title={i18n.t('reference.heading.name')}
-              titleSize="h3"
               optional={true}
               filterErrors={Name.requiredErrorsOnly}
               scrollIntoView={this.props.scrollIntoView}>

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -258,7 +258,6 @@ export default class EmploymentItem extends ValidationElement {
    *    - Federal Contractor
    *    - Non-Government
    *    - Self Employment
-   *    - Unemployment
    *    - Other
    */
   showLeaving() {
@@ -283,7 +282,6 @@ export default class EmploymentItem extends ValidationElement {
           'FederalContractor',
           'NonGovernment',
           'SelfEmployment',
-          'Unemployment',
           'Other'
         ].includes(activity))
     )
@@ -456,109 +454,107 @@ export default class EmploymentItem extends ValidationElement {
         </Show>
 
         <Show when={this.showReference()}>
-          <div>
+          <Field
+            title={i18n.t(`${prefix}.heading.reference`)}
+            titleSize="h2"
+            className="no-margin-bottom"
+            scrollIntoView={this.props.scrollIntoView}
+          />
+
+          <div className="reference">
             <Field
-              title={i18n.t(`${prefix}.heading.reference`)}
-              titleSize="h2"
-              className="no-margin-bottom"
-              scrollIntoView={this.props.scrollIntoView}
-            />
+              title={i18n.t('reference.heading.name')}
+              titleSize="h3"
+              optional={true}
+              filterErrors={Name.requiredErrorsOnly}
+              scrollIntoView={this.props.scrollIntoView}>
+              <Name
+                name="ReferenceName"
+                prefix={'name'}
+                className="reference-name"
+                {...this.props.ReferenceName}
+                scrollIntoView={this.props.scrollIntoView}
+                onUpdate={this.updateReferenceName}
+                onError={this.props.onError}
+                required={this.props.required}
+              />
+            </Field>
 
-            <div className="reference">
-              <Field
-                title={i18n.t('reference.heading.name')}
-                titleSize="h3"
-                optional={true}
-                filterErrors={Name.requiredErrorsOnly}
-                scrollIntoView={this.props.scrollIntoView}>
-                <Name
-                  name="ReferenceName"
-                  prefix={'name'}
-                  className="reference-name"
-                  {...this.props.ReferenceName}
-                  scrollIntoView={this.props.scrollIntoView}
-                  onUpdate={this.updateReferenceName}
-                  onError={this.props.onError}
-                  required={this.props.required}
-                />
-              </Field>
+            <Field
+              title={i18n.t('reference.heading.phone.default')}
+              className="override-required"
+              help={'reference.help.phone'}
+              adjustFor="telephone"
+              scrollIntoView={this.props.scrollIntoView}>
+              <Telephone
+                name="ReferencePhone"
+                className="reference-phone"
+                {...this.props.ReferencePhone}
+                allowNotApplicable={false}
+                onUpdate={this.updateReferencePhone}
+                onError={this.props.onError}
+                required={this.props.required}
+              />
+            </Field>
 
-              <Field
-                title={i18n.t('reference.heading.phone.default')}
-                className="override-required"
-                help={'reference.help.phone'}
-                adjustFor="telephone"
-                scrollIntoView={this.props.scrollIntoView}>
-                <Telephone
-                  name="ReferencePhone"
-                  className="reference-phone"
-                  {...this.props.ReferencePhone}
-                  allowNotApplicable={false}
-                  onUpdate={this.updateReferencePhone}
-                  onError={this.props.onError}
-                  required={this.props.required}
-                />
-              </Field>
-
-              <Field
-                title={i18n.t('reference.heading.address')}
-                optional={true}
-                help={'reference.help.address'}
-                adjustFor="address"
-                scrollIntoView={this.props.scrollIntoView}>
-                <p>{i18n.t('reference.para.address')}</p>
-                <Location
-                  name="ReferenceAddress"
-                  className="reference-address"
-                  {...this.props.ReferenceAddress}
-                  label={i18n.t('reference.label.address')}
-                  layout={Location.ADDRESS}
-                  geocode={true}
-                  addressBooks={this.props.addressBooks}
-                  addressBook="Reference"
-                  showPostOffice={true}
-                  dispatch={this.props.dispatch}
-                  onUpdate={this.updateReferenceAddress}
-                  onError={this.props.onError}
-                />
-              </Field>
-            </div>
+            <Field
+              title={i18n.t('reference.heading.address')}
+              optional={true}
+              help={'reference.help.address'}
+              adjustFor="address"
+              scrollIntoView={this.props.scrollIntoView}>
+              <p>{i18n.t('reference.para.address')}</p>
+              <Location
+                name="ReferenceAddress"
+                className="reference-address"
+                {...this.props.ReferenceAddress}
+                label={i18n.t('reference.label.address')}
+                layout={Location.ADDRESS}
+                geocode={true}
+                addressBooks={this.props.addressBooks}
+                addressBook="Reference"
+                showPostOffice={true}
+                dispatch={this.props.dispatch}
+                onUpdate={this.updateReferenceAddress}
+                onError={this.props.onError}
+              />
+            </Field>
           </div>
         </Show>
 
         <Show when={this.showAdditionalActivity()}>
-          <div>
-            <Field
-              title={i18n.t(`${prefix}.heading.additionalActivity`)}
-              titleSize="h2"
-              optional={true}
-              className="no-margin-bottom"
-              scrollIntoView={this.props.scrollIntoView}>
-              {i18n.m(`${prefix}.para.additionalActivity`)}
-            </Field>
+          <Field
+            title={i18n.t(`${prefix}.heading.additionalActivity`)}
+            titleSize="h2"
+            optional={true}
+            className="no-margin-bottom"
+            scrollIntoView={this.props.scrollIntoView}>
+            {i18n.m(`${prefix}.para.additionalActivity`)}
+          </Field>
 
-            <AdditionalActivity
-              name="Additional"
-              {...this.props.Additional}
-              onUpdate={this.updateAdditional}
-              onError={this.props.onError}
-              required={this.props.required}
-              scrollIntoView={this.props.scrollIntoView}
-            />
-          </div>
+          <AdditionalActivity
+            name="Additional"
+            {...this.props.Additional}
+            onUpdate={this.updateAdditional}
+            onError={this.props.onError}
+            required={this.props.required}
+            scrollIntoView={this.props.scrollIntoView}
+          />
         </Show>
 
-        <ReasonLeft
-          name="ReasonLeft"
-          {...this.props.ReasonLeft}
-          Dates={this.props.Dates}
-          onUpdate={this.updateReasonLeft}
-          onError={this.props.onError}
-          required={this.props.required}
-          scrollIntoView={this.props.scrollIntoView}
-        />
+        <Show when={this.showEmployed() && this.showLeaving()}>
+          <ReasonLeft
+            name="ReasonLeft"
+            {...this.props.ReasonLeft}
+            Dates={this.props.Dates}
+            onUpdate={this.updateReasonLeft}
+            onError={this.props.onError}
+            required={this.props.required}
+            scrollIntoView={this.props.scrollIntoView}
+          />
+        </Show>
 
-        <Show when={this.showLeaving()}>
+        <Show when={this.showEmployed() && this.showLeaving()}>
           <Reprimand
             name="Reprimand"
             {...this.props.Reprimand}

--- a/src/components/Section/History/Employment/EmploymentItem.test.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.test.jsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { today, daysAgo } from '../dateranges'
 import EmploymentItem from './EmploymentItem'
+import ReasonLeft from './ReasonLeft'
+import Reprimand from './Reprimand'
 
 describe('The employment component', () => {
   it('no error on empty', () => {
@@ -133,43 +135,36 @@ describe('The employment component', () => {
     expect(component.find('.reason-description').length).toBe(0)
   })
 
-  it('does not display reason for leaving for unemployment', () => {
-    const past = daysAgo(today, 365 * 3)
-    const props = {
-      EmploymentActivity: { value: 'Unemployment' },
-      Dates: {
-        present: true,
-        from: {
-          month: `${past.getMonth() + 1}`,
-          day: `${past.getDate()}`,
-          year: `${past.getFullYear()}`
-        },
-        to: {}
+  describe('when unemployment is selected', () => {
+    let component
+
+    beforeEach(() => {
+      const past = daysAgo(today, 365 * 3)
+      const props = {
+        EmploymentActivity: { value: 'Unemployment' },
+        Dates: {
+          present: true,
+          from: {
+            month: `${past.getMonth() + 1}`,
+            day: `${past.getDate()}`,
+            year: `${past.getFullYear()}`
+          },
+          to: {}
+        }
       }
-    }
-    const component = mount(<EmploymentItem {...props} />)
-    expect(component.find('.reason-description').length).toBe(0)
+      component = mount(<EmploymentItem {...props} />)
+    })
+
+    it('it does not display reason for leaving', () => {
+      expect(component.contains(<ReasonLeft />)).toBe(false)
+    })
+
+    it('it does not display reprimand', () => {
+      expect(component.contains(<Reprimand />)).toBe(false)
+    })
   })
 
-  it('does not display reprimand for unemployment', () => {
-    const past = daysAgo(today, 365 * 3)
-    const props = {
-      EmploymentActivity: { value: 'Unemployment' },
-      Dates: {
-        present: true,
-        from: {
-          month: `${past.getMonth() + 1}`,
-          day: `${past.getDate()}`,
-          year: `${past.getFullYear()}`
-        },
-        to: {}
-      }
-    }
-    const component = mount(<EmploymentItem {...props} />)
-    expect(component.find('.reprimand-branch').length).toBe(0)
-  })
-
-  it('does display reason for leaving if not currently employed', () => {
+  it('it does display reason for leaving', () => {
     const past = daysAgo(today, 365 * 3)
     const props = {
       EmploymentActivity: { value: 'ActiveMilitary' },

--- a/src/components/Section/History/Employment/EmploymentItem.test.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.test.jsx
@@ -133,6 +133,42 @@ describe('The employment component', () => {
     expect(component.find('.reason-description').length).toBe(0)
   })
 
+  it('does not display reason for leaving for unemployment', () => {
+    const past = daysAgo(today, 365 * 3)
+    const props = {
+      EmploymentActivity: { value: 'Unemployment' },
+      Dates: {
+        present: true,
+        from: {
+          month: `${past.getMonth() + 1}`,
+          day: `${past.getDate()}`,
+          year: `${past.getFullYear()}`
+        },
+        to: {}
+      }
+    }
+    const component = mount(<EmploymentItem {...props} />)
+    expect(component.find('.reason-description').length).toBe(0)
+  })
+
+  it('does not display reprimand for unemployment', () => {
+    const past = daysAgo(today, 365 * 3)
+    const props = {
+      EmploymentActivity: { value: 'Unemployment' },
+      Dates: {
+        present: true,
+        from: {
+          month: `${past.getMonth() + 1}`,
+          day: `${past.getDate()}`,
+          year: `${past.getFullYear()}`
+        },
+        to: {}
+      }
+    }
+    const component = mount(<EmploymentItem {...props} />)
+    expect(component.find('.reprimand-branch').length).toBe(0)
+  })
+
   it('does display reason for leaving if not currently employed', () => {
     const past = daysAgo(today, 365 * 3)
     const props = {

--- a/src/validators/employment.js
+++ b/src/validators/employment.js
@@ -253,9 +253,7 @@ export class EmploymentValidator {
 
       case 'Unemployment':
         // Unemployment
-        return (
-          this.validDates() && this.validReference() && this.validReasonLeft()
-        )
+        return this.validDates() && this.validReference()
 
       default:
         return false


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/841

This uses conditional logic to hide the `Reason for leaving` and `Reprimand` questions when `Unemployment` is chosen as the employment activity. Also removed some unnecessary `<div>`s so sorry for the added noise in the diff.