### PR TITLE
Improve React Makefile test command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: Run React tests
           command: |
             TESTFILES=$(circleci tests glob "./src/**/*.test.js*" | circleci tests split)
-            make test-react COVERAGE=--coverage FILES="$(echo ${TESTFILES})"
+            make test-react FLAGS="--ci --silent --coverage" FILES="$(echo ${TESTFILES})"
       - run:
           name: Run Go tests
           command: make test-go

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ lint-go:
 test: test-react test-go
 test-react:
 	$(info Running React test suite)
-	@docker-compose run --rm js yarn test $(COVERAGE) $(FILES)
+	@docker-compose run --rm js yarn test $(FLAGS) $(FILES)
 test-go:
 	$(info Running Go test suite)
 	@docker-compose run --rm api make test

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -4,25 +4,43 @@ The frontend is built in [React](https://reactjs.org/), wired up with [React Rou
 
 Here are some of the major directories:
 
-* [`/`](..): Things like the [`package.json`](../package.json) and config files for other tools live at the root directory of the repository
-* [`specs/`](../specs): [Integration tests](../specs/README.md)
-* [`src/`](../src): All the frontend source files live here
-  * [`actions/`](../src/actions): [Redux action creators](https://redux.js.org/basics/actions#action-creators)
-  * [`components/`](../src/components): Underlying React components used by the views or other components. Each should have corresponding styles (where applicable), tests, etc. in the same subdirectory.
-  * [`config/locales/`](../src/config/locales): Where any user-visible text is stored
-  * [`reducers/`](../src/reducers): [Redux reducers](https://redux.js.org/basics/reducers)
-  * [`sass/`](../src/sass): Handful of shared SASS files
-  * [`validators/`](../src/validators): The validation logic
-  * [`views/`](../src/views): Higher-level React components that correspond to different pages/routes
+- [`/`](..): Things like the [`package.json`](../package.json) and config files for other tools live at the root directory of the repository
+- [`specs/`](../specs): [Integration tests](../specs/README.md)
+- [`src/`](../src): All the frontend source files live here
+  - [`actions/`](../src/actions): [Redux action creators](https://redux.js.org/basics/actions#action-creators)
+  - [`components/`](../src/components): Underlying React components used by the views or other components. Each should have corresponding styles (where applicable), tests, etc. in the same subdirectory.
+  - [`config/locales/`](../src/config/locales): Where any user-visible text is stored
+  - [`reducers/`](../src/reducers): [Redux reducers](https://redux.js.org/basics/reducers)
+  - [`sass/`](../src/sass): Handful of shared SASS files
+  - [`validators/`](../src/validators): The validation logic
+  - [`views/`](../src/views): Higher-level React components that correspond to different pages/routes
 
 ## Troubleshooting
 
-* Use of the [React Developer Tools](https://github.com/facebook/react-devtools) and [Redux DevTools Extension](http://extension.remotedev.io/) are recommended for frontend work.
-* With the React extension, the Redux store can be inspected by running `$r.store.getState();` in your browser's JavaScript console.
+- Use of the [React Developer Tools](https://github.com/facebook/react-devtools) and [Redux DevTools Extension](http://extension.remotedev.io/) are recommended for frontend work.
+- With the React extension, the Redux store can be inspected by running `$r.store.getState();` in your browser's JavaScript console.
 
 ## Tests
 
 Unit tests are written in [Jest](https://facebook.github.io/jest/), with [snapshot tests](https://jestjs.io/docs/en/snapshot-testing) for ensuring components don't inadvertently change.
+
+To run the React test suite:
+
+```shell
+make test-react
+```
+
+To run a subset of tests, use the `FILES` argument, using a space as a delimiter between file paths:
+
+```shell
+make test-react FILES="src/components/Navigation/Navigation.test.jsx src/components/Navigation/SectionLink.test.jsx"
+```
+
+If changes are made that require updating a snapshot(s), pass the appropriate flag using the `FLAGS` argument:
+
+```shell
+make test-react FLAGS="--updateSnapshot"
+```
 
 [Information about integration tests.](../specs/README.md)
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     ]
   },
   "scripts": {
-    "test": "NODE_ENV=test jest --ci --silent",
+    "test": "NODE_ENV=test jest",
     "lint-css": "gulp lint",
     "lint-js": "eslint --ext .js,.jsx src/",
     "lint": "npm run lint-css && npm run lint-js",


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/996

This allows extra flags to be passed to `make react-test`, allowing finer grained control of testing locally vs on CI. `--silent` and `--ci` are now only used on CI, and a new `FLAGS` argument allows Jest flags to be passed to the Docker container, allowing for snapshots to be generated within the container (`make test-react FLAGS="--updateSnapshot"`).