### PR TITLE
Make prior investigation text field optional

### DIFF
--- a/src/components/Section/Legal/Investigations/HistoryItem.jsx
+++ b/src/components/Section/Legal/Investigations/HistoryItem.jsx
@@ -187,6 +187,7 @@ export default class HistoryItem extends ValidationElement {
         <Field
           title={i18n.t('legal.investigations.history.heading.issued')}
           adjustFor="text"
+          optional={true}
           scrollIntoView={this.props.scrollIntoView}>
           <Text
             name="Issued"
@@ -194,7 +195,6 @@ export default class HistoryItem extends ValidationElement {
             onUpdate={this.updateIssued}
             onError={this.props.onError}
             className="legal-investigations-history-issued"
-            required={this.props.required}
           />
         </Field>
 


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/1098

Based on the validation matrix and pdf form, the question `Provide the name of agency that issued the clearance eligibility/access if different from the investigating agency` should not be required - this makes it optional.