### PR TITLE
Properly style APO address type radio button

### DIFF
--- a/src/components/Form/Location/Address.jsx
+++ b/src/components/Form/Location/Address.jsx
@@ -12,7 +12,10 @@ import ApoFpo from '../ApoFpo'
 import Show from '../Show'
 import Suggestions from '../Suggestions'
 import { AddressSuggestion } from './AddressSuggestion'
-import LocationValidator, { countryString, isInternational } from '../../../validators/location'
+import LocationValidator, {
+  countryString,
+  isInternational
+} from '../../../validators/location'
 import { countryValueResolver } from './Location'
 
 export default class Address extends ValidationElement {
@@ -46,16 +49,16 @@ export default class Address extends ValidationElement {
     this.storeErrors = this.storeErrors.bind(this)
     this.focusField = this.focusField.bind(this)
     this.blurField = this.blurField.bind(this)
-    this.onAddressUpdate = this.onAddressUpdate.bind(this);
-    this.blurForceUpdate = this.blurForceUpdate.bind(this);
+    this.onAddressUpdate = this.onAddressUpdate.bind(this)
+    this.blurForceUpdate = this.blurForceUpdate.bind(this)
   }
 
   onAddressUpdate(nextValue) {
-    const { name, value } = nextValue;
+    const { name, value } = nextValue
 
     this.update({
       [name]: value
-    });
+    })
   }
 
   updateCountry(values) {
@@ -176,7 +179,7 @@ export default class Address extends ValidationElement {
     this.setState({ showAddressBook: true })
   }
 
-  closeAddressBook(hook = function () {}) {
+  closeAddressBook(hook = function() {}) {
     this.setState({ showAddressBook: false }, hook)
   }
 
@@ -240,8 +243,8 @@ export default class Address extends ValidationElement {
   render() {
     const book = this.props.addressBooks[this.props.addressBook] || []
     const country = countryString(this.props.country)
-    const locationValidator = new LocationValidator(this.props);
-    const instateZipcode = locationValidator.validZipcodeState();
+    const locationValidator = new LocationValidator(this.props)
+    const instateZipcode = locationValidator.validZipcodeState()
 
     return (
       <div className="address">
@@ -264,7 +267,7 @@ export default class Address extends ValidationElement {
               onBlur={this.props.onBlur}
               onFocus={this.props.onFocus}
             />
-            <Show when={this.props.showPostOffice}>
+            {this.props.showPostOffice && (
               <Radio
                 name="addressType"
                 label={i18n.m('address.options.apoFpo.label')}
@@ -276,10 +279,7 @@ export default class Address extends ValidationElement {
                 onBlur={this.props.onBlur}
                 onFocus={this.props.onFocus}
               />
-            </Show>
-            <Show when={!this.props.showPostOffice}>
-              <div className="apofpo postoffice block" />
-            </Show>
+            )}
             <Radio
               name="addressType"
               label={i18n.m('address.options.international.label')}

--- a/src/components/Form/Location/Address.scss
+++ b/src/components/Form/Location/Address.scss
@@ -50,6 +50,7 @@
     &.no-postoffice {
       > .block.domestic > label:last-child,
       > .block.international > label:last-child {
+        height: 10rem;
         width: 26rem;
       }
     }

--- a/src/components/Form/Location/Address.test.jsx
+++ b/src/components/Form/Location/Address.test.jsx
@@ -128,7 +128,7 @@ describe('The Address component', () => {
       showPostOffice: false
     }
     const component = mount(<Address {...props} />)
-    expect(component.find('.address-options .postoffice').length).toBe(1)
+    expect(component.find('.address-options .postoffice').length).toBe(0)
   })
 
   it('simulate blurring', () => {

--- a/src/components/Form/RadioGroup/RadioGroup.jsx
+++ b/src/components/Form/RadioGroup/RadioGroup.jsx
@@ -50,7 +50,7 @@ export default class RadioGroup extends ValidationElement {
     const name = self.props.name ? `${self.state.uid}-${self.props.name}` : null
     const children = React.Children.map(self.props.children, child => {
       // If type is not Radio, stop
-      if (child.type !== Radio) {
+      if (!child || child.type !== Radio) {
         return child
       }
 

--- a/src/views/Form/Form.scss
+++ b/src/views/Form/Form.scss
@@ -158,32 +158,8 @@ select {
 .blocks {
   line-height: 4.6rem;
 
-  > .block:not(.extended):first-child:nth-last-child(3),
-  > .block:not(.extended):first-child:nth-last-child(3) ~ .block,
-  > .block:not(.extended):first-child:nth-last-child(4),
-  > .block:not(.extended):first-child:nth-last-child(4) ~ .block,
-  > .block:not(.extended):first-child:nth-last-child(5),
-  > .block:not(.extended):first-child:nth-last-child(5) ~ .block,
-  > .block:not(.extended):first-child:nth-last-child(6),
-  > .block:not(.extended):first-child:nth-last-child(6) ~ .block,
-  > .block:not(.extended):first-child:nth-last-child(7),
-  > .block:not(.extended):first-child:nth-last-child(7) ~ .block,
-  > .block:not(.extended):first-child:nth-last-child(8),
-  > .block:not(.extended):first-child:nth-last-child(8) ~ .block,
-  > .block:not(.extended):first-child:nth-last-child(9),
-  > .block:not(.extended):first-child:nth-last-child(9) ~ .block,
-  > .block:not(.extended):first-child:nth-last-child(10),
-  > .block:not(.extended):first-child:nth-last-child(10) ~ .block,
-  > .block:not(.extended):first-child:nth-last-child(11),
-  > .block:not(.extended):first-child:nth-last-child(11) ~ .block,
-  > .block:not(.extended):first-child:nth-last-child(12),
-  > .block:not(.extended):first-child:nth-last-child(12) ~ .block,
-  > .block:not(.extended):first-child:nth-last-child(13),
-  > .block:not(.extended):first-child:nth-last-child(13) ~ .block,
-  > .block:not(.extended):first-child:nth-last-child(14),
-  > .block:not(.extended):first-child:nth-last-child(14) ~ .block,
-  > .block:not(.extended):first-child:nth-last-child(15),
-  > .block:not(.extended):first-child:nth-last-child(15) ~ .block {
+  .block:not(.extended):first-child:nth-last-child(n + 3),
+  .block:not(.extended):first-child:nth-last-child(n + 3) ~ .block {
     label {
       height: 10rem;
       width: 18rem;


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/582
Fixes https://github.com/18F/e-QIP-prototype/issues/147 (I think?)

Due to the way the APO option was nested in a `Show` component, the logic to apply the `checked` CSS class, along with some of the proper styles were not getting applied correctly. When looking into this I also noticed some extra markup and unnecessary CSS that I was able to remove.

There are several instances of our CSS (and javascript) that rely on a direct parent/child relationship (sibling selectors, table cells, flexbox, etc). The `Show` component sometimes requires the component it's wrapping to be inside a container `<span>` which throws that relationship off. React 16 introduced `<React.Fragment>` which will avoid this issue when we are able to upgrade.

**After:**
<img width="630" alt="screen shot 2018-11-09 at 10 55 53 am" src="https://user-images.githubusercontent.com/1178494/48273136-426e4c80-e40e-11e8-93fb-154dded3df3f.png">
