### PR TITLE
(WIP) Collect secondary address when residence is a military address

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     ]
   },
   "scripts": {
-    "test": "NODE_ENV=test jest",
+    "test": "NODE_ENV=test jest --ci",
     "lint-css": "gulp lint",
     "lint-js": "eslint --ext .js,.jsx src/",
     "lint": "npm run lint-css && npm run lint-js",

--- a/src/components/Form/Field/Field.jsx
+++ b/src/components/Form/Field/Field.jsx
@@ -36,6 +36,8 @@ const message = id => {
   )
 }
 
+// XXX All references to `comments` in this component refer to help text / info boxes
+
 export default class Field extends ValidationElement {
   constructor(props) {
     super(props)

--- a/src/components/Form/Location/APOAddress.jsx
+++ b/src/components/Form/Location/APOAddress.jsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { i18n } from '../../../config'
+import Street from '../Street'
+import ZipCode from '../ZipCode'
+import RadioGroup from '../RadioGroup'
+import Radio from '../Radio'
+import ApoFpo from '../ApoFpo'
+
+class APOAddress extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    return (
+      <div>
+        <Street
+          name="street"
+          label={i18n.t('address.apoFpo.street.label')}
+          placeholder={this.props.postOfficeStreetPlaceholder}
+          className="mailing street required"
+          value={this.props.street}
+          onUpdate={this.onAddressUpdate}
+          onError={this.handleError}
+          onFocus={this.focusField}
+          onBlur={this.blurField}
+          required={this.props.required}
+          disabled={this.props.disabled}
+        />
+        <label>{i18n.t('address.apoFpo.select.label')}</label>
+        <RadioGroup
+          className="apofpo"
+          selectedValue={this.props.city}
+          disabled={this.props.disabled}
+          required={this.props.required}
+          onError={this.handleError}>
+          <Radio
+            name="city"
+            className="apo"
+            label={i18n.m('address.apoFpo.apoFpoType.apo.label')}
+            value="APO"
+            disabled={this.props.disabled}
+            onUpdate={this.onAddressUpdate}
+            onBlur={this.blurField}
+            onFocus={this.focusField}
+          />
+          <Radio
+            name="city"
+            className="fpo"
+            label={i18n.m('address.apoFpo.apoFpoType.fpo.label')}
+            value="FPO"
+            disabled={this.props.disabled}
+            onUpdate={this.onAddressUpdate}
+            onBlur={this.blurField}
+            onFocus={this.focusField}
+          />
+          <Radio
+            name="city"
+            className="dpo"
+            label={i18n.m('address.apoFpo.apoFpoType.dpo.label')}
+            value="DPO"
+            disabled={this.props.disabled}
+            onUpdate={this.onAddressUpdate}
+            onBlur={this.blurField}
+            onFocus={this.focusField}
+          />
+        </RadioGroup>
+        <div className="state-zip-wrap">
+          <ApoFpo
+            name="state"
+            className="state required"
+            label={this.props.postOfficeStateLabel}
+            value={this.props.state}
+            onUpdate={this.onAddressUpdate}
+            onError={this.handleError}
+            onFocus={this.focusField}
+            onBlur={this.blurField}
+            required={this.props.required}
+            disabled={this.props.disabled}
+            tabNext={() => {
+              this.props.tab(
+                this.refs.apo_zipcode.refs.zipcode.refs.text.refs.input
+              )
+            }}
+          />
+          <ZipCode
+            name="zipcode"
+            ref="apo_zipcode"
+            key="apo_zipcode"
+            className="zipcode required"
+            label={this.props.postOfficeZipcodeLabel}
+            value={this.props.zipcode}
+            status={instateZipcode}
+            onUpdate={this.onAddressUpdate}
+            onError={this.handleError}
+            onFocus={this.focusField}
+            onBlur={this.blurField}
+            required={this.props.required}
+            disabled={this.props.disabled}
+          />
+        </div>
+      </div>
+    )
+  }
+}
+
+APOAddress.defaultProps = {
+  disabled: false,
+  required: false,
+  postOfficeStreetPlaceholder: i18n.t('address.apoFpo.street.placeholder'),
+  postOfficeStateLabel: i18n.t('address.apoFpo.apoFpo.label'),
+  postOfficeZipcodeLabel: i18n.t('address.apoFpo.zipcode.label'),
+}
+
+export default APOAddress

--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -608,11 +608,6 @@ export default class Location extends ValidationElement {
             required={this.props.required}
           />
         )
-      // XXX This is used in ContactItem, which is foreign business contacts,
-      // would we ever need domestic fields for this?
-      // Should we have a separate component/case to just handle international
-      // city/country
-      // Also used in JobOffer, SponsorshipItem which only covers foreign offers/sponsorships?
       case Location.US_CITY_STATE_ZIP_INTERNATIONAL_CITY:
         return (
           <ToggleableLocation

--- a/src/components/Form/Location/PhysicalAddress.jsx
+++ b/src/components/Form/Location/PhysicalAddress.jsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { i18n } from '../../../config'
+import Field from '../Field'
+import Location from './Location'
+import ValidationElement from '../ValidationElement';
+
+class PhysicalAddress extends ValidationElement {
+  constructor(props) {
+    super(props)
+
+    this.handleUpdate = this.handleUpdate.bind(this);
+  }
+
+  // XXX This is not a great pattern, but we don't have a clear
+  // way to update the state of this PhysicalAddress prop when
+  // a user chooses a 'country' value that is not a military address
+  componentWillUnmount() {
+    this.props.onUpdate({})
+  }
+
+  handleUpdate(values) {
+    const { name, HasDifferentAddress, Telephone } = this.props.physicalAddress
+
+    this.props.onUpdate({
+      Address: values
+    })
+  }
+
+  render() {
+    const { addressFieldMetadata, physicalAddress } = this.props
+
+    return (
+      <Field title={i18n.t('address.physicalLocationRequired')}>
+        <Location
+          {...addressFieldMetadata}
+          {...physicalAddress.Address}
+          addressBook={this.props.addressBook}
+          addressBooks={this.props.addressBooks}
+          geocode
+          label={i18n.t('address.label')}
+          layout={Location.ADDRESS}
+          onUpdate={this.handleUpdate}
+          required
+        />
+      </Field>
+    )
+  }
+}
+
+const mapStateToProps = ({ addressBooks }) => addressBooks
+
+PhysicalAddress.defaultProps = {
+  addressBook: 'Residence',
+  addressFieldMetadata: {
+    streetLabel: i18n.t('address.us.street.label'),
+    streetPlaceholder: i18n.t('address.us.street.placeholder'),
+    street2Label: i18n.t('address.us.street2.label'),
+    stateLabel: i18n.t('address.us.state.label'),
+    cityLabel: i18n.t('address.us.city.label'),
+    zipcodeLabel: i18n.t('address.us.zipcode.label'),
+    countyLabel: i18n.t('address.us.county.label'),
+    countryLabel: i18n.t('address.international.country.label'),
+  },
+  physicalAddress: {}
+}
+
+export default PhysicalAddress

--- a/src/components/Form/Location/PhysicalAddress.jsx
+++ b/src/components/Form/Location/PhysicalAddress.jsx
@@ -1,30 +1,54 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { i18n } from '../../../config'
+import Show from '../Show'
 import Field from '../Field'
 import Location from './Location'
-import locationValidator from '../../../validators/location'
+import Branch from '../Branch'
 import ValidationElement from '../ValidationElement'
+import LocationValidator, { countryString } from '../../../validators/location';
 
 class PhysicalAddress extends ValidationElement {
   constructor(props) {
     super(props)
 
-    this.handleUpdate = this.handleUpdate.bind(this);
+    this.handleUpdate = this.handleUpdate.bind(this)
+    this.confirmMilitaryAddress = this.confirmMilitaryAddress.bind(this)
   }
 
   // XXX This is not a great pattern, but we don't have a clear
   // way to update the state of this PhysicalAddress prop when
   // a user chooses a 'country' value that is not a military address
   componentWillUnmount() {
-    this.props.onUpdate({})
+    this.props.onUpdate({
+      branch: { value: '' },
+      items: [{
+        Item: {
+          Address: {},
+          name: '',
+          HasDifferentAddress: false,
+          Telephone: {}
+        }
+      }]
+    })
   }
 
   handleUpdate(values) {
-    const { name, HasDifferentAddress, Telephone } = this.props.physicalAddress
+    const { physicalAddress } = this.props
+    const { name, HasDifferentAddress, Telephone } = physicalAddress.items[0].Item
 
     this.props.onUpdate({
-      Address: values
+      branch: physicalAddress.branch,
+      items: [
+        {
+          Item: {
+            Address: values,
+            name,
+            HasDifferentAddress,
+            Telephone
+          }
+        }
+      ]
     })
   }
 
@@ -36,32 +60,80 @@ class PhysicalAddress extends ValidationElement {
    * 
    * so potentially we prepare props in a couple of different ways,
    * and have a show block around the branch piece
+   * 
    */
+
+  getCountry() {
+    const maybeAddress = this.props.physicalAddress.items[0]
+    const country = countryString(maybeAddress && maybeAddress.country)
+    
+    return countryString(this.props.country) || country
+  }
+
+  confirmMilitaryAddress(value) {
+    this.props.onUpdate({
+      branch: value,
+      items: [
+        {
+          Item: this.props.physicalAddress.items[0].Item.Address || {}
+        }
+      ]
+    })
+  }
 
   render() {
     const { addressFieldMetadata, physicalAddress } = this.props
+    const country = this.getCountry()
+    const locationValidator = new LocationValidator({ country })
 
     return (
-      <Field title={i18n.t('address.physicalLocationRequired')}>
-        <Location
-          {...addressFieldMetadata}
-          {...physicalAddress.Address}
-          country={this.props.country}
-          addressBook={this.props.addressBook}
-          addressBooks={this.props.addressBooks}
-          geocode
-          label={i18n.t('address.label')}
-          layout={this.props.layout}
-          disableToggle={this.props.disableToggle}
-          onUpdate={this.handleUpdate}
-          required
-        />
-      </Field>
+      <div>
+        <Show when={this.props.isForeign}>
+          <Branch
+            label={i18n.t('address.militaryAddress')}
+            labelSize="h3"
+            onUpdate={this.confirmMilitaryAddress}
+            value={physicalAddress.branch && physicalAddress.branch.value}
+          />
+        </Show>
+        <Show when={physicalAddress.branch && physicalAddress.branch.value === 'Yes'}>
+          <Field title={i18n.t('address.physicalLocationRequired')}>
+            <Location
+              {...addressFieldMetadata}
+              {...physicalAddress.items[0].Item.Address}
+              country='POSTOFFICE'
+              addressBook={this.props.addressBook}
+              addressBooks={this.props.addressBooks}
+              geocode
+              label={i18n.t('address.label')}
+              layout={this.props.layout}
+              disableToggle={this.props.disableToggle}
+              onUpdate={this.handleUpdate}
+              required
+            />
+          </Field>
+        </Show>
+        <Show when={locationValidator.isPostOffice()}>
+          <Field title={i18n.t('address.physicalLocationRequired')}>
+            <Location
+              {...addressFieldMetadata}
+              {...physicalAddress.items[0].Item.Address}
+              addressBook={this.props.addressBook}
+              addressBooks={this.props.addressBooks}
+              geocode
+              label={i18n.t('address.label')}
+              layout={this.props.layout}
+              onUpdate={this.handleUpdate}
+              required
+            />
+          </Field>
+        </Show>
+      </div>
     )
   }
 }
 
-const mapStateToProps = ({ addressBooks }) => addressBooks
+const mapStateToProps = state => state
 
 PhysicalAddress.defaultProps = {
   addressBook: 'Residence',
@@ -76,7 +148,8 @@ PhysicalAddress.defaultProps = {
     countryLabel: i18n.t('address.international.country.label'),
   },
   layout: Location.ADDRESS,
-  physicalAddress: {}
 }
 
-export default PhysicalAddress
+
+export { PhysicalAddress }
+export default connect(mapStateToProps)(PhysicalAddress)

--- a/src/components/Form/Location/PhysicalAddress.jsx
+++ b/src/components/Form/Location/PhysicalAddress.jsx
@@ -3,7 +3,8 @@ import { connect } from 'react-redux'
 import { i18n } from '../../../config'
 import Field from '../Field'
 import Location from './Location'
-import ValidationElement from '../ValidationElement';
+import locationValidator from '../../../validators/location'
+import ValidationElement from '../ValidationElement'
 
 class PhysicalAddress extends ValidationElement {
   constructor(props) {
@@ -27,6 +28,16 @@ class PhysicalAddress extends ValidationElement {
     })
   }
 
+  /**
+   * Need to have two render functions, one to just show the physical location
+   * field with a toggle, and the other to render the APO address choice branch,
+   * and THEN display the location field if the user indicates that they had
+   * a military address in the foreign country
+   * 
+   * so potentially we prepare props in a couple of different ways,
+   * and have a show block around the branch piece
+   */
+
   render() {
     const { addressFieldMetadata, physicalAddress } = this.props
 
@@ -35,11 +46,13 @@ class PhysicalAddress extends ValidationElement {
         <Location
           {...addressFieldMetadata}
           {...physicalAddress.Address}
+          country={this.props.country}
           addressBook={this.props.addressBook}
           addressBooks={this.props.addressBooks}
           geocode
           label={i18n.t('address.label')}
-          layout={Location.ADDRESS}
+          layout={this.props.layout}
+          disableToggle={this.props.disableToggle}
           onUpdate={this.handleUpdate}
           required
         />
@@ -62,6 +75,7 @@ PhysicalAddress.defaultProps = {
     countyLabel: i18n.t('address.us.county.label'),
     countryLabel: i18n.t('address.international.country.label'),
   },
+  layout: Location.ADDRESS,
   physicalAddress: {}
 }
 

--- a/src/components/Form/Location/PhysicalAddress.test.jsx
+++ b/src/components/Form/Location/PhysicalAddress.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import PhysicalAddress from './PhysicalAddress'
+import { address } from '../../../config/locales/en/address'
+
+describe('<PhysicalLocation />', () => {
+  it('renders a location component', () => {
+    const component = mount(<PhysicalAddress />)
+
+    expect(component.find('Location').length).toEqual(1)
+  })
+
+  it.only('renders the correct field label', () => {
+    const component = mount(<PhysicalAddress />)
+    const field = component.find('Field')
+
+    expect(field.length).toEqual(1)
+    expect(field.prop('title')).toEqual(address.physicalLocationRequired)
+  })
+})

--- a/src/components/Section/History/Residence/Residence.jsx
+++ b/src/components/Section/History/Residence/Residence.jsx
@@ -6,7 +6,7 @@ import validate, {
   ResidenceValidator
 } from '../../../../validators'
 import SubsectionElement from '../../SubsectionElement'
-import { Accordion } from '../../../Form'
+import Branch, { Accordion } from '../../../Form'
 import { newGuid } from '../../../Form/ValidationElement'
 import { openState } from '../../../Form/Accordion/Accordion'
 import { today, daysAgo } from '../dateranges'
@@ -125,8 +125,8 @@ export default class Residence extends SubsectionElement {
           required={this.props.required}
           scrollIntoView={this.props.scrollIntoView}>
           <ResidenceItem
+            bind
             name="Item"
-            bind={true}
             addressBooks={this.props.addressBooks}
             dispatch={this.props.dispatch}
             required={this.props.required}

--- a/src/components/Section/History/Residence/Residence.jsx
+++ b/src/components/Section/History/Residence/Residence.jsx
@@ -6,7 +6,7 @@ import validate, {
   ResidenceValidator
 } from '../../../../validators'
 import SubsectionElement from '../../SubsectionElement'
-import Branch, { Accordion } from '../../../Form'
+import { Accordion } from '../../../Form'
 import { newGuid } from '../../../Form/ValidationElement'
 import { openState } from '../../../Form/Accordion/Accordion'
 import { today, daysAgo } from '../dateranges'

--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { i18n } from '../../../../config'
-import { physicaladdress } from '../../../../schema/form/physicaladdress'
+import { physicaladdress, collection } from '../../../../schema/form'
 import {
   ValidationElement,
   DateRange,
@@ -255,12 +255,30 @@ export default class ResidenceItem extends ValidationElement {
     return country !== null && country !== undefined && country !== 'POSTOFFICE' && country !== 'United States'
   }
 
+  computeAlternateAddressProps() {
+    const { PhysicalAddress } = this.props
+
+    if (!PhysicalAddress) {
+      return {
+        branch: { value: '' },
+        items: []
+      }
+    }
+
+    if (!PhysicalAddress.List) {
+      return PhysicalAddress
+    }
+
+    return PhysicalAddress.List
+  }
+
   render() {
     // Certain elements are present if the date range of the residency was
     // within the last 3 years.
     const dates = this.props.Dates || {}
     const from = buildDate(dates.from)
     const to = buildDate(dates.to)
+    const physicalAddress = this.computeAlternateAddressProps();
 
     return (
       <div className="residence">
@@ -294,7 +312,8 @@ export default class ResidenceItem extends ValidationElement {
         </Field>
         <Show when={this.isMilitaryAddress()}>
           <PhysicalAddress
-            physicalAddress={this.props.PhysicalAddress}
+            country="POSTOFFICE"
+            physicalAddress={physicalAddress}
             onUpdate={this.updatePhysicalAddress}
           />
         </Show>
@@ -309,9 +328,9 @@ export default class ResidenceItem extends ValidationElement {
             */
           }
           <PhysicalAddress
-            country="POSTOFFICE"
+            isForeign
             layout={Location.US_ADDRESS}
-            physicalAddress={this.props.PhysicalAddress}
+            physicalAddress={physicalAddress}
             onUpdate={this.updatePhysicalAddress}
           />
         </Show>
@@ -643,7 +662,18 @@ ResidenceItem.defaultProps = {
   Dates: {},
   Address: {},
   Comments: {},
-  PhysicalAddress: physicaladdress(),
+  PhysicalAddress: {
+    List: {
+      branch: { value: ''},
+      items: [{
+        Item: {
+          HasDifferentAddress: false,
+          Address: {},
+          Telephone: {}
+        }
+      }]
+    }
+  },
   Role: {},
   RoleOther: {},
   ReferenceName: {},

--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { i18n } from '../../../../config'
+import { physicaladdress } from '../../../../schema/form/physicaladdress'
 import {
   ValidationElement,
   DateRange,
@@ -18,8 +20,10 @@ import {
   NotApplicable,
   Email
 } from '../../../Form'
+import PhysicalAddress from '../../../Form/Location/PhysicalAddress'
 import { today, daysAgo } from '../dateranges'
 import { buildDate } from '../../../../validators/helpers'
+import { countryString } from '../../../../validators/location'
 
 // We need to determine how far back 3 years ago was
 const threeYearsAgo = daysAgo(today, 365 * 3)
@@ -59,6 +63,7 @@ export default class ResidenceItem extends ValidationElement {
     this.updateReferenceEmailNotApplicable = this.updateReferenceEmailNotApplicable.bind(
       this
     )
+    this.updatePhysicalAddress = this.updatePhysicalAddress.bind(this)
     this.updateReferenceEmail = this.updateReferenceEmail.bind(this)
     this.updateReferenceAddress = this.updateReferenceAddress.bind(this)
     this.updateComments = this.updateComments.bind(this)
@@ -76,6 +81,7 @@ export default class ResidenceItem extends ValidationElement {
       name: this.props.name,
       Dates: this.props.Dates,
       Address: this.props.Address,
+      PhysicalAddress: this.props.PhysicalAddress,
       Comments: this.props.Comments,
       Role: this.props.Role,
       RoleOther: this.props.RoleOther,
@@ -187,6 +193,12 @@ export default class ResidenceItem extends ValidationElement {
     })
   }
 
+  updatePhysicalAddress(values) {
+    this.update({
+      PhysicalAddress: values
+    })
+  }
+
   updateDates(values) {
     const dates = this.props.Dates || {}
     const from = dates.from
@@ -234,6 +246,10 @@ export default class ResidenceItem extends ValidationElement {
     })
   }
 
+  isMilitaryAddress() {
+    return countryString(this.props.Address.country) === 'POSTOFFICE'
+  }
+
   render() {
     // Certain elements are present if the date range of the residency was
     // within the last 3 years.
@@ -245,7 +261,7 @@ export default class ResidenceItem extends ValidationElement {
       <div className="residence">
         <Field
           title={i18n.t('history.residence.heading.address')}
-          optional={true}
+          optional
           help="history.residence.help.address"
           comments={false}
           commentsName="Comments"
@@ -254,23 +270,29 @@ export default class ResidenceItem extends ValidationElement {
           onUpdate={this.updateComments}
           onError={this.props.onError}
           adjustFor="address"
-          shrink={true}
+          shrink
           scrollIntoView={this.props.scrollIntoView}>
           <Location
             name="Address"
             {...this.props.Address}
             label={i18n.t('history.residence.label.address')}
             layout={Location.ADDRESS}
-            geocode={true}
+            geocode
             addressBook="Residence"
             addressBooks={this.props.addressBooks}
-            showPostOffice={true}
+            showPostOffice
             dispatch={this.props.dispatch}
             onUpdate={this.updateAddress}
             onError={this.props.onError}
             required={this.props.required}
           />
         </Field>
+        <Show when={this.isMilitaryAddress()}>
+          <PhysicalAddress
+            physicalAddress={this.props.PhysicalAddress}
+            onUpdate={this.updatePhysicalAddress}
+          />
+        </Show>
 
         <Field
           title={i18n.t('history.residence.heading.dates')}
@@ -356,7 +378,7 @@ export default class ResidenceItem extends ValidationElement {
             <Field
               title={i18n.t('history.residence.heading.reference')}
               titleSize="h2"
-              optional={true}
+              optional
               className="no-margin-bottom"
               scrollIntoView={this.props.scrollIntoView}>
               {i18n.m('history.residence.para.reference')}
@@ -366,7 +388,7 @@ export default class ResidenceItem extends ValidationElement {
               <Field
                 title={i18n.t('reference.heading.name')}
                 titleSize="h3"
-                optional={true}
+                optional
                 filterErrors={Name.requiredErrorsOnly}
                 scrollIntoView={this.props.scrollIntoView}>
                 <Name
@@ -385,7 +407,7 @@ export default class ResidenceItem extends ValidationElement {
                 title={i18n.t('reference.heading.contact')}
                 help={'reference.help.contact'}
                 adjustFor="labels"
-                shrink={true}
+                shrink
                 scrollIntoView={this.props.scrollIntoView}>
                 <DateControl
                   name="ReferenceLastContact"
@@ -399,13 +421,13 @@ export default class ResidenceItem extends ValidationElement {
 
               <Field
                 title={i18n.t('reference.heading.relationship')}
-                comments={true}
+                comments
                 commentsName="ReferenceRelationshipComments"
                 commentsValue={this.props.ReferenceRelationshipComments}
                 commentsAdd={'reference.label.relationship.comments'}
                 onUpdate={this.updateReferenceRelationshipComments}
                 adjustFor="labels"
-                shrink={true}
+                shrink
                 scrollIntoView={this.props.scrollIntoView}>
                 <label>{i18n.t('reference.label.relationship.title')}</label>
                 <CheckboxGroup
@@ -488,7 +510,7 @@ export default class ResidenceItem extends ValidationElement {
               <Field
                 title={i18n.t('reference.heading.correspondence')}
                 titleSize="h2"
-                optional={true}
+                optional
                 className="no-margin-bottom"
                 scrollIntoView={this.props.scrollIntoView}>
                 {i18n.m('reference.para.correspondence')}
@@ -567,7 +589,7 @@ export default class ResidenceItem extends ValidationElement {
 
               <Field
                 title={i18n.t('reference.heading.address')}
-                optional={true}
+                optional
                 help={'reference.help.address'}
                 adjustFor="address"
                 scrollIntoView={this.props.scrollIntoView}>
@@ -578,10 +600,10 @@ export default class ResidenceItem extends ValidationElement {
                   {...this.props.ReferenceAddress}
                   label={i18n.t('reference.label.address')}
                   layout={Location.ADDRESS}
-                  geocode={true}
+                  geocode
                   addressBooks={this.props.addressBooks}
                   addressBook="Reference"
-                  showPostOffice={true}
+                  showPostOffice
                   dispatch={this.props.dispatch}
                   onUpdate={this.updateReferenceAddress}
                   onError={this.props.onError}
@@ -599,6 +621,7 @@ ResidenceItem.defaultProps = {
   Dates: {},
   Address: {},
   Comments: {},
+  PhysicalAddress: physicaladdress(),
   Role: {},
   RoleOther: {},
   ReferenceName: {},

--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -250,6 +250,11 @@ export default class ResidenceItem extends ValidationElement {
     return countryString(this.props.Address.country) === 'POSTOFFICE'
   }
 
+  isForeignAddress() {
+    const country = countryString(this.props.Address.country);
+    return country !== null && country !== undefined && country !== 'POSTOFFICE' && country !== 'United States'
+  }
+
   render() {
     // Certain elements are present if the date range of the residency was
     // within the last 3 years.
@@ -289,6 +294,23 @@ export default class ResidenceItem extends ValidationElement {
         </Field>
         <Show when={this.isMilitaryAddress()}>
           <PhysicalAddress
+            physicalAddress={this.props.PhysicalAddress}
+            onUpdate={this.updatePhysicalAddress}
+          />
+        </Show>
+        <Show when={this.isForeignAddress()}>
+          {
+            /*
+             * Note that we have to force a layout of US_ADDRESS because of the way the
+             *
+             * Location component overrides the disableToggle property.
+             * The actual layout that will be show in this instance is that of
+             * the APO military address form
+            */
+          }
+          <PhysicalAddress
+            country="POSTOFFICE"
+            layout={Location.US_ADDRESS}
             physicalAddress={this.props.PhysicalAddress}
             onUpdate={this.updatePhysicalAddress}
           />

--- a/src/components/Section/History/Residence/ResidenceItem.test.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.test.jsx
@@ -62,19 +62,32 @@ describe('The residence component', () => {
     expect(component.find('.role.hidden').length).toEqual(0)
   })
 
-  it('displays an address component when a military address is specified', () => {
-    const props = {
-      Address: {
-        country: 'POSTOFFICE'
+  describe('displaying a <PhysicalAddress/> component', () => {
+    let component;
+
+    beforeEach(() => {
+      const props = {
+        Address: {
+          country: 'POSTOFFICE'
+        },
+        PhysicalAddress: {}
       }
-    }
 
-    const component = mount(<ResidenceItem {...props} />)
-    expect(component.find('PhysicalAddress').length).toEqual(1)
+      component = mount(<ResidenceItem {...props} />)
+    })
 
-    component.setProps({Address: 'Spain'})
-    expect(component.find('PhysicalAddress').length).toEqual(0)
+    it('displays an address component when a military address is specified', () => {
+      expect(component.find('PhysicalAddress').length).toEqual(1)
+
+      component.setProps({Address: 'Spain'})
+      expect(component.find('PhysicalAddress').length).toEqual(0)
+    })
+
+    it('supplies the physicalAddress prop to the <PhysicalAddress> component', () => {
+      expect(component.find('PhysicalAddress').prop('physicalAddress')).toBeDefined();
+    })
   })
+
 
   it('performs updates for components', () => {
     let updates = 0

--- a/src/components/Section/History/Residence/ResidenceItem.test.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.test.jsx
@@ -62,6 +62,20 @@ describe('The residence component', () => {
     expect(component.find('.role.hidden').length).toEqual(0)
   })
 
+  it('displays an address component when a military address is specified', () => {
+    const props = {
+      Address: {
+        country: 'POSTOFFICE'
+      }
+    }
+
+    const component = mount(<ResidenceItem {...props} />)
+    expect(component.find('PhysicalAddress').length).toEqual(1)
+
+    component.setProps({Address: 'Spain'})
+    expect(component.find('PhysicalAddress').length).toEqual(0)
+  })
+
   it('performs updates for components', () => {
     let updates = 0
     const expected = {

--- a/src/config/locales/en/address.js
+++ b/src/config/locales/en/address.js
@@ -1,6 +1,7 @@
 export const address = {
   label: 'This address is',
   spinner: 'Verifying your address',
+  physicalLocationRequired: 'Please provide a physical address for this location',
   options: {
     us: {
       label: 'In the<br>United States'

--- a/src/config/locales/en/address.js
+++ b/src/config/locales/en/address.js
@@ -2,6 +2,7 @@ export const address = {
   label: 'This address is',
   spinner: 'Verifying your address',
   physicalLocationRequired: 'Please provide a physical address for this location',
+  militaryAddress: 'Do you or did you have an APO/FPO address at this location',
   options: {
     us: {
       label: 'In the<br>United States'

--- a/src/schema/form/alternateaddress.js
+++ b/src/schema/form/alternateaddress.js
@@ -1,0 +1,4 @@
+import * as form from '../form'
+
+export const alternateAddress = () =>
+  form.collection([form.physicaladdress])

--- a/src/schema/section/history-residence.js
+++ b/src/schema/section/history-residence.js
@@ -7,6 +7,7 @@ export const historyResidence = (data = {}) => {
       Item: {
         Dates: form.daterange(xitem.Dates),
         Address: form.location(xitem.Address),
+        PhysicalAddress: form.physicaladdress(xitem.PhysicalAddress),
         Comments: form.textarea(xitem.Comments),
         ReferenceName: form.name(xitem.ReferenceName),
         ReferenceLastContact: form.datecontrol(xitem.ReferenceLastContact),
@@ -28,6 +29,7 @@ export const historyResidence = (data = {}) => {
       }
     }
   })
+
   return {
     List: form.collection(items, (data.List || {}).branch)
   }

--- a/src/schema/section/history-residence.js
+++ b/src/schema/section/history-residence.js
@@ -3,11 +3,19 @@ import * as form from '../form'
 export const historyResidence = (data = {}) => {
   const items = ((data.List || {}).items || []).map(x => {
     const xitem = x.Item || {}
+
     return {
       Item: {
         Dates: form.daterange(xitem.Dates),
         Address: form.location(xitem.Address),
-        PhysicalAddress: form.physicaladdress(xitem.PhysicalAddress),
+        PhysicalAddress: {
+          List: form.collection(
+            [{
+              Item: form.physicaladdress(xitem.PhysicalAddress)
+            }],
+          xitem.branch)
+        },
+        //PhysicalAddress: form.physicaladdress(xitem.PhysicalAddress),
         Comments: form.textarea(xitem.Comments),
         ReferenceName: form.name(xitem.ReferenceName),
         ReferenceLastContact: form.datecontrol(xitem.ReferenceLastContact),

--- a/src/schema/section/history-residence.test.js
+++ b/src/schema/section/history-residence.test.js
@@ -17,6 +17,13 @@ describe('Schema for financial taxes', () => {
               Address: {
                 country: null
               },
+              PhysicalAddress: {
+                Address: {
+                  country: null,
+                },
+                HasDifferentAddress: {},
+                Telephone: {},
+              },
               Comments: {},
               ReferenceName: {},
               ReferenceLastContact: {},

--- a/src/validators/location.js
+++ b/src/validators/location.js
@@ -2,14 +2,17 @@ import { api } from '../services/api'
 import Layouts from '../components/Form/Location/Layouts'
 import { isZipcodeState, zipcodes } from '../config'
 
+const isDefined = x => x !== null && x !== undefined
+
 export const isInternational = location => {
   return !['United States', 'POSTOFFICE'].includes(
     countryString(location.country || {})
   )
 }
 
+// XXX TEST ME
 export const countryString = country => {
-  if (country && country.value) {
+  if (country && isDefined(country.value)) {
     if (Array.isArray(country.value)) {
       return country.value[0]
     }

--- a/src/validators/location.js
+++ b/src/validators/location.js
@@ -10,7 +10,6 @@ export const isInternational = location => {
   )
 }
 
-// XXX TEST ME
 export const countryString = country => {
   if (country && isDefined(country.value)) {
     if (Array.isArray(country.value)) {


### PR DESCRIPTION
Part of #924 

Prompts the user to enter a secondary physical address when a military address is given in the residence section, or to enter an APO address when they have indicated foreign residence.

Currently, this is only present within the Residence History component