### PR TITLE
[DON'T MERGE] Add codecov back in when ready 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
       - run:
           name: Run Go tests
           command: make test-go
+      - run:	
+          name: Code coverage	
+          command: make coverage
 
   cloudgov:
     machine: true


### PR DESCRIPTION
Add coverage back in once the team decides to start using again after API coverage is at a comfortable level.

This is a placeholder PR so this step is not forgotten about. 🚀 