### PR TITLE
[WIP] Allows "Outside the United States" to be selected without a typed country

### DIFF
--- a/api/location.go
+++ b/api/location.go
@@ -44,7 +44,7 @@ type Location struct {
 	State           string `json:"state,omitempty"`
 	Zipcode         string `json:"zipcode,omitempty"`
 	County          string `json:"county,omitempty"`
-	Country         string `json:"country,omitempty"`
+	Country         string `json:"country"`
 	CountryComments string `json:"countryComments,omitempty"`
 	Validated       bool   `json:"validated,omitempty"`
 }

--- a/src/components/Form/Location/Address.jsx
+++ b/src/components/Form/Location/Address.jsx
@@ -40,7 +40,7 @@ export default class Address extends ValidationElement {
     this.update = this.update.bind(this)
     this.updateCountry = this.updateCountry.bind(this)
     this.updateAddressType = this.updateAddressType.bind(this)
-    this.addressTypeFunc = this.addressTypeFunc.bind(this)
+    this.addressType = this.addressType.bind(this)
     this.openAddressBook = this.openAddressBook.bind(this)
     this.closeAddressBook = this.closeAddressBook.bind(this)
     this.renderAddressBookItem = this.renderAddressBookItem.bind(this)
@@ -162,17 +162,14 @@ export default class Address extends ValidationElement {
     this.update({}, 0, true)
   }
 
-  addressTypeFunc(props) {
+  addressType() {
     const country = countryString(this.props.country)
-    switch (true) {
-      case props.value === country:
-        return true
-      case props.value === 'International' &&
-        !['United States', 'POSTOFFICE'].includes(country):
-        return true
-      default:
-        return false
+
+    if (['United States', 'POSTOFFICE'].includes(country)) {
+      return country
     }
+
+    return "International"
   }
 
   openAddressBook() {
@@ -255,13 +252,14 @@ export default class Address extends ValidationElement {
               this.props.showPostOffice ? '' : 'no-postoffice'
             }`.trim()}
             disabled={this.props.disabled}
-            selectedValueFunc={this.addressTypeFunc}>
+            selectedValue={this.addressType()}
+          >
             <Radio
               name="addressType"
               label={i18n.m('address.options.us.label')}
               value="United States"
               className="domestic"
-              ignoreDeselect="true"
+              ignoreDeselect
               disabled={this.props.disabled}
               onUpdate={this.updateAddressType}
               onBlur={this.props.onBlur}
@@ -273,7 +271,7 @@ export default class Address extends ValidationElement {
                 label={i18n.m('address.options.apoFpo.label')}
                 value="POSTOFFICE"
                 className="apofpo postoffice"
-                ignoreDeselect="true"
+                ignoreDeselect
                 disabled={this.props.disabled}
                 onUpdate={this.updateAddressType}
                 onBlur={this.props.onBlur}
@@ -285,7 +283,7 @@ export default class Address extends ValidationElement {
               label={i18n.m('address.options.international.label')}
               value="International"
               className="international"
-              ignoreDeselect="true"
+              ignoreDeselect
               disabled={this.props.disabled}
               onUpdate={this.updateAddressType}
               onBlur={this.props.onBlur}

--- a/src/components/Form/Location/Address.test.jsx
+++ b/src/components/Form/Location/Address.test.jsx
@@ -62,18 +62,17 @@ describe('The Address component', () => {
   })
 
   it('Performs address type update', () => {
-    let updates = 0
     const props = {
       showPostOffice: true,
-      onUpdate: () => {
-        updates++
-      }
+      onUpdate: jest.fn()
     }
     const component = mount(<Address {...props} />)
-    component.find('.address-options .domestic input').simulate('change')
+
+    // Not testing .domestic because it is intially selected, so there is no change
+    // when clicked
     component.find('.address-options .postoffice input').simulate('change')
     component.find('.address-options .international input').simulate('change')
-    expect(updates).toBe(3)
+    expect(props.onUpdate).toHaveBeenCalledTimes(2)
   })
 
   it('Validates required', () => {

--- a/src/components/Form/Radio/Radio.jsx
+++ b/src/components/Form/Radio/Radio.jsx
@@ -60,17 +60,25 @@ export default class Radio extends ValidationElement {
    * Update the value of the radio button
    */
   update(clicked = false) {
+    const { name, value, ignoreDeselect } = this.props;
+    const { checked } = this.state;
+
     if (this.skip(clicked)) {
       return
     }
+    if (ignoreDeselect && checked) {
+      return
+    }
 
-    const checked = !this.state.checked
-    const value = checked ? this.props.value : ''
-    this.setState({ checked: checked, value: value }, () => {
+    const updatedValue = !checked ? value : ''
+    this.setState((prevState) => ({
+      checked: !prevState.checked,
+      value: updatedValue
+    }), () => {
       this.props.onUpdate({
-        name: this.props.name,
-        value: value,
-        checked: checked
+        name,
+        value: updatedValue,
+        checked
       })
 
       // Toggling the focus of the element serves two purposes

--- a/src/components/Form/RadioGroup/RadioGroup.jsx
+++ b/src/components/Form/RadioGroup/RadioGroup.jsx
@@ -46,21 +46,17 @@ export default class RadioGroup extends ValidationElement {
   }
 
   render() {
-    const self = this
-    const name = self.props.name ? `${self.state.uid}-${self.props.name}` : null
-    const children = React.Children.map(self.props.children, child => {
+    const { selectedValue } = this.props;
+    const name = this.props.name ? `${this.state.uid}-${this.props.name}` : null
+    const children = React.Children.map(this.props.children, child => {
       // If type is not Radio, stop
       if (!child || child.type !== Radio) {
         return child
       }
 
       // Check if current value matches one of the child radio options
-      let checked = child.props.value === self.props.selectedValue
+      let checked = child.props.value === selectedValue
 
-      // Use function when you want custom behavior
-      if (this.props.selectedValueFunc) {
-        checked = self.props.selectedValueFunc(child.props)
-      }
       const onUpdate = option => {
         if (child.props.onUpdate) {
           child.props.onUpdate(option)
@@ -72,7 +68,7 @@ export default class RadioGroup extends ValidationElement {
         <child.type
           {...child.props}
           name={name || child.props.name}
-          disabled={self.props.disabled}
+          disabled={this.props.disabled}
           checked={checked}
           onUpdate={onUpdate}
         />
@@ -80,10 +76,10 @@ export default class RadioGroup extends ValidationElement {
     })
 
     const errorClass =
-      self.state.error === true && self.props.disabled === false
+    this.state.error === true && this.props.disabled === false
         ? 'usa-input-error'
         : ''
-    const classes = ['blocks', self.props.className, errorClass]
+    const classes = ['blocks', this.props.className, errorClass]
       .join(' ')
       .trim()
     return <div className={classes}>{children}</div>

--- a/src/components/Form/RadioGroup/RadioGroup.test.jsx
+++ b/src/components/Form/RadioGroup/RadioGroup.test.jsx
@@ -30,13 +30,10 @@ describe('The RadioGroup component', () => {
     ).toBe(true)
   })
 
-  it('renders radio button children with selected func', () => {
-    let selectedValueFunc = props => {
-      return props.value === 'Option1'
-    }
+  it('renders radio button children with selectedValue', () => {
 
     const component = mount(
-      <RadioGroup name={'rgroup'} selectedValueFunc={selectedValueFunc}>
+      <RadioGroup name={'rgroup'} selectedValue="Option2">
         <Radio value="Option1" />
         <Radio value="Option2" />
       </RadioGroup>
@@ -45,7 +42,7 @@ describe('The RadioGroup component', () => {
     expect(
       component
         .find('input[type="radio"]')
-        .first()
+        .last()
         .props().checked
     ).toBe(true)
   })


### PR DESCRIPTION
Fixes #1097 and #1140 

The first thing this PR fixes is that it allows applicants to indicate that their address is outside of the United States WITHOUT typing a country in. When a user saves their progress without a country typed in, the progress will still be saved.

The second thing this PR fixes is that it eliminates the erratic behavior of the radio buttons. There was an `ignoreDeselect` prop being passed, but no actual usage of it, so I added something minimal to make sure there are no events occurring when clicking on a selected radio button.