### PR TITLE
Removing codecov until needing to add back in

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,6 @@ jobs:
       - run:
           name: Run Go tests
           command: make test-go
-      - run:
-          name: Code coverage
-          command: make coverage
 
   cloudgov:
     machine: true


### PR DESCRIPTION
Codecov is currently blocking PRs so we are going to remove the coverage until we can bring it up.
Fixes https://github.com/18F/e-QIP-prototype/issues/1009

At the time of this PR Coverage is 
API - 7.89%
SRC - 90.19%

![screen shot 2018-11-13 at 2 59 19 pm](https://user-images.githubusercontent.com/1449852/48439622-ba14e200-e754-11e8-8acc-6eb453e8e45b.png)