### PR TITLE
Encapsulate alternate address behavior

### DIFF
--- a/src/components/Form/Location/AlternateAddress.jsx
+++ b/src/components/Form/Location/AlternateAddress.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux';
 import { i18n } from '../../../config'
 import Field from '../Field'
@@ -7,9 +8,16 @@ import Show from '../Show'
 import Location from './Location'
 import LocationValidator, { countryString } from '../../../validators/location'
 import ValidationElement from '../ValidationElement'
-import alternateAddress from '../../../schema/form/alternateAddress'
+import alternateAddress from '../../../schema/form/alternateaddress'
 
 const alternateAddressDefaultState = alternateAddress
+const propTypes = {
+  address: PropTypes.object,
+  belongingTo: PropTypes.string,
+  country: PropTypes.string,
+  onUpdate: PropTypes.func
+}
+
 
 class AlternateAddress extends ValidationElement {
   constructor(props) {
@@ -126,6 +134,7 @@ class AlternateAddress extends ValidationElement {
   }
 }
 
+AlternateAddress.propTypes = propTypes
 AlternateAddress.defaultProps = {
   addressFieldMetadata: {
     streetLabel: i18n.t('address.us.street.label'),

--- a/src/components/Form/Location/AlternateAddress.jsx
+++ b/src/components/Form/Location/AlternateAddress.jsx
@@ -9,8 +9,10 @@ import LocationValidator, { countryString } from '../../../validators/location'
 import ValidationElement from '../ValidationElement'
 
 const alternateAddressDefaultState = () => ({
-  Address: {},
-  HasDifferentAddress: { value: '' }
+  AlternateAddress: {
+    Address: {},
+    HasDifferentAddress: { value: '' }
+  }
 })
 
 class AlternateAddress extends ValidationElement {
@@ -23,21 +25,25 @@ class AlternateAddress extends ValidationElement {
 
   componentDidUpdate(prevProps) {
     if (!this.isSameCountry(prevProps.country) && !this.isForeignAddress()) {
-      this.props.onUpdateCountry(alternateAddressDefaultState());
+      this.props.onUpdate(alternateAddressDefaultState())      
     }
   }
 
   handleUpdate(values) {
     this.props.onUpdate({
-      ...this.props.alternateAddress,
-      Address: values
+      AlternateAddress: {
+        ...this.props.alternateAddress,
+        Address: values
+      }
     })
   }
 
   setAlternateAddress(values) {
     this.props.onUpdate({
-      ...this.props.alternateAddress,
-      HasDifferentAddress: values
+      AlternateAddress: {
+        ...this.props.alternateAddress,
+        HasDifferentAddress: values
+      }
     })
   }
 
@@ -129,8 +135,7 @@ AlternateAddress.defaultProps = {
     countyLabel: i18n.t('address.us.county.label'),
     countryLabel: i18n.t('address.international.country.label'),
   },
-  layout: Location.ADDRESS,
-  onUpdateCountry: () => ({})
+  layout: Location.ADDRESS
 }
 
 const mapStateToProps = ({ application }, ownProps) => ({

--- a/src/components/Form/Location/AlternateAddress.jsx
+++ b/src/components/Form/Location/AlternateAddress.jsx
@@ -18,7 +18,6 @@ const propTypes = {
   onUpdate: PropTypes.func
 }
 
-
 class AlternateAddress extends ValidationElement {
   constructor(props) {
     super(props)
@@ -98,7 +97,7 @@ class AlternateAddress extends ValidationElement {
   render() {
     return (
       <div>
-        <Show when={this.isForeignAddress()}>
+        <Show when={this.isForeignAddress() && this.props.allowForeignMilitary}>
           <Branch
             label={i18n.t('address.militaryAddress')}
             labelSize="h3"
@@ -106,7 +105,7 @@ class AlternateAddress extends ValidationElement {
             value={this.props.address.HasDifferentAddress.value}
           />
         </Show>
-        <Show when={this.isForeignMilitaryAddress() && this.props.allowForeignMilitary}>
+        <Show when={this.isForeignMilitaryAddress()}>
           <Field title={i18n.t('address.physicalLocationRequired')}>
             <Location
               {...this.prepareProps({

--- a/src/components/Form/Location/AlternateAddress.test.jsx
+++ b/src/components/Form/Location/AlternateAddress.test.jsx
@@ -3,13 +3,14 @@ import { mount } from 'enzyme'
 import { fn } from 'jest'
 import { AlternateAddress } from './AlternateAddress'
 import { address } from '../../../config/locales/en/address'
+import alternateAddress from '../../../schema/form/alternateaddress'
 
 describe('<AlternateAddress />', () => {
   describe('when a user indicates a foreign address', () => {
     it('renders a Branch component', () => {
       const props = {
         country: '',
-        alternateAddress: {
+        address: {
           HasDifferentAddress: '',
           Address: { country: '' }
         }
@@ -26,7 +27,7 @@ describe('<AlternateAddress />', () => {
       const props = {
         allowForeignMilitary: true,
         country: '',
-        alternateAddress: {
+        address: {
           HasDifferentAddress: { value: 'Yes' }
         }
       }
@@ -39,13 +40,13 @@ describe('<AlternateAddress />', () => {
     it('passes the branch value to the branch', () => {
       const props = {
         country: '',
-        alternateAddress: {
+        address: {
           HasDifferentAddress: { value: 'No' }
         }
       }
       const component = mount(<AlternateAddress {...props} />)
 
-      expect(component.find('Branch').prop('value')).toEqual(props.alternateAddress.HasDifferentAddress.value)
+      expect(component.find('Branch').prop('value')).toEqual(props.address.HasDifferentAddress.value)
     })
 
     describe('when the user toggles to an APO address', () => {
@@ -53,7 +54,7 @@ describe('<AlternateAddress />', () => {
         const props = {
           onUpdate: () => ({}),
           country: 'Spain',
-          alternateAddress: {
+          address: {
             HasDifferentAddress: { value: 'Yes' }
           }
         }
@@ -74,7 +75,7 @@ describe('<AlternateAddress />', () => {
   it('renders the correct field label', () => {
     const props = {
       country: 'POSTOFFICE',
-      alternateAddress: {
+      address: {
         HasDifferentAddress: { value: '' },
         Address: {}
       }
@@ -88,9 +89,10 @@ describe('<AlternateAddress />', () => {
 
   it('resets the alternate address when a new country type is selected', () => {
     const props = {
+      belongingTo: 'Address',
       onUpdate: jest.fn(),
       country: 'Germany',
-      alternateAddress: {
+      address: {
         Address: {
           country: 'POSTOFFICE',
           state: 'AA'
@@ -100,14 +102,17 @@ describe('<AlternateAddress />', () => {
     }
 
     const component = mount(<AlternateAddress {...props} />)
-    expect(component.prop('alternateAddress').Address.country).toEqual(props.alternateAddress.Address.country);
+    expect(component.prop('address').Address.country).toEqual(props.address.Address.country);
 
     component.setProps({ country: 'United States' })
 
     expect(props.onUpdate.mock.calls.length).toBe(1)
     expect(props.onUpdate.mock.calls[0][0]).toEqual({
-      Address: {},
-      HasDifferentAddress: { value: '' }
+      Address: {
+        Address: { country: null },
+        HasDifferentAddress: { value: '' },
+        Telephone: {}
+      }
     })
   })
 
@@ -115,7 +120,7 @@ describe('<AlternateAddress />', () => {
     it('supplies the correct props to the Location component', () => {
       const props = {
         country: 'POSTOFFICE',
-        alternateAddress: {
+        address: {
           Address: {
             country: ''
           },
@@ -127,7 +132,7 @@ describe('<AlternateAddress />', () => {
 
       expect(location.prop('disableToggle')).toEqual(undefined);
       expect(location.prop('geocode')).toEqual(true);
-      expect(location.prop('country')).toEqual(props.alternateAddress.Address.country)
+      expect(location.prop('country')).toEqual(props.address.Address.country)
     })
   })
 })

--- a/src/components/Form/Location/AlternateAddress.test.jsx
+++ b/src/components/Form/Location/AlternateAddress.test.jsx
@@ -9,6 +9,7 @@ describe('<AlternateAddress />', () => {
   describe('when a user indicates a foreign address', () => {
     it('renders a Branch component', () => {
       const props = {
+        allowForeignMilitary: true,
         country: '',
         address: {
           HasDifferentAddress: '',
@@ -39,6 +40,7 @@ describe('<AlternateAddress />', () => {
 
     it('passes the branch value to the branch', () => {
       const props = {
+        allowForeignMilitary: true,
         country: '',
         address: {
           HasDifferentAddress: { value: 'No' }
@@ -52,6 +54,7 @@ describe('<AlternateAddress />', () => {
     describe('when the user toggles to an APO address', () => {
       it('toggles the secondary APO address form properly', () => {
         const props = {
+          allowForeignMilitary: true,
           onUpdate: () => ({}),
           country: 'Spain',
           address: {

--- a/src/components/Form/Location/AlternateAddress.test.jsx
+++ b/src/components/Form/Location/AlternateAddress.test.jsx
@@ -50,6 +50,7 @@ describe('<AlternateAddress />', () => {
     describe('when the user toggles to an APO address', () => {
       it('toggles the secondary APO address form properly', () => {
         const props = {
+          onUpdate: () => ({}),
           country: 'Spain',
           alternateAddress: {
             HasDifferentAddress: { value: 'Yes' }
@@ -86,7 +87,7 @@ describe('<AlternateAddress />', () => {
 
   it('resets the alternate address when a new country type is selected', () => {
     const props = {
-      onUpdateCountry: jest.fn(),
+      onUpdate: jest.fn(),
       country: 'Germany',
       alternateAddress: {
         Address: {
@@ -102,8 +103,8 @@ describe('<AlternateAddress />', () => {
 
     component.setProps({ country: 'United States' })
 
-    expect(props.onUpdateCountry.mock.calls.length).toBe(1)
-    expect(props.onUpdateCountry.mock.calls[0][0]).toEqual({
+    expect(props.onUpdate.mock.calls.length).toBe(1)
+    expect(props.onUpdate.mock.calls[0][0]).toEqual({
       Address: {},
       HasDifferentAddress: { value: '' }
     })

--- a/src/components/Form/Location/AlternateAddress.test.jsx
+++ b/src/components/Form/Location/AlternateAddress.test.jsx
@@ -24,6 +24,7 @@ describe('<AlternateAddress />', () => {
 
     it('renders an APO/FPO-only component when Branch value is yes', () => {
       const props = {
+        allowForeignMilitary: true,
         country: '',
         alternateAddress: {
           HasDifferentAddress: { value: 'Yes' }

--- a/src/components/Form/Location/alternateAddressProvider.jsx
+++ b/src/components/Form/Location/alternateAddressProvider.jsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import AlternateAddress from './AlternateAddress'
+
+/**
+ * Becuase of the way the app is structured, this component
+ * MUST be passed an onUpdate function which conforms to the
+ * `update` function included in every component in this app
+ * 
+ */
+// const propTypes = {
+//   onUpdate: PropTypes.func.isRequired
+// }
+
+const alternateAddressProvider = (Component) => {
+  class AddressProvider extends React.Component {
+    constructor(props) {
+      super(props)
+
+      this.renderAlternateAddress = this.renderAlternateAddress.bind(this)
+    }
+
+    renderAlternateAddress(extraProps) {
+      return (
+        <AlternateAddress
+          {...extraProps}
+          alternateAddress={this.props.AlternateAddress}
+          onUpdate={extraProps.onUpdate}
+        />
+      );
+    }
+
+    render() {
+      return (
+        <Component 
+          {...this.props}
+          render={this.renderAlternateAddress}
+        />
+      )
+    }
+  }
+
+  AddressProvider.defaultProps = {
+    AlternateAddress: {
+      Address: {},
+      HasDifferentAddress: { value: '' }
+    }
+  }
+
+  return AddressProvider
+}
+
+
+export default alternateAddressProvider

--- a/src/components/Form/Location/alternateAddressProvider.jsx
+++ b/src/components/Form/Location/alternateAddressProvider.jsx
@@ -1,16 +1,13 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import AlternateAddress from './AlternateAddress'
+import alternateAddress from '../../../schema/form/alternateAddress'
 
 /**
  * Becuase of the way the app is structured, this component
  * MUST be passed an onUpdate function which conforms to the
  * `update` function included in every component in this app
  * 
- */
-// const propTypes = {
-//   onUpdate: PropTypes.func.isRequired
-// }
+*/
 
 const alternateAddressProvider = (Component) => {
   class AddressProvider extends React.Component {
@@ -24,8 +21,8 @@ const alternateAddressProvider = (Component) => {
       return (
         <AlternateAddress
           {...extraProps}
-          alternateAddress={this.props.AlternateAddress}
-          onUpdate={extraProps.onUpdate}
+          addressBook={this.props.addressBook}
+          allowForeignMilitary
         />
       );
     }
@@ -41,10 +38,8 @@ const alternateAddressProvider = (Component) => {
   }
 
   AddressProvider.defaultProps = {
-    AlternateAddress: {
-      Address: {},
-      HasDifferentAddress: { value: '' }
-    }
+    addressBook: 'Residence',
+    allowForeignMilitary: true,
   }
 
   return AddressProvider

--- a/src/components/Form/Location/alternateAddressProvider.jsx
+++ b/src/components/Form/Location/alternateAddressProvider.jsx
@@ -1,13 +1,6 @@
 import React from 'react'
 import AlternateAddress from './AlternateAddress'
-import alternateAddress from '../../../schema/form/alternateAddress'
-
-/**
- * Becuase of the way the app is structured, this component
- * MUST be passed an onUpdate function which conforms to the
- * `update` function included in every component in this app
- * 
-*/
+import alternateAddress from '../../../schema/form/alternateaddress'
 
 const alternateAddressProvider = (Component) => {
   class AddressProvider extends React.Component {
@@ -17,12 +10,19 @@ const alternateAddressProvider = (Component) => {
       this.renderAlternateAddress = this.renderAlternateAddress.bind(this)
     }
 
+
+    /**
+     * Becuase of the way the app is structured, this component
+     * MUST be passed an `onUpdate` function in the extraProps obj that
+     * conforms to the `update` function included in every component in this app
+     *
+    */
     renderAlternateAddress(extraProps) {
       return (
         <AlternateAddress
           {...extraProps}
           addressBook={this.props.addressBook}
-          allowForeignMilitary
+          allowForeignMilitary={this.props.allowForeignMilitary}
         />
       );
     }

--- a/src/components/Form/Location/alternateAddressProvider.test.jsx
+++ b/src/components/Form/Location/alternateAddressProvider.test.jsx
@@ -10,10 +10,6 @@ describe('.alternateAddressProvider', () => {
     const mock = component.instance().renderAlternateAddress;
     const expected = {
       addressBook: 'Residence',
-      AlternateAddress: {
-        Address: {},
-        HasDifferentAddress: { value: '' }
-      },
       allowForeignMilitary: true,
       render: mock
     }

--- a/src/components/Form/Location/alternateAddressProvider.test.jsx
+++ b/src/components/Form/Location/alternateAddressProvider.test.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme'
+import alternateAddressProvider from './alternateAddressProvider'
+
+describe('.alternateAddressProvider', () => {
+  it('decorates the supplied component with the correct props', () => {
+    const Component = alternateAddressProvider(() => <div />)
+    Component.prototype.renderAlternateAddress = jest.fn();
+    const component = shallow(<Component />)
+    const mock = component.instance().renderAlternateAddress;
+    const expected = {
+      addressBook: 'Residence',
+      AlternateAddress: {
+        Address: {},
+        HasDifferentAddress: { value: '' }
+      },
+      allowForeignMilitary: true,
+      render: mock
+    }
+
+    expect(component.props()).toEqual(expected);
+  })
+})

--- a/src/components/Section/History/Employment/Employment.jsx
+++ b/src/components/Section/History/Employment/Employment.jsx
@@ -10,6 +10,9 @@ import { today, daysAgo } from '../dateranges'
 import { InjectGaps, EmploymentCustomSummary } from '../summaries'
 import EmploymentItem from './EmploymentItem'
 import { Gap } from '../Gap'
+import alternateAddressProvider from '../../../Form/Location/alternateAddressProvider'
+
+const AlternateAddressEmploymentItem = alternateAddressProvider(EmploymentItem)
 
 const byline = (item, index, initial, translation, required, validator) => {
   // If item is required and not currently opened and is not valid, show message
@@ -159,9 +162,9 @@ export default class Employment extends SubsectionElement {
           appendClass="no-margin-bottom"
           required={this.props.required}
           scrollIntoView={this.props.scrollIntoView}>
-          <EmploymentItem
+          <AlternateAddressEmploymentItem
+            bind
             name="Item"
-            bind={true}
             addressBooks={this.props.addressBooks}
             dispatch={this.props.dispatch}
             required={this.props.required}

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -24,6 +24,7 @@ export default class EmploymentItem extends ValidationElement {
   constructor(props) {
     super(props)
 
+    this.update = this.update.bind(this);
     this.updateEmploymentActivity = this.updateEmploymentActivity.bind(this)
     this.updateEmployment = this.updateEmployment.bind(this)
     this.updateDates = this.updateDates.bind(this)
@@ -518,6 +519,11 @@ export default class EmploymentItem extends ValidationElement {
                 onError={this.props.onError}
               />
             </Field>
+
+            { this.props.render({
+              country: this.props.ReferenceAddress.country,
+              onUpdate: this.update
+            })}
           </div>
         </Show>
 

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -521,6 +521,8 @@ export default class EmploymentItem extends ValidationElement {
             </Field>
 
             { this.props.render({
+              address: this.props.ReferenceAlternateAddress,
+              belongingTo: 'ReferenceAddress',
               country: this.props.ReferenceAddress.country,
               onUpdate: this.update
             })}

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -522,7 +522,7 @@ export default class EmploymentItem extends ValidationElement {
 
             { this.props.render({
               address: this.props.ReferenceAlternateAddress,
-              belongingTo: 'ReferenceAddress',
+              belongingTo: 'ReferenceAlternateAddress',
               country: this.props.ReferenceAddress.country,
               onUpdate: this.update
             })}

--- a/src/components/Section/History/Employment/EmploymentItem.test.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.test.jsx
@@ -5,24 +5,27 @@ import EmploymentItem from './EmploymentItem'
 import ReasonLeft from './ReasonLeft'
 import Reprimand from './Reprimand'
 
+const alternateAddressRenderMock = jest.fn();
+const buildProps = other => ({ render: alternateAddressRenderMock, ...other})
+
 describe('The employment component', () => {
   it('no error on empty', () => {
-    const expected = {
+    const expected = buildProps({
       name: 'employment'
-    }
+    })
     const component = mount(<EmploymentItem {...expected} />)
     expect(component.find('.h3').length).toBeGreaterThan(0)
   })
 
   it('can populate values for Military, NationalGuard and USPHS', () => {
     let updates = 0
-    const expected = {
+    const expected = buildProps({
       name: 'employment',
       EmploymentActivity: { value: 'ActiveMilitary' },
       onUpdate: () => {
         updates++
       }
-    }
+    })
     const selectors = [
       '.employment-title',
       '.employment-duty-station',
@@ -47,7 +50,7 @@ describe('The employment component', () => {
 
   it('display displinary when within 7 years', () => {
     const sevenYearsAgo = daysAgo(today, 365 * 7)
-    const props = {
+    const props = buildProps({
       EmploymentActivity: { value: 'ActiveMilitary' },
       Dates: {
         present: true,
@@ -58,14 +61,14 @@ describe('The employment component', () => {
         },
         to: {}
       }
-    }
+    })
     const component = mount(<EmploymentItem {...props} />)
     expect(component.find('.reprimand-branch').length).toBe(1)
   })
 
   it('does not display disciplinary if not within 7 years', () => {
     const past = daysAgo(today, 365 * 8)
-    const props = {
+    const props = buildProps({
       EmploymentActivity: { value: 'ActiveMilitary' },
       Dates: {
         present: false,
@@ -76,14 +79,14 @@ describe('The employment component', () => {
         },
         to: {}
       }
-    }
+    })
     const component = mount(<EmploymentItem {...props} />)
     expect(component.find('.reprimand-branch').length).toBe(0)
   })
 
   it('display reason left options when within 7 years', () => {
     const sevenYearsAgo = daysAgo(today, 365 * 7)
-    const props = {
+    const props = buildProps({
       EmploymentActivity: { value: 'ActiveMilitary' },
       Dates: {
         present: true,
@@ -94,14 +97,14 @@ describe('The employment component', () => {
         },
         to: {}
       }
-    }
+    })
     const component = mount(<EmploymentItem {...props} />)
     expect(component.find('.reason-options').length).toBe(1)
   })
 
   it('does not display reason left options if not within 7 years', () => {
     const past = daysAgo(today, 365 * 8)
-    const props = {
+    const props = buildProps({
       EmploymentActivity: { value: 'ActiveMilitary' },
       Dates: {
         present: false,
@@ -112,14 +115,14 @@ describe('The employment component', () => {
         },
         to: {}
       }
-    }
+    })
     const component = mount(<EmploymentItem {...props} />)
     expect(component.find('.reason-options').length).toBe(0)
   })
 
   it('does not display reason for leaving if currently employed', () => {
     const past = daysAgo(today, 365 * 3)
-    const props = {
+    const props = buildProps({
       EmploymentActivity: { value: 'ActiveMilitary' },
       Dates: {
         present: true,
@@ -130,7 +133,7 @@ describe('The employment component', () => {
         },
         to: {}
       }
-    }
+    })
     const component = mount(<EmploymentItem {...props} />)
     expect(component.find('.reason-description').length).toBe(0)
   })
@@ -140,7 +143,7 @@ describe('The employment component', () => {
 
     beforeEach(() => {
       const past = daysAgo(today, 365 * 3)
-      const props = {
+      const props = buildProps({
         EmploymentActivity: { value: 'Unemployment' },
         Dates: {
           present: true,
@@ -151,7 +154,7 @@ describe('The employment component', () => {
           },
           to: {}
         }
-      }
+      })
       component = mount(<EmploymentItem {...props} />)
     })
 
@@ -166,7 +169,7 @@ describe('The employment component', () => {
 
   it('it does display reason for leaving', () => {
     const past = daysAgo(today, 365 * 3)
-    const props = {
+    const props = buildProps({
       EmploymentActivity: { value: 'ActiveMilitary' },
       Dates: {
         present: false,
@@ -177,7 +180,7 @@ describe('The employment component', () => {
         },
         to: {}
       }
-    }
+    })
     const component = mount(<EmploymentItem {...props} />)
     expect(component.find('.reason-description').length).toBe(1)
   })

--- a/src/components/Section/History/Residence/Residence.jsx
+++ b/src/components/Section/History/Residence/Residence.jsx
@@ -13,6 +13,9 @@ import { today, daysAgo } from '../dateranges'
 import { InjectGaps, ResidenceCustomSummary } from '../summaries'
 import ResidenceItem from './ResidenceItem'
 import { Gap } from '../Gap'
+import alternateAddressProvider from '../../../Form/Location/alternateAddressProvider'
+
+const AlternateAddressResidenceItem = alternateAddressProvider(ResidenceItem)
 
 const byline = (item, index, initial, translation, required, validator) => {
   switch (true) {
@@ -124,7 +127,7 @@ export default class Residence extends SubsectionElement {
           appendLabel={i18n.t('history.residence.collection.append')}
           required={this.props.required}
           scrollIntoView={this.props.scrollIntoView}>
-          <ResidenceItem
+          <AlternateAddressResidenceItem
             bind
             name="Item"
             addressBooks={this.props.addressBooks}

--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -62,7 +62,7 @@ export default class ResidenceItem extends ValidationElement {
     this.updateReferenceEmailNotApplicable = this.updateReferenceEmailNotApplicable.bind(
       this
     )
-    this.updateAlternateAddress = this.updateAlternateAddress.bind(this)
+   // this.updateAlternateAddress = this.updateAlternateAddress.bind(this)
     this.updateReferenceEmail = this.updateReferenceEmail.bind(this)
     this.updateReferenceAddress = this.updateReferenceAddress.bind(this)
     this.updateComments = this.updateComments.bind(this)
@@ -80,7 +80,6 @@ export default class ResidenceItem extends ValidationElement {
       name: this.props.name,
       Dates: this.props.Dates,
       Address: this.props.Address,
-      AlternateAddress: this.props.AlternateAddress,
       Comments: this.props.Comments,
       Role: this.props.Role,
       RoleOther: this.props.RoleOther,
@@ -192,11 +191,11 @@ export default class ResidenceItem extends ValidationElement {
     })
   }
 
-  updateAlternateAddress(values) {
-    this.update({
-      AlternateAddress: values
-    })
-  }
+  // updateAlternateAddress(values) {
+  //   this.update({
+  //     AlternateAddress: values
+  //   })
+  // }
 
   updateDates(values) {
     const dates = this.props.Dates || {}
@@ -283,12 +282,15 @@ export default class ResidenceItem extends ValidationElement {
           />
         </Field>
 
-        <AlternateAddress
+        { this.props.render({
+          country: this.props.Address.country,
+          onUpdate: this.update
+        })}
+        {/*<AlternateAddress
           country={this.props.Address.country}
-          onUpdateCountry={this.updateAlternateAddress}
           onUpdate={this.updateAlternateAddress}
           alternateAddress={this.props.AlternateAddress}
-        />
+        />*/}
 
         <Field
           title={i18n.t('history.residence.heading.dates')}
@@ -615,12 +617,12 @@ export default class ResidenceItem extends ValidationElement {
 
 ResidenceItem.defaultProps = {
   Dates: {},
-  Address: {},
+ // Address: {},
   Comments: {},
-  AlternateAddress: {
-    Address: {},
-    HasDifferentAddress: { value: '' }
-  },
+  // AlternateAddress: {
+  //   Address: {},
+  //   HasDifferentAddress: { value: '' }
+  // },
   Role: {},
   RoleOther: {},
   ReferenceName: {},

--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -62,7 +62,6 @@ export default class ResidenceItem extends ValidationElement {
     this.updateReferenceEmailNotApplicable = this.updateReferenceEmailNotApplicable.bind(
       this
     )
-   // this.updateAlternateAddress = this.updateAlternateAddress.bind(this)
     this.updateReferenceEmail = this.updateReferenceEmail.bind(this)
     this.updateReferenceAddress = this.updateReferenceAddress.bind(this)
     this.updateComments = this.updateComments.bind(this)
@@ -77,23 +76,7 @@ export default class ResidenceItem extends ValidationElement {
    */
   update(queue) {
     this.props.onUpdate({
-      name: this.props.name,
-      Dates: this.props.Dates,
-      Address: this.props.Address,
-      Comments: this.props.Comments,
-      Role: this.props.Role,
-      RoleOther: this.props.RoleOther,
-      ReferenceName: this.props.ReferenceName,
-      ReferenceLastContact: this.props.ReferenceLastContact,
-      ReferenceRelationshipComments: this.props.ReferenceRelationshipComments,
-      ReferenceRelationship: this.props.ReferenceRelationship,
-      ReferenceRelationshipOther: this.props.ReferenceRelationshipOther,
-      ReferencePhoneEvening: this.props.ReferencePhoneEvening,
-      ReferencePhoneDay: this.props.ReferencePhoneDay,
-      ReferencePhoneMobile: this.props.ReferencePhoneMobile,
-      ReferenceEmailNotApplicable: this.props.ReferenceEmailNotApplicable,
-      ReferenceEmail: this.props.ReferenceEmail,
-      ReferenceAddress: this.props.ReferenceAddress,
+      ...this.props,
       ...queue
     })
   }
@@ -191,12 +174,6 @@ export default class ResidenceItem extends ValidationElement {
     })
   }
 
-  // updateAlternateAddress(values) {
-  //   this.update({
-  //     AlternateAddress: values
-  //   })
-  // }
-
   updateDates(values) {
     const dates = this.props.Dates || {}
     const from = dates.from
@@ -282,15 +259,12 @@ export default class ResidenceItem extends ValidationElement {
           />
         </Field>
 
-        { this.props.render({
+        {this.props.render({
+          belongingTo: 'AlternateAddress',
+          address: this.props.AlternateAddress,
           country: this.props.Address.country,
           onUpdate: this.update
         })}
-        {/*<AlternateAddress
-          country={this.props.Address.country}
-          onUpdate={this.updateAlternateAddress}
-          alternateAddress={this.props.AlternateAddress}
-        />*/}
 
         <Field
           title={i18n.t('history.residence.heading.dates')}
@@ -607,6 +581,14 @@ export default class ResidenceItem extends ValidationElement {
                   onError={this.props.onError}
                 />
               </Field>
+
+              {this.props.render({
+                belongingTo: 'ReferenceAlternateAddress',
+                address: this.props.ReferenceAlternateAddress,
+                country: this.props.ReferenceAddress.country,
+                onUpdate: this.update
+              })}
+
             </div>
           </div>
         </Show>
@@ -617,12 +599,8 @@ export default class ResidenceItem extends ValidationElement {
 
 ResidenceItem.defaultProps = {
   Dates: {},
- // Address: {},
+  Address: {},
   Comments: {},
-  // AlternateAddress: {
-  //   Address: {},
-  //   HasDifferentAddress: { value: '' }
-  // },
   Role: {},
   RoleOther: {},
   ReferenceName: {},

--- a/src/components/Section/History/Residence/ResidenceItem.test.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.test.jsx
@@ -4,12 +4,17 @@ import configureMockStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
 import ResidenceItem from './ResidenceItem'
 
+const alternateAddressRenderMock = jest.fn();
 const mountComponent = (mockStore, Component, props) => {
   const store = mockStore({ application: { AddressBooks: {} }})
+  const finalProps = {
+    render: alternateAddressRenderMock,
+    ...props
+  }
 
   return mount(
     <Provider store={store}>
-      <Component {...props} />
+      <Component {...finalProps} />
     </Provider>
   )
 }
@@ -18,7 +23,7 @@ describe('The residence component', () => {
   const mockStore = configureMockStore()
 
   it('renders without crashing', () => {
-    shallow(<ResidenceItem />)
+    shallow(<ResidenceItem render={alternateAddressRenderMock}/>)
   })
 
   it('no error on empty', () => {
@@ -77,28 +82,10 @@ describe('The residence component', () => {
     expect(component.find('.role.hidden').length).toEqual(0)
   })
 
-  describe('displaying a <PhysicalAddress/> component', () => {
-    it('supplies the physicalAddress prop to the <PhysicalAddress> component', () => {
-      const props = {
-        Address: {
-          country: 'POSTOFFICE'
-        },
-        AlternateAddress: {
-          HasDifferentAddress: { value: '' }
-        }
-      }
-
-      const component = mountComponent(mockStore, ResidenceItem, props);
-      expect(component.find('AlternateAddress').prop('alternateAddress')).toBeDefined();
-    })
-  })
-
-
   it('performs updates for components', () => {
     let updates = 0
     const expected = {
       name: 'residence',
-
       Dates: {
         from: {
           day: '1',

--- a/src/schema/form/alternateaddress.js
+++ b/src/schema/form/alternateaddress.js
@@ -1,0 +1,13 @@
+import { general } from './general'
+
+const defaultState = (options = {}) => ({
+  Address: {},
+  HasDifferentAddress: { value: '' },
+  ...options
+})
+
+const alternateaddress = (data = {}) =>
+  general('alternateaddress', defaultState(data))
+
+export { alternateaddress }
+export default defaultState

--- a/src/schema/form/alternateaddress.js
+++ b/src/schema/form/alternateaddress.js
@@ -1,8 +1,11 @@
 import { general } from './general'
 
 const defaultState = (options = {}) => ({
-  Address: {},
+  Address: {
+    country: null
+  },
   HasDifferentAddress: { value: '' },
+  Telephone: {},
   ...options
 })
 

--- a/src/schema/form/index.js
+++ b/src/schema/form/index.js
@@ -1,3 +1,4 @@
+import { alternateaddress } from './alternateaddress'
 import { benefit } from './benefit'
 import { branch } from './branch'
 import { checkbox } from './checkbox'
@@ -33,6 +34,7 @@ import { textarea } from './textarea'
 import { signature } from './signature'
 
 export {
+  alternateaddress,
   benefit,
   branch,
   checkbox,

--- a/src/schema/section/history-employment.js
+++ b/src/schema/section/history-employment.js
@@ -27,7 +27,6 @@ export const historyEmployment = (data = {}) => {
           })
         ),
         Telephone: form.telephone(xitem.Telephone),
-        PhysicalAddress: form.physicaladdress(xitem.PhysicalAddress),
         ReasonLeft: form.reasonleft(xitem.ReasonLeft),
         Reprimand: form.collection(
           ((reprimand || {}).items || []).map(y => {
@@ -44,7 +43,8 @@ export const historyEmployment = (data = {}) => {
         Supervisor: form.supervisor(xitem.Supervisor),
         ReferenceName: form.name(xitem.ReferenceName),
         ReferencePhone: form.telephone(xitem.ReferencePhone),
-        ReferenceAddress: form.location(xitem.ReferenceAddress)
+        ReferenceAddress: form.location(xitem.ReferenceAddress),
+        ReferenceAlternateAddress: form.physicaladdress(xitem.ReferenceAlternateAddress),
       }
     }
   })

--- a/src/schema/section/history-employment.test.js
+++ b/src/schema/section/history-employment.test.js
@@ -41,7 +41,7 @@ describe('Schema for financial taxes', () => {
                 ]
               },
               Telephone: {},
-              PhysicalAddress: {
+              ReferenceAlternateAddress: {
                 HasDifferentAddress: {},
                 Address: {
                   country: null

--- a/src/schema/section/history-residence.js
+++ b/src/schema/section/history-residence.js
@@ -24,6 +24,7 @@ export const historyResidence = (data = {}) => {
         ),
         ReferenceEmail: form.email(xitem.ReferenceEmail),
         ReferenceAddress: form.location(xitem.ReferenceAddress),
+        ReferenceAlternateAddress: form.physicaladdress(xitem.ReferenceAlternateAddress),
         Role: form.radio(xitem.Role),
         RoleOther: form.text(xitem.RoleOther)
       }

--- a/src/schema/section/history-residence.test.js
+++ b/src/schema/section/history-residence.test.js
@@ -1,5 +1,6 @@
 import { unschema } from '../schema'
 import { historyResidence } from './history-residence'
+import alternateAddress from '../form/alternateaddress'
 
 describe('Schema for financial taxes', () => {
   it('can wrap in schema', () => {
@@ -17,13 +18,7 @@ describe('Schema for financial taxes', () => {
               Address: {
                 country: null
               },
-              AlternateAddress: {
-                Address: {
-                  country: null,
-                },
-                HasDifferentAddress: {},
-                Telephone: {},
-              },
+              AlternateAddress: alternateAddress(),
               Comments: {},
               ReferenceName: {},
               ReferenceLastContact: {},
@@ -38,6 +33,7 @@ describe('Schema for financial taxes', () => {
               ReferenceAddress: {
                 country: null
               },
+              ReferenceAlternateAddress: alternateAddress(),
               Role: {},
               RoleOther: {}
             }


### PR DESCRIPTION
Completes #1107, #1108

* Should make it easier to reuse this functionality in the code
* Adds `AlternateAddress` to employment and the reference address section of the `History` subsection