### PR TITLE
Add minDate and minDateEqualTo props to relative alias

### DIFF
--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -230,6 +230,7 @@ export default class DateRange extends ValidationElement {
             maxDate={this.props.maxDate}
             maxDateEqualTo={this.props.maxDateEqualTo}
             prefix={this.props.prefix}
+            relationship={this.props.relationship}
             onError={this.handleErrorFrom}
             disabled={this.props.disabled}
             required={this.props.required}
@@ -256,6 +257,7 @@ export default class DateRange extends ValidationElement {
             maxDate={this.props.maxDate}
             maxDateEqualTo={this.props.maxDateEqualTo}
             prefix={this.props.prefix}
+            relationship={this.props.relationship}
             onError={this.handleErrorTo}
             required={
               this.props.required && !this.state.present && !this.props.disabled
@@ -293,6 +295,7 @@ DateRange.defaultProps = {
   minDateEqualTo: false,
   maxDate: new Date(),
   maxDateEqualTo: false,
+  relationship: '',
   allowPresent: true,
   onError: (value, arr) => {
     return arr
@@ -324,7 +327,9 @@ DateRange.errors = [
       ) {
         return null
       }
-      return props.from.date && props.to.date && props.from.date <= props.to.date
+      return (
+        props.from.date && props.to.date && props.from.date <= props.to.date
+      )
     }
   }
 ]

--- a/src/components/Section/Relationships/Relatives/Alias.jsx
+++ b/src/components/Section/Relationships/Relatives/Alias.jsx
@@ -97,7 +97,8 @@ export default class Alias extends ValidationElement {
             {...this.props.Dates}
             prefix="relative"
             minDateEqualTo={true}
-            minDate={this.props.applicantBirthdate.date}
+            minDate={this.props.minDate}
+            relationship={this.props.relationship}
             onUpdate={this.updateDates}
             onError={this.props.onError}
             required={this.props.required}

--- a/src/components/Section/Relationships/Relatives/Alias.jsx
+++ b/src/components/Section/Relationships/Relatives/Alias.jsx
@@ -96,6 +96,8 @@ export default class Alias extends ValidationElement {
             className="alias-dates"
             {...this.props.Dates}
             prefix="relative"
+            minDateEqualTo={true}
+            minDate={this.props.applicantBirthdate.date}
             onUpdate={this.updateDates}
             onError={this.props.onError}
             required={this.props.required}

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -24,6 +24,7 @@ import { RelativeValidator } from '../../../../validators'
 import { countryString } from '../../../../validators/location'
 import { today, daysAgo } from '../../History/dateranges'
 import Alias from './Alias'
+import { extractDate } from '../../History/dateranges'
 
 export default class Relative extends ValidationElement {
   constructor(props) {
@@ -642,7 +643,8 @@ export default class Relative extends ValidationElement {
               </Field>
               <Alias
                 name="Item"
-                applicantBirthdate={this.props.Birthdate}
+                minDate={extractDate(this.props.Birthdate)}
+                relationship="Other"
                 onError={this.props.onError}
                 hideMaiden={mother}
                 required={this.props.required}


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/962

Even with the `minDate` prop set and returning the proper date it is still validating against applicant DOB and not relative DOB. 

The relative DOB is 5/5/1959 and the from date for other names used is 5/5/1960



![screen shot 2018-11-13 at 11 15 42 am](https://user-images.githubusercontent.com/1449852/48427699-55975a00-e737-11e8-836f-5f32965d066c.png)
