### PR TITLE
Fix mandatory counseling for not been ordered

### DIFF
--- a/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.jsx
+++ b/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.jsx
@@ -66,11 +66,20 @@ export default class OrderedTreatment extends ValidationElement {
     let selected = cb.value
     let list = [...((this.props.OrderedBy || {}).values || [])]
 
-    if (list.includes(selected)) {
-      list.splice(list.indexOf(selected), 1)
-    } else {
-      list.push(selected)
-    }
+      if (list.includes(selected)) {
+        list.splice(list.indexOf(selected), 1)
+      } else {
+        if (selected !== "None" && list.includes("None")) {
+          list.splice(list.indexOf("None"), 1)
+          list.push(selected)
+        }
+        else if (selected === "None") {
+          list = [selected]
+        }
+        else {
+          list.push(selected)
+        }
+      }
 
     this.update({ OrderedBy: { values: list } })
   }

--- a/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.jsx
+++ b/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.jsx
@@ -69,12 +69,8 @@ export default class OrderedTreatment extends ValidationElement {
       if (list.includes(selected)) {
         list.splice(list.indexOf(selected), 1)
       } else {
-        if (selected !== "None" && list.includes("None")) {
-          list.splice(list.indexOf("None"), 1)
-          list.push(selected)
-        }
-        else if (selected === "None") {
-          list = [selected]
+        if (selected !== "None" && list.includes("None") || selected === "None") {
+            list = [selected]
         }
         else {
           list.push(selected)

--- a/src/validators/drugorderedtreatments.js
+++ b/src/validators/drugorderedtreatments.js
@@ -76,6 +76,18 @@ export class DrugOrderedTreatmentValidator {
   }
 
   isValid() {
-    return validGenericTextfield(this.explanation) && this.validActionTaken()
+    return validGenericTextfield(this.explanation) && this.validActionTaken() && this.validOrderedBy()
+  }
+
+  validOrderedBy() {
+    if (this.orderedBy.length <= 1) {
+      return true
+    }
+    else {
+      if (this.orderedBy.includes("None")) {
+        return false
+      }
+      return true
+    }
   }
 }

--- a/src/validators/drugorderedtreatments.js
+++ b/src/validators/drugorderedtreatments.js
@@ -83,11 +83,5 @@ export class DrugOrderedTreatmentValidator {
     if (this.orderedBy.length <= 1) {
       return true
     }
-    else {
-      if (this.orderedBy.includes("None")) {
-        return false
-      }
-      return true
-    }
   }
 }

--- a/src/validators/drugorderedtreatments.test.js
+++ b/src/validators/drugorderedtreatments.test.js
@@ -192,6 +192,29 @@ describe('Drug Ordered Treatment Validation', function() {
             items: [
               {
                 Item: {
+                  OrderedBy: ['Employer','None'],
+                  Explanation: {
+                    value: 'The explanation'
+                  },
+                  ActionTaken: { value: 'No' },
+                  NoActionTakenExplanation: {
+                    value: 'No action taken'
+                  }
+                }
+              }
+            ]
+          }
+        },
+        expected: false
+      },
+      {
+        state: {
+          TreatmentOrdered: { value: 'Yes' },
+          List: {
+            branch: { value: 'No' },
+            items: [
+              {
+                Item: {
                   OrderedBy: ['Employer'],
                   Explanation: {
                     value: 'The explanation'


### PR DESCRIPTION
Fixes #1047 

Adding functionality to toggle the buttons off when `I have not been ordered, advised, or asked to seek counseling or treatment by any of the above.` has been selected

The UI here is really confusing and could use some thought.

![click](https://user-images.githubusercontent.com/1449852/47879920-396ef100-ddf8-11e8-863b-7ebfe2db0690.gif)
