### PR TITLE
Add HTTP Error response codes to all API errors

### DIFF
--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -57,7 +57,6 @@ func main() {
 	// Declare a new router with any middleware injected
 	r := mux.NewRouter()
 	r.HandleFunc("/", http.RootHandler{Env: settings}.ServeHTTP).Methods("GET")
-	r.HandleFunc("/refresh", http.RefreshHandler{Env: settings, Log: logger, Token: token, Database: database}.ServeHTTP).Methods("POST")
 
 	// Authentication schemes
 	o := r.PathPrefix("/auth").Subrouter()
@@ -71,6 +70,8 @@ func main() {
 
 	// Account specific actions
 	sec := http.JWTHandler{Log: logger, Token: token}
+	r.Handle("/refresh", sec.Middleware(http.RefreshHandler{Env: settings, Log: logger, Token: token, Database: database})).Methods("POST")
+
 	a := r.PathPrefix("/me").Subrouter()
 	a.Handle("/logout", sec.Middleware(http.LogoutHandler{Env: settings, Log: logger, Token: token, Database: database})).Methods("GET")
 	a.Handle("/validate", sec.Middleware(http.ValidateHandler{Env: settings, Log: logger, Token: token, Database: database})).Methods("POST")

--- a/api/http/attachment.go
+++ b/api/http/attachment.go
@@ -177,7 +177,7 @@ func (service AttachmentUpdateHandler) ServeHTTP(w http.ResponseWriter, r *http.
 	account := &api.Account{ID: id}
 	if _, err := account.Get(service.Database, id); err != nil {
 		service.Log.WarnError(api.NoAccount, err, api.LogFields{})
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		RespondWithStructuredError(w, api.NoAccount, http.StatusUnauthorized)
 		return
 	}
 

--- a/api/http/basic_auth.go
+++ b/api/http/basic_auth.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/18F/e-QIP-prototype/api"
@@ -18,8 +17,8 @@ type BasicAuthHandler struct {
 // ServeHTTP processes a users request to login with a Username and Password
 func (service BasicAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !service.Env.True(api.BasicEnabled) {
-		service.Log.Warn(api.BasicAuthAttemptDenied, api.LogFields{})
-		http.Error(w, "Basic authentication is not implemented", http.StatusInternalServerError)
+		service.Log.Warn(api.BasicAuthNotImplemented, api.LogFields{})
+		RespondWithStructuredError(w, api.BasicAuthNotImplemented, http.StatusInternalServerError)
 		return
 	}
 
@@ -30,19 +29,19 @@ func (service BasicAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	if err := DecodeJSON(r.Body, &respBody); err != nil {
 		service.Log.WarnError(api.BasicAuthError, err, api.LogFields{})
-		Error(w, r, err)
+		RespondWithStructuredError(w, api.BasicAuthError, http.StatusInternalServerError)
 		return
 	}
 
 	if respBody.Username == "" {
 		service.Log.Warn(api.BasicAuthMissingUsername, api.LogFields{})
-		Error(w, r, fmt.Errorf("Username is required"))
+		RespondWithStructuredError(w, api.BasicAuthMissingUsername, http.StatusBadRequest)
 		return
 	}
 
 	if respBody.Password == "" {
 		service.Log.Warn(api.BasicAuthMissingPassword, api.LogFields{})
-		Error(w, r, fmt.Errorf("Password is required"))
+		RespondWithStructuredError(w, api.BasicAuthMissingPassword, http.StatusBadRequest)
 		return
 	}
 
@@ -53,14 +52,14 @@ func (service BasicAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	// Associate with a database context.
 	if _, err := account.Get(service.Database, 0); err != nil {
 		service.Log.WarnError(api.AccountUpdateError, err, api.LogFields{"username": account.Username})
-		Error(w, r, err)
+		RespondWithStructuredError(w, api.AccountUpdateError, http.StatusInternalServerError)
 		return
 	}
 
 	// Validate the user name and password combination
 	if err := account.BasicAuthentication(service.Database, respBody.Password); err != nil {
 		service.Log.WarnError(api.BasicAuthInvalid, err, api.LogFields{"account": account.ID})
-		Error(w, r, err)
+		RespondWithStructuredError(w, api.BasicAuthInvalid, http.StatusUnauthorized)
 		return
 	}
 
@@ -68,7 +67,7 @@ func (service BasicAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	signedToken, _, err := service.Token.NewToken(account.ID, api.BasicAuthAudience)
 	if err != nil {
 		service.Log.WarnError(api.JWTError, err, api.LogFields{"account": account.ID})
-		Error(w, r, err)
+		RespondWithStructuredError(w, api.JWTError, http.StatusInternalServerError)
 		return
 	}
 

--- a/api/http/cors.go
+++ b/api/http/cors.go
@@ -37,7 +37,7 @@ func (service CORSHandler) Middleware(next http.Handler) http.Handler {
 				"Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
 		} else {
 			service.Log.Info(api.CORSDenied, api.LogFields{"origin": origin})
-			http.Error(w, api.CORSDenied, http.StatusBadRequest)
+			RespondWithStructuredError(w, api.CORSDenied, http.StatusBadRequest)
 			return
 		}
 

--- a/api/http/error.go
+++ b/api/http/error.go
@@ -14,14 +14,28 @@ func Error(w http.ResponseWriter, r *http.Request, err error) {
 }
 
 type structuredError struct {
-	Errors interface{}
+	Message string `json:"message"`
+}
+
+type structuredErrors struct {
+	Errors []structuredError `json:"errors"`
+}
+
+func newStructuredError(message string) structuredError {
+	return structuredError{
+		Message: message,
+	}
+}
+
+func newStructuredErrors(errors ...structuredError) structuredErrors {
+	return structuredErrors{
+		Errors: errors,
+	}
 }
 
 // RespondWithStructuredError writes an error code and a json error response
 func RespondWithStructuredError(w http.ResponseWriter, errorMessage string, code int) {
-	errorStruct := structuredError{
-		Errors: errorMessage,
-	}
+	errorStruct := newStructuredErrors(newStructuredError(errorMessage))
 	// It's a little ugly to not just have json write directly to the the Writer, but I don't see another way
 	// to return 500 correctly in the case of an error.
 	jsonString, err := json.Marshal(errorStruct)

--- a/api/http/form.go
+++ b/api/http/form.go
@@ -26,7 +26,7 @@ func (service FormHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	account := &api.Account{ID: id}
 	if _, err := account.Get(service.Database, id); err != nil {
 		service.Log.WarnError(api.NoAccount, err, api.LogFields{})
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		RespondWithStructuredError(w, api.NoAccount, http.StatusUnauthorized)
 		return
 	}
 

--- a/api/http/hash.go
+++ b/api/http/hash.go
@@ -17,21 +17,15 @@ type HashHandler struct {
 
 // ServeHTTP returns the hash of the application data used to verify data integrity.
 func (service HashHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	account := &api.Account{}
 
-	// Valid token and audience while populating the audience ID
-	_, id, err := service.Token.CheckToken(r)
-	if err != nil {
-		service.Log.WarnError(api.InvalidJWT, err, api.LogFields{})
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	account.ID = id
+	// Get account ID
+	id := AccountIDFromRequestContext(r)
 
 	// Get the account information from the data store
+	account := &api.Account{ID: id}
 	if _, err := account.Get(service.Database, account.ID); err != nil {
 		service.Log.WarnError(api.NoAccount, err, api.LogFields{})
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		RespondWithStructuredError(w, api.NoAccount, http.StatusUnauthorized)
 		return
 	}
 

--- a/api/http/json.go
+++ b/api/http/json.go
@@ -6,16 +6,6 @@ import (
 	"net/http"
 )
 
-// EncodeErrJSON will return an error in JSON format.
-func EncodeErrJSON(w http.ResponseWriter, errors interface{}) error {
-	w.Header().Set("Content-Type", "application/json")
-	return json.NewEncoder(w).Encode(struct {
-		Errors interface{}
-	}{
-		Errors: errors,
-	})
-}
-
 // EncodeJSON encodes any object and writes it to a response writer
 func EncodeJSON(w http.ResponseWriter, data interface{}) error {
 	w.Header().Set("Content-Type", "application/json")

--- a/api/http/jwt.go
+++ b/api/http/jwt.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/18F/e-QIP-prototype/api"
@@ -18,10 +19,29 @@ func (service JWTHandler) Middleware(next http.Handler) http.Handler {
 		_, id, err := service.Token.CheckToken(r)
 		if err != nil {
 			service.Log.WarnError(api.InvalidJWT, err, api.LogFields{})
-			http.Error(w, err.Error(), http.StatusUnauthorized)
+			RespondWithStructuredError(w, api.InvalidJWT, http.StatusUnauthorized)
 			return
 		}
 		service.Log.AddField("account", id)
-		next.ServeHTTP(w, r)
+		newContext := SetAccountIDInRequestContext(r, id)
+
+		next.ServeHTTP(w, r.WithContext(newContext))
 	})
+}
+
+type authContextKey string
+
+const accountIDKey authContextKey = "ACCOUNT_ID"
+
+// SetAccountIDInRequestContext modifies the request's Context() to add the Account
+func SetAccountIDInRequestContext(r *http.Request, accountID int) context.Context {
+	return context.WithValue(r.Context(), accountIDKey, accountID)
+}
+
+// AccountIDFromRequestContext gets the reference to the Account stored in the request.Context()
+func AccountIDFromRequestContext(r *http.Request) int {
+	// This will panic if it is not set or if it's not an int. That will always be a programmer
+	// error so I think that it's worth the tradeoff for the simpler method signature.
+	accountID := r.Context().Value(accountIDKey).(int)
+	return accountID
 }

--- a/api/http/logout.go
+++ b/api/http/logout.go
@@ -28,12 +28,5 @@ func (service LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If the account is locked then we cannot proceed
-	if account.Locked {
-		service.Log.Warn(api.AccountLocked, api.LogFields{})
-		// EncodeErrJSON(w, err)
-		return
-	}
-
 	service.Log.Info(api.LoggedOut, api.LogFields{})
 }

--- a/api/http/logout.go
+++ b/api/http/logout.go
@@ -16,28 +16,22 @@ type LogoutHandler struct {
 
 // ServeHTTP will end the user session.
 func (service LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	account := &api.Account{}
 
-	// Valid token and audience while populating the audience ID
-	_, id, err := service.Token.CheckToken(r)
-	if err != nil {
-		service.Log.WarnError(api.InvalidJWT, err, api.LogFields{})
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	// Get account ID
+	id := AccountIDFromRequestContext(r)
 
 	// Get the account information from the data store
-	account.ID = id
+	account := &api.Account{ID: id}
 	if _, err := account.Get(service.Database, id); err != nil {
 		service.Log.WarnError(api.NoAccount, err, api.LogFields{})
-		EncodeErrJSON(w, err)
+		RespondWithStructuredError(w, api.NoAccount, http.StatusUnauthorized)
 		return
 	}
 
 	// If the account is locked then we cannot proceed
 	if account.Locked {
 		service.Log.Warn(api.AccountLocked, api.LogFields{})
-		EncodeErrJSON(w, err)
+		// EncodeErrJSON(w, err)
 		return
 	}
 

--- a/api/http/refresh.go
+++ b/api/http/refresh.go
@@ -18,13 +18,8 @@ type RefreshHandler struct {
 // ServeHTTP refreshes a given token.
 func (service RefreshHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
-	// Valid token and audience
-	_, id, err := service.Token.CheckToken(r)
-	if err != nil {
-		service.Log.WarnError(api.InvalidJWT, err, api.LogFields{})
-		RespondWithStructuredError(w, api.InvalidJWT, http.StatusInternalServerError)
-		return
-	}
+	// Get account ID
+	id := AccountIDFromRequestContext(r)
 
 	// Generate a new token
 	signedToken, _, err := service.Token.NewToken(id, service.Token.CurrentAudience(r))

--- a/api/http/refresh.go
+++ b/api/http/refresh.go
@@ -22,7 +22,7 @@ func (service RefreshHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	_, id, err := service.Token.CheckToken(r)
 	if err != nil {
 		service.Log.WarnError(api.InvalidJWT, err, api.LogFields{})
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		RespondWithStructuredError(w, api.InvalidJWT, http.StatusInternalServerError)
 		return
 	}
 

--- a/api/http/refresh.go
+++ b/api/http/refresh.go
@@ -17,7 +17,6 @@ type RefreshHandler struct {
 
 // ServeHTTP refreshes a given token.
 func (service RefreshHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	account := &api.Account{}
 
 	// Valid token and audience
 	_, id, err := service.Token.CheckToken(r)
@@ -28,11 +27,10 @@ func (service RefreshHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Generate a new token
-	account.ID = id
 	signedToken, _, err := service.Token.NewToken(id, service.Token.CurrentAudience(r))
 	if err != nil {
 		service.Log.WarnError(api.JWTError, err, api.LogFields{})
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		RespondWithStructuredError(w, api.JWTError, http.StatusInternalServerError)
 		return
 	}
 

--- a/api/http/saml.go
+++ b/api/http/saml.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	redirectTo = os.Getenv("API_REDIRECT")
+	redirectTo   = os.Getenv("API_REDIRECT")
 	cookieDomain = os.Getenv("COOKIE_DOMAIN")
 )
 
@@ -28,15 +28,15 @@ type SamlRequestHandler struct {
 // ServeHTTP is the initial entry point for authentication.
 func (service SamlRequestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !service.Env.True(api.SamlEnabled) {
-		service.Log.Warn(api.SamlAttemptDenied, api.LogFields{})
-		http.Error(w, "SAML is not implemented", http.StatusInternalServerError)
+		service.Log.Warn(api.SamlNotImplemented, api.LogFields{})
+		RespondWithStructuredError(w, api.SamlNotImplemented, http.StatusInternalServerError)
 		return
 	}
 
 	encoded, url, err := service.SAML.CreateAuthenticationRequest()
 	if err != nil {
 		service.Log.WarnError(api.SamlRequestError, err, api.LogFields{})
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		RespondWithStructuredError(w, api.SamlRequestError, http.StatusInternalServerError)
 		return
 	}
 
@@ -61,8 +61,8 @@ type SamlResponseHandler struct {
 // ServeHTTP is the returning entry point for authentication.
 func (service SamlResponseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !service.Env.True(api.SamlEnabled) {
-		service.Log.Warn(api.SamlAttemptDenied, api.LogFields{})
-		http.Error(w, "SAML is not implemented", http.StatusInternalServerError)
+		service.Log.Warn(api.SamlNotImplemented, api.LogFields{})
+		RespondWithStructuredError(w, api.SamlNotImplemented, http.StatusInternalServerError)
 		return
 	}
 
@@ -114,7 +114,7 @@ func (service SamlResponseHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		// Default to frontend host
 		uri, _ := url.Parse(redirectTo)
 		cookieDomain = strings.Split(uri.Host, ":")[0]
-        }
+	}
 	expiration := time.Now().Add(time.Duration(1) * time.Minute)
 	cookie := &http.Cookie{
 		Domain:   cookieDomain,

--- a/api/http/save.go
+++ b/api/http/save.go
@@ -17,17 +17,12 @@ type SaveHandler struct {
 
 // ServeHTTP saves a payload of information for the provided account.
 func (service SaveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	account := &api.Account{}
 
-	// Valid token and audience while populating the audience ID
-	_, id, err := service.Token.CheckToken(r)
-	if err != nil {
-		service.Log.WarnError(api.InvalidJWT, err, api.LogFields{})
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	// Get account ID
+	id := AccountIDFromRequestContext(r)
 
 	// Get the account information from the data store
+	account := &api.Account{}
 	account.ID = id
 	if _, err := account.Get(service.Database, id); err != nil {
 		service.Log.WarnError(api.NoAccount, err, api.LogFields{})
@@ -62,7 +57,7 @@ func (service SaveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	entity, err := payload.Entity()
 	if err != nil {
 		service.Log.WarnError(api.PayloadEntityError, err, api.LogFields{})
-		RespondWithStructuredError(w, api.PayloadEntityError, http.StatusInternalServerError)
+		RespondWithStructuredError(w, api.PayloadEntityError, http.StatusBadRequest)
 		return
 	}
 

--- a/api/http/save.go
+++ b/api/http/save.go
@@ -22,8 +22,7 @@ func (service SaveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	id := AccountIDFromRequestContext(r)
 
 	// Get the account information from the data store
-	account := &api.Account{}
-	account.ID = id
+	account := &api.Account{ID: id}
 	if _, err := account.Get(service.Database, id); err != nil {
 		service.Log.WarnError(api.NoAccount, err, api.LogFields{})
 		RespondWithStructuredError(w, api.NoAccount, http.StatusUnauthorized)
@@ -68,5 +67,4 @@ func (service SaveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	EncodeErrJSON(w, nil)
 }

--- a/api/http/save_test.go
+++ b/api/http/save_test.go
@@ -1,0 +1,128 @@
+package http
+
+import (
+    "fmt"
+    "net/http"
+    "net/http/httptest"
+    "strings"
+    "testing"
+
+    "github.com/18F/e-QIP-prototype/api/mock"
+)
+
+func TestSaveHandler(t *testing.T) {
+
+    var mockDB mock.DatabaseService
+    mockDB.SelectFn = func(query interface{}) error {
+        fmt.Println("SELECTING", query)
+        return nil
+    }
+
+    var mockLog mock.LogService
+
+    handler := SaveHandler{
+        Env:      nil,
+        Log:      &mockLog,
+        Token:    nil,
+        Database: &mockDB,
+    }
+
+    requestJSON := `
+    {
+       "type":"identification.name",
+       "props":{
+          "Name":{
+             "type":"name",
+             "props":{
+                "first":"MacRae",
+                "firstInitialOnly":false,
+                "last":"Fenton",
+                "lastInitialOnly":false,
+                "middle":"William",
+                "middleInitialOnly":false,
+                "noMiddleName":false,
+                "suffix":"",
+                "suffixOther":""
+             }
+          }
+       }
+    }`
+    reqBody := strings.NewReader(requestJSON)
+
+    // Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+    // pass 'nil' as the third parameter.
+    req := httptest.NewRequest("POST", "/me/save", reqBody)
+    accountID := 1
+    req = req.WithContext(SetAccountIDInRequestContext(req, accountID))
+    // We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+    rr := httptest.NewRecorder()
+    // Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+    // directly and pass in our Request and ResponseRecorder.
+    handler.ServeHTTP(rr, req)
+
+    // Check the status code is what we expect.
+    if status := rr.Code; status != http.StatusOK {
+        t.Errorf("handler returned wrong status code: got %v want %v",
+            status, http.StatusOK)
+    }
+
+    // Check the response body is what we expect.
+    expected := `{"Errors":null}` + "\n"
+    if rr.Body.String() != expected {
+        t.Errorf("handler returned unexpected body: got %v want %v",
+            rr.Body.String(), expected)
+    }
+
+    // Check that the db got called
+    if mockDB.SelectCount != 1 {
+        t.Errorf("never called the mock db.")
+    }
+}
+
+func TestSaveHandlerBadEntity(t *testing.T) {
+
+    var mockDB mock.DatabaseService
+    mockDB.SelectFn = func(query interface{}) error {
+        fmt.Println("SELECTING", query)
+        return nil
+    }
+
+    var mockLog mock.LogService
+
+    handler := SaveHandler{
+        Env:      nil,
+        Log:      &mockLog,
+        Token:    nil,
+        Database: &mockDB,
+    }
+
+    requestJSON := `
+    {
+       "hello": "there"
+    }`
+    reqBody := strings.NewReader(requestJSON)
+
+    // Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+    // pass 'nil' as the third parameter.
+    req := httptest.NewRequest("POST", "/me/save", reqBody)
+    accountID := 1
+    req = req.WithContext(SetAccountIDInRequestContext(req, accountID))
+    // We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+    rr := httptest.NewRecorder()
+    // Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+    // directly and pass in our Request and ResponseRecorder.
+    handler.ServeHTTP(rr, req)
+
+    // Check the status code is what we expect.
+    if status := rr.Code; status != http.StatusBadRequest {
+        t.Errorf("handler returned wrong status code: got %v want %v",
+            status, http.StatusOK)
+    }
+
+    // Check the response body is what we expect.
+    expected := `{"Errors":"Error converting payload into valid entity"}` + "\n"
+    if rr.Body.String() != expected {
+        t.Errorf("handler returned unexpected body: got %v want %v",
+            rr.Body.String(), expected)
+    }
+}

--- a/api/http/save_test.go
+++ b/api/http/save_test.go
@@ -120,7 +120,7 @@ func TestSaveHandlerBadEntity(t *testing.T) {
     }
 
     // Check the response body is what we expect.
-    expected := `{"Errors":"Error converting payload into valid entity"}` + "\n"
+    expected := `{"errors":[{"message":"Error converting payload into valid entity"}]}` + "\n"
     if rr.Body.String() != expected {
         t.Errorf("handler returned unexpected body: got %v want %v",
             rr.Body.String(), expected)

--- a/api/http/save_test.go
+++ b/api/http/save_test.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-    "fmt"
     "net/http"
     "net/http/httptest"
     "strings"
@@ -14,7 +13,6 @@ func TestSaveHandler(t *testing.T) {
 
     var mockDB mock.DatabaseService
     mockDB.SelectFn = func(query interface{}) error {
-        fmt.Println("SELECTING", query)
         return nil
     }
 
@@ -67,7 +65,7 @@ func TestSaveHandler(t *testing.T) {
     }
 
     // Check the response body is what we expect.
-    expected := `{"Errors":null}` + "\n"
+    expected := ``
     if rr.Body.String() != expected {
         t.Errorf("handler returned unexpected body: got %v want %v",
             rr.Body.String(), expected)
@@ -83,7 +81,6 @@ func TestSaveHandlerBadEntity(t *testing.T) {
 
     var mockDB mock.DatabaseService
     mockDB.SelectFn = func(query interface{}) error {
-        fmt.Println("SELECTING", query)
         return nil
     }
 

--- a/api/http/section.go
+++ b/api/http/section.go
@@ -16,35 +16,29 @@ type SectionHandler struct {
 
 // ServeHTTP returns data for one section of the application.
 func (service SectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	account := &api.Account{}
 
-	// Valid token and audience while populating the audience ID
-	_, id, err := service.Token.CheckToken(r)
-	if err != nil {
-		service.Log.WarnError(api.InvalidJWT, err, api.LogFields{})
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	// Get account ID
+	id := AccountIDFromRequestContext(r)
 
 	// Get the account information from the data store
-	account.ID = id
+	account := &api.Account{ID: id}
 	if _, err := account.Get(service.Database, id); err != nil {
 		service.Log.WarnError(api.NoAccount, err, api.LogFields{})
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		RespondWithStructuredError(w, api.NoAccount, http.StatusUnauthorized)
 		return
 	}
 
 	// If the account is locked then we cannot proceed
 	if account.Locked {
 		service.Log.Warn(api.AccountLocked, api.LogFields{})
-		EncodeErrJSON(w, err)
+		RespondWithStructuredError(w, api.AccountLocked, http.StatusForbidden)
 		return
 	}
 
 	payloadType := r.FormValue("type")
 	if payloadType == "" {
-		service.Log.WarnError(api.PayloadMissingType, err, api.LogFields{})
-		http.Error(w, "No payload type provided", http.StatusInternalServerError)
+		service.Log.WarnError(api.PayloadMissingType, nil, api.LogFields{})
+		RespondWithStructuredError(w, api.PayloadMissingType, http.StatusBadRequest)
 		return
 	}
 
@@ -54,7 +48,7 @@ func (service SectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	entity, err := payload.Entity()
 	if err != nil {
 		service.Log.WarnError(api.PayloadEntityError, err, api.LogFields{})
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		RespondWithStructuredError(w, api.PayloadEntityError, http.StatusBadRequest)
 		return
 	}
 

--- a/api/http/status.go
+++ b/api/http/status.go
@@ -17,21 +17,15 @@ type StatusHandler struct {
 
 // ServeHTTP returns the accounts current state.
 func (service StatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	account := &api.Account{}
 
-	// Valid token and audience while populating the audience ID
-	_, id, err := service.Token.CheckToken(r)
-	if err != nil {
-		service.Log.WarnError(api.InvalidJWT, err, api.LogFields{})
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	// Get account ID
+	id := AccountIDFromRequestContext(r)
 
 	// Get the account information from the data store
-	account.ID = id
+	account := &api.Account{ID: id}
 	if _, err := account.Get(service.Database, id); err != nil {
 		service.Log.WarnError(api.NoAccount, err, api.LogFields{})
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		RespondWithStructuredError(w, api.NoAccount, http.StatusInternalServerError)
 		return
 	}
 

--- a/api/http/validate.go
+++ b/api/http/validate.go
@@ -21,7 +21,7 @@ func (service ValidateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		service.Log.WarnError(api.PayloadEmpty, err, api.LogFields{})
-		EncodeErrJSON(w, err)
+		RespondWithStructuredError(w, api.PayloadEmpty, http.StatusBadRequest)
 		return
 	}
 
@@ -29,16 +29,15 @@ func (service ValidateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	payload := &api.Payload{}
 	if err := payload.Unmarshal(body); err != nil {
 		service.Log.WarnError(api.PayloadDeserializeError, err, api.LogFields{})
-		EncodeErrJSON(w, err)
+		RespondWithStructuredError(w, api.PayloadDeserializeError, http.StatusBadRequest)
 		return
 	}
 
 	// Extract the entity interface of the payload and validate it
 	if ok, err := payload.Valid(); !ok {
 		service.Log.WarnError(api.PayloadInvalid, err, api.LogFields{})
-		EncodeErrJSON(w, err)
+		RespondWithStructuredError(w, api.PayloadInvalid, http.StatusBadRequest)
 		return
 	}
 
-	EncodeErrJSON(w, nil)
 }

--- a/api/log.go
+++ b/api/log.go
@@ -25,6 +25,7 @@ type LogService interface {
 const (
 	AccountLocked                              = "The account is currently locked"
 	AccountUpdateError                         = "Not able to update account information"
+	BasicAuthNotImplemented                    = "Basic authentication is not implemented"
 	BasicAuthAttemptDenied                     = "An attempt for basic authentication was denied"
 	BasicAuthError                             = "Failed to decode JSON for basic authentication"
 	BasicAuthInvalid                           = "Basic authentication invalid"
@@ -49,6 +50,7 @@ const (
 	PayloadMissingType                         = "Payload is missing a type"
 	PdfError                                   = "Error generating archival signature PDFs"
 	RetrievingAccount                          = "Retrieving account"
+	SamlNotImplemented                         = "SAML is not implemented"
 	SamlAttemptDenied                          = "An attempt for SAML authentication was denied"
 	SamlFormError                              = "SAML response form value missing"
 	SamlIdentifierMissing                      = "SAML attribute identifier missing"
@@ -74,6 +76,7 @@ const (
 	WebserviceErrorCreatingImportRequest       = "Unable to create import request"
 	TransmissionError                          = "Error transmitting package"
 	TransmissionStorageError                   = "Failed to store transmission record"
+	AttachmentsNotImplemented                  = "Attachments is not implemented"
 	AttachmentDenied                           = "An attempt for attachments was denied"
 	AttachmentNoFile                           = "No attachment file found in multipart form data"
 	AttachmentCopyBufferError                  = "Could not copy file buffer"

--- a/api/log.go
+++ b/api/log.go
@@ -44,7 +44,7 @@ const (
 	NoUsername                                 = "Unable to retrieve account because no username was provided"
 	PayloadDeserializeError                    = "Failed to deserialize payload"
 	PayloadEmpty                               = "Payload not provided"
-	PayloadEntityError                         = "Error creating entity from the payload"
+	PayloadEntityError                         = "Error converting payload into valid entity"
 	PayloadInvalid                             = "Payload is invalid"
 	PayloadMissingType                         = "Payload is missing a type"
 	PdfError                                   = "Error generating archival signature PDFs"

--- a/api/mock/database.go
+++ b/api/mock/database.go
@@ -1,7 +1,10 @@
 package mock
 
 // DatabaseService mock implementation.
-type DatabaseService struct{}
+type DatabaseService struct {
+	SelectFn    func(query interface{}) error
+	SelectCount int
+}
 
 // Configure establishes a new database connection
 func (service *DatabaseService) Configure() {
@@ -71,5 +74,6 @@ func (service *DatabaseService) Delete(query interface{}) error {
 
 // Select returns the model from the data store
 func (service *DatabaseService) Select(query interface{}) error {
-	return nil
+	service.SelectCount++
+	return service.SelectFn(query)
 }


### PR DESCRIPTION
This PR introduces RespondWithStructuredError() a method for returning a standardized error list and an HTTP response code for API errors. 

It goes through all the API handlers and returns appropriate error codes for errors.

Another task will be to sort out what the JSON response for most successful responses should be. For things like save and submit we should return something. 