### PR TITLE
Remove prop enumeration

### DIFF
--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -45,22 +45,7 @@ export default class EmploymentItem extends ValidationElement {
 
   update(queue) {
     this.props.onUpdate({
-      EmploymentActivity: this.props.EmploymentActivity,
-      Employment: this.props.Employment,
-      Dates: this.props.Dates,
-      Title: this.props.Title,
-      DutyStation: this.props.DutyStation,
-      Status: this.props.Status,
-      Address: this.props.Address,
-      Telephone: this.props.Telephone,
-      Supervisor: this.props.Supervisor,
-      ReferenceName: this.props.ReferenceName,
-      ReferencePhone: this.props.ReferencePhone,
-      ReferenceAddress: this.props.ReferenceAddress,
-      PhysicalAddress: this.props.PhysicalAddress,
-      Additional: this.props.Additional,
-      ReasonLeft: this.props.ReasonLeft,
-      Reprimand: this.props.Reprimand,
+      ...this.props,
       ...queue
     })
   }


### PR DESCRIPTION
Fixes #1117

* Since the data is formatted and filtered before submission to the
server, there isnt a need to enumerate the props we want to update

* This also means we don't have to remember to add props to the
enumerated object

It's possible (perhaps likely) that this bug will show up again in some of the other places we are adding the alternate address flow, I'll be going back through and auditing them
