### PR TITLE
Fix tax year increment bug

### DIFF
--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -38,6 +38,7 @@ export const datePart = (part, date) => {
     case 'year':
     case 'yy':
     case 'y':
+      d.setYear(date)
       return d.getFullYear()
   }
 

--- a/src/components/Section/Financial/Taxes/TaxesItem.jsx
+++ b/src/components/Section/Financial/Taxes/TaxesItem.jsx
@@ -139,6 +139,7 @@ export default class TaxesItem extends ValidationElement {
           <DateControl
             name="Year"
             {...this.props.Year}
+            year={this.props.Year.year || this.props.Year.value}
             className="taxes-year"
             hideMonth={true}
             hideDay={true}

--- a/src/components/Section/Financial/Taxes/TaxesItem.jsx
+++ b/src/components/Section/Financial/Taxes/TaxesItem.jsx
@@ -139,7 +139,6 @@ export default class TaxesItem extends ValidationElement {
           <DateControl
             name="Year"
             {...this.props.Year}
-            year={this.props.Year.year || this.props.Year.value}
             className="taxes-year"
             hideMonth={true}
             hideDay={true}


### PR DESCRIPTION
Fixes #1071 

In this PR, I have verified that test case 7 displays the correct year and starting a new form also displays the correct year.

Because `DateControl.jsx` is a heavily used component throughout the application, I am mildly nervous about the changes breaking something else. I did a bit a regression, and haven't seen any red flags yet.

The issue with the code was:
```
var date = new Date("2015");
// Wed Dec 31 2014 16:00:00 GMT-0800 (Pacific Standard Time)

date.getFullYear();
// 2014

It should be 2015.
```
Instead, I manually use `setYear` on the date in the switch statement. I am hesitant to refactor the component more because other bugs that might be introduced.