### PR TITLE
Create a live-reload script for the server

### DIFF
--- a/api/bin/live_reload.sh
+++ b/api/bin/live_reload.sh
@@ -6,7 +6,7 @@
 
 # entr doesn't work in docker containers, being tracked by this bug:https://github.com/docker/for-mac/issues/896
 
-set -u -o pipefail
+set -eu -o pipefail
 
 # This just ensure that we clean up propperly on ctr-c, mostly useful for debugging this script.
 sigint_handler()

--- a/api/bin/live_reload.sh
+++ b/api/bin/live_reload.sh
@@ -19,18 +19,18 @@ trap sigint_handler SIGINT
 
 while true; do
 
-	if make build; then
-		./api 2>&1 &
-	  PID=$!
-	else
-		PID=-1
-	fi
+  if make build; then
+    ./api 2>&1 &
+    PID=$!
+  else
+    PID=-1
+  fi
   # inotifiywait runs until it hears a file event in this directory or any recursive subdirectories.
   # when it does, we kill the running server and start the loop over again.
   # if this script is looping on end, that likely means that we are touching some file other than
   # ./api on `make build.` you can add other files that should be ignored to the --exclude regex.
   inotifywait --exclude "(api$|\\.sh$)" -e modify -e move -e create -e delete -e attrib -r .
   if [ "$PID" -ne -1 ]; then
-	  kill "$PID"
-	fi
+    kill "$PID"
+  fi
 done

--- a/api/bin/live_reload.sh
+++ b/api/bin/live_reload.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# this script will only work on linux with inotify-tools installed.
+# This is a bashy clone of entr.
+# on macOS just use `entr`, it's so good.
+
+# entr doesn't work in docker containers, being tracked by this bug:https://github.com/docker/for-mac/issues/896
+
+set -u -o pipefail
+
+# This just ensure that we clean up propperly on ctr-c, mostly useful for debugging this script.
+sigint_handler()
+{
+  kill "$PID"
+  exit
+}
+
+trap sigint_handler SIGINT
+
+while true; do
+
+	if make build; then
+		./api 2>&1 &
+	  PID=$!
+	else
+		PID=-1
+	fi
+  # inotifiywait runs until it hears a file event in this directory or any recursive subdirectories.
+  # when it does, we kill the running server and start the loop over again.
+  # if this script is looping on end, that likely means that we are touching some file other than
+  # ./api on `make build.` you can add other files that should be ignored to the --exclude regex.
+  inotifywait --exclude "(api$|\\.sh$)" -e modify -e move -e create -e delete -e attrib -r .
+  if [ "$PID" -ne -1 ]; then
+	  kill "$PID"
+	fi
+done

--- a/conf/docker/Dockerfile.api
+++ b/conf/docker/Dockerfile.api
@@ -10,6 +10,9 @@ ENV PATH="${PATH}:${GOPATH}/src/github.com/18F/e-QIP-prototype/api/bin"
 # libxml2-utils provides xmllint and is only required for automated tests, not production use
 RUN DEBIAN_FRONTEND=noninteractive apt-get -q -y update && apt-get -q -y install xmlsec1 strace libxml2-utils;
 
+# install inotify-tools
+RUN apt-get -q -y install inotify-tools
+
 # install dependencies
 COPY api/Gopkg.toml api/Gopkg.lock ./
 RUN dep ensure -vendor-only

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       dockerfile: conf/docker/Dockerfile.api
     env_file:
       - .env
+    command: ./bin/live_reload.sh
     volumes:
       - .:/go/src/github.com/18F/e-QIP-prototype
       - /go/src/github.com/18F/e-QIP-prototype/api/vendor


### PR DESCRIPTION
This leaves the api container as it was, still running the ./bin/run.sh script but calls a different ./bin/live_reload.sh script from the docker container. 

I believe that this should functionally behave the same as before anywhere docker-compose.yaml is being used. The only trick is if extraneous files are being touched inside of ./api differently from the way it's behaving in local development. That could lead to a server restart loop as is.

Let's see if this passes CI. 