### PR TITLE
Align form headings with exact text in SF-86

### DIFF
--- a/src/components/Form/Location/AlternateAddress.jsx
+++ b/src/components/Form/Location/AlternateAddress.jsx
@@ -123,7 +123,7 @@ class AlternateAddress extends ValidationElement {
           * had an APO/FPO (military) address in the foreign country
         */}
         <Show when={this.isForeignMilitaryAddress()}>
-          <Field title={i18n.t('address.physicalLocationRequired')}>
+          <Field title={i18n.t('address.apoFpoRequired')}>
             <Location
               {...this.prepareProps({
                 country: 'POSTOFFICE',
@@ -140,6 +140,8 @@ class AlternateAddress extends ValidationElement {
                 addressBook: this.props.addressBook,
                 addressBooks: this.props.addressBooks,
                 geocode: true,
+                streetLabel: i18n.t('address.physical.street.label'),
+                cityLabel: i18n.t('address.physical.city.label'),
                 layout: this.props.layout
               })}
             />
@@ -165,7 +167,7 @@ AlternateAddress.defaultProps = {
   },
   forceAPO: false,
   layout: Location.ADDRESS,
-  militaryAddressLabel: i18n.t('address.militaryAddress.me'),
+  militaryAddressLabel: i18n.t('address.militaryAddress.meEmployment'),
 }
 
 const mapStateToProps = ({ application }, ownProps) => {

--- a/src/components/Form/Location/AlternateAddress.jsx
+++ b/src/components/Form/Location/AlternateAddress.jsx
@@ -116,7 +116,7 @@ class AlternateAddress extends ValidationElement {
             value={this.props.address.HasDifferentAddress.value}
           />
         </Show>
-        {/* 
+        {/*
           * This next block is a bit confusing. It renders when the user has indicated
           * that the associated address is in a foreign country AND has selected 'Yes'
           * in the preceeding <Branch/> component, indicating that they (or someone they knew)
@@ -157,7 +157,6 @@ AlternateAddress.defaultProps = {
   addressBook: 'Residence',
   addressFieldMetadata: {
     streetLabel: i18n.t('address.us.street.label'),
-    streetPlaceholder: i18n.t('address.us.street.placeholder'),
     street2Label: i18n.t('address.us.street2.label'),
     stateLabel: i18n.t('address.us.state.label'),
     cityLabel: i18n.t('address.us.city.label'),

--- a/src/components/Form/Location/AlternateAddress.test.jsx
+++ b/src/components/Form/Location/AlternateAddress.test.jsx
@@ -20,7 +20,7 @@ describe('<AlternateAddress />', () => {
       const branch = component.find('Branch')
   
       expect(branch.length).toEqual(1)
-      expect(branch.prop('label')).toEqual(address.militaryAddress.me)
+      expect(branch.prop('label')).toEqual(address.militaryAddress.meEmployment)
     })
 
     it('renders an APO/FPO-only component when Branch value is yes', () => {

--- a/src/components/Section/Foreign/Contacts/ForeignNational.jsx
+++ b/src/components/Section/Foreign/Contacts/ForeignNational.jsx
@@ -687,7 +687,7 @@ export default class ForeignNational extends ValidationElement {
           belongingTo: 'AlternateAddress',
           country: this.props.Address.country,
           forceAPO: true,
-          militaryAddressLabel: i18n.t('address.militaryAddress.other'),
+          militaryAddressLabel: i18n.t('address.militaryAddress.foreignNational'),
           onUpdate: this.update
         })}
 

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -442,6 +442,7 @@ export default class EmploymentItem extends ValidationElement {
             address: this.props.SupervisorAlternateAddress,
             belongingTo: 'SupervisorAlternateAddress',
             country: this.props.Supervisor.Address.country,
+            militaryAddressLabel: i18n.t('address.militaryAddress.supervisor'),
             onUpdate: this.update
           })}
         </Show>
@@ -516,6 +517,7 @@ export default class EmploymentItem extends ValidationElement {
               address: this.props.ReferenceAlternateAddress,
               belongingTo: 'ReferenceAlternateAddress',
               country: this.props.ReferenceAddress.country,
+              militaryAddressLabel: i18n.t(`${prefix}.heading.militaryAddress`),
               onUpdate: this.update
             })}
           </div>

--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -263,6 +263,7 @@ export default class ResidenceItem extends ValidationElement {
           belongingTo: 'AlternateAddress',
           address: this.props.AlternateAddress,
           country: this.props.Address.country,
+          militaryAddressLabel: i18n.t('address.militaryAddress.meResidence'),
           onUpdate: this.update
         })}
 
@@ -588,6 +589,7 @@ export default class ResidenceItem extends ValidationElement {
                 belongingTo: 'ReferenceAlternateAddress',
                 address: this.props.ReferenceAlternateAddress,
                 country: this.props.ReferenceAddress.country,
+                militaryAddressLabel: i18n.t('address.militaryAddress.residenceVerifier'),
                 onUpdate: this.update
               })}
 

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -438,6 +438,7 @@ class CivilUnion extends ValidationElement {
                 addressBook="Residence"
                 belongingTo="AlternateAddress"
                 country={this.props.Address.country}
+                militaryAddressLabel={i18n.t('address.militaryAddress.spouse')}
                 onUpdate={this.update}
               />
             </Show>

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -687,7 +687,7 @@ export default class Relative extends ValidationElement {
             belongingTo: 'AlternateAddress',
             country: this.props.Address.country,
             forceAPO: true,
-            militaryAddressLabel: i18n.t('address.militaryAddress.other'),
+            militaryAddressLabel: i18n.t('address.militaryAddress.relative'),
             onUpdate: this.update
           })}
         </Show>

--- a/src/config/locales/en/address.js
+++ b/src/config/locales/en/address.js
@@ -1,11 +1,16 @@
 export const address = {
   label: 'This address is',
   spinner: 'Verifying your address',
-  physicalLocationRequired: 'Please provide a physical address for this location',
+  physicalLocationRequired: 'Provide physical location data with street address, base, post, embassy, unit, and country location or home port/fleet headquarter.',
+  apoFpoRequired: 'Provide APO/FPO address.',
   militaryAddress: {
-    me: 'Do you or did you have an APO/FPO address at this location',
-    other: 'Does this person have an APO/FPO address',
-    foreignNational: 'Does this person have an APO/FPO address? Provide the foreign national\'s APO/FPO address'
+    meResidence: 'Did you have an APO/FPO address while at this location?',
+    meEmployment: 'Do you or did you have an APO/FPO address while at this location?',
+    spouse: 'Does the person have an APO/FPO address within the United States?',
+    relative: 'Does this relative have an APO/FPO address?',
+    foreignNational: 'Does this person have an APO/FPO address? Provide the foreign national\'s APO/FPO address.',
+    supervisor: 'Did/does your supervisor have an APO/FPO address while at this location?',
+    residenceVerifier: 'Does the person who knew you have an APO/FPO address?',
   },
   options: {
     us: {
@@ -37,6 +42,14 @@ export const address = {
     },
     zipcode: {
       label: 'ZIP Code'
+    }
+  },
+  physical: {
+    street: {
+      label: 'Street address/Unit/Duty Location'
+    },
+    city: {
+      label: 'City or Post Name'
     }
   },
   international: {

--- a/src/config/locales/en/address.js
+++ b/src/config/locales/en/address.js
@@ -6,9 +6,9 @@ export const address = {
   militaryAddress: {
     meResidence: 'Did you have an APO/FPO address while at this location?',
     meEmployment: 'Do you or did you have an APO/FPO address while at this location?',
-    spouse: 'Does the person have an APO/FPO address within the United States?',
+    spouse: 'Does the person have an APO/FPO address?',
     relative: 'Does this relative have an APO/FPO address?',
-    foreignNational: 'Does this person have an APO/FPO address? Provide the foreign national\'s APO/FPO address.',
+    foreignNational: 'Does this person have an APO/FPO address?',
     supervisor: 'Did/does your supervisor have an APO/FPO address while at this location?',
     residenceVerifier: 'Does the person who knew you have an APO/FPO address?',
   },

--- a/src/config/locales/en/address.js
+++ b/src/config/locales/en/address.js
@@ -46,7 +46,7 @@ export const address = {
   },
   physical: {
     street: {
-      label: 'Street address/Unit/Duty Location'
+      label: 'Street Address/Unit/Duty Location'
     },
     city: {
       label: 'City or Post Name'

--- a/src/config/locales/en/history.js
+++ b/src/config/locales/en/history.js
@@ -1355,6 +1355,7 @@ export const history = {
           'Provide the name of someone that can verify your self-employment',
         physicalAddress:
           'Is your physical work address different than your employment address?',
+        militaryAddress: 'Does your self-employment verifier have an APO/FPO address?',
         additionalActivity: 'Additional periods of activity with this employer'
       },
       employer: {
@@ -1458,6 +1459,7 @@ export const history = {
     },
     unemployment: {
       heading: {
+        militaryAddress: 'Does your unemployment verifier have an APO/FPO address?',
         reference:
           'Provide the name of someone who can verify your unemployment activities and means of support'
       }


### PR DESCRIPTION
Closes #1116. Sole exception is address.apoFpoRequired, which does not have an exact correspondence in the SF-86.