### PR TITLE
Restore missing bind prop on spouse's alias component

### DIFF
--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -18,9 +18,9 @@ import {
   Country,
   Location,
   BranchCollection,
-  AccordionItem,
+  AccordionItem
 } from '../../../Form'
-import { countryString } from '../../../../validators/location';
+import { countryString } from '../../../../validators/location'
 
 export default class CivilUnion extends ValidationElement {
   constructor(props) {
@@ -191,7 +191,7 @@ export default class CivilUnion extends ValidationElement {
      * `this.props.BirthPlace` can end up in a number of different states,
      * depending on the choices a user makes in this section _and_ on
      * the initial state of the app.
-     * 
+     *
      * The initial, pristine value for this.props.BirthPlace is `undefined`.
      * This occurs despite the BirthPlace key/value pair in defaultProps,
      * indicating that the value is being explicitly supplied at some point.
@@ -216,10 +216,11 @@ export default class CivilUnion extends ValidationElement {
      *
      *  {name: "country", comments: "", showComments: false, value: ['germany']}
      *
-    */
+     */
 
-    const { country } = this.props.BirthPlace;
-    const showForeignBornDocumentation = country && countryString(country) !== 'United States'
+    const { country } = this.props.BirthPlace
+    const showForeignBornDocumentation =
+      country && countryString(country) !== 'United States'
 
     return (
       <div className="civil-union">
@@ -320,6 +321,7 @@ export default class CivilUnion extends ValidationElement {
                 scrollIntoView={this.props.scrollIntoView}>
                 <Name
                   name="Name"
+                  bind
                   onError={this.props.onError}
                   required={this.props.required}
                   scrollIntoView={this.props.scrollIntoView}


### PR DESCRIPTION
`bind` was inadvertently removed in a previous commit and was causing the fields not to retain the values entered in. Fixes issue @ryanhofdotgov was seeing with test case 7 data.