### PR TITLE
Add AlternateAddress to database for Civil Unions

### DIFF
--- a/api/civilunion.go
+++ b/api/civilunion.go
@@ -7,6 +7,7 @@ type CivilUnion struct {
 	PayloadAddress                       Payload `json:"Address" sql:"-"`
 	PayloadAddressSeparated              Payload `json:"AddressSeparated" sql:"-"`
 	PayloadAddressSeparatedNotApplicable Payload `json:"AddressSeparatedNotApplicable" sql:"-"`
+	PayloadAlternateAddress              Payload `json:"AlternateAddress" sql:"-"`
 	PayloadBirthPlace                    Payload `json:"BirthPlace" sql:"-"`
 	PayloadBirthdate                     Payload `json:"Birthdate" sql:"-"`
 	PayloadCitizenship                   Payload `json:"Citizenship" sql:"-"`
@@ -27,6 +28,7 @@ type CivilUnion struct {
 	Address                       *Location            `json:"-"`
 	AddressSeparated              *Location            `json:"-"`
 	AddressSeparatedNotApplicable *NotApplicable       `json:"-"`
+	AlternateAddress              *PhysicalAddress     `json:"-"`
 	BirthPlace                    *Location            `json:"-"`
 	Birthdate                     *DateControl         `json:"-"`
 	Citizenship                   *Country             `json:"-"`
@@ -49,6 +51,7 @@ type CivilUnion struct {
 	AddressID                       int `json:"-"`
 	AddressSeparatedID              int `json:"-"`
 	AddressSeparatedNotApplicableID int `json:"-"`
+	AlternateAddressID              int `json:"-"`
 	BirthPlaceID                    int `json:"-"`
 	BirthdateID                     int `json:"-"`
 	CitizenshipID                   int `json:"-"`
@@ -90,6 +93,12 @@ func (entity *CivilUnion) Unmarshal(raw []byte) error {
 		return err
 	}
 	entity.AddressSeparatedNotApplicable = addressSeparatedNotApplicable.(*NotApplicable)
+
+	alternateAddress, err := entity.PayloadAlternateAddress.Entity()
+	if err != nil {
+		return err
+	}
+	entity.AlternateAddress = alternateAddress.(*PhysicalAddress)
 
 	birthPlace, err := entity.PayloadBirthPlace.Entity()
 	if err != nil {
@@ -194,6 +203,9 @@ func (entity *CivilUnion) Marshal() Payload {
 	}
 	if entity.AddressSeparatedNotApplicable != nil {
 		entity.PayloadAddressSeparatedNotApplicable = entity.AddressSeparatedNotApplicable.Marshal()
+	}
+	if entity.AlternateAddress != nil {
+		entity.PayloadAlternateAddress = entity.AlternateAddress.Marshal()
 	}
 	if entity.BirthPlace != nil {
 		entity.PayloadBirthPlace = entity.BirthPlace.Marshal()
@@ -368,6 +380,12 @@ func (entity *CivilUnion) Save(context DatabaseService, account int) (int, error
 	}
 	entity.AddressSeparatedNotApplicableID = addressSeparatedNotApplicableID
 
+	alternateAddressID, err := entity.AlternateAddress.Save(context, account)
+	if err != nil {
+		return alternateAddressID, err
+	}
+	entity.AlternateAddressID = alternateAddressID
+
 	birthPlaceID, err := entity.BirthPlace.Save(context, account)
 	if err != nil {
 		return birthPlaceID, err
@@ -492,6 +510,9 @@ func (entity *CivilUnion) Delete(context DatabaseService, account int) (int, err
 	if _, err := entity.AddressSeparatedNotApplicable.Delete(context, account); err != nil {
 		return entity.ID, err
 	}
+	if _, err := entity.AlternateAddress.Delete(context, account); err != nil {
+		return entity.ID, err
+	}
 	if _, err := entity.BirthPlace.Delete(context, account); err != nil {
 		return entity.ID, err
 	}
@@ -571,6 +592,11 @@ func (entity *CivilUnion) Get(context DatabaseService, account int) (int, error)
 	}
 	if entity.AddressSeparatedNotApplicableID != 0 {
 		if _, err := entity.AddressSeparatedNotApplicable.Get(context, account); err != nil {
+			return entity.ID, err
+		}
+	}
+	if entity.AlternateAddressID != 0 {
+		if _, err := entity.AlternateAddress.Get(context, account); err != nil {
 			return entity.ID, err
 		}
 	}
@@ -672,16 +698,25 @@ func (entity *CivilUnion) Find(context DatabaseService) error {
 		}
 		entity.Address.ID = previous.AddressID
 		entity.AddressID = previous.AddressID
+
 		if entity.AddressSeparated == nil {
 			entity.AddressSeparated = &Location{}
 		}
 		entity.AddressSeparated.ID = previous.AddressSeparatedID
 		entity.AddressSeparatedID = previous.AddressSeparatedID
+
 		if entity.AddressSeparatedNotApplicable == nil {
 			entity.AddressSeparatedNotApplicable = &NotApplicable{}
 		}
 		entity.AddressSeparatedNotApplicable.ID = previous.AddressSeparatedNotApplicableID
 		entity.AddressSeparatedNotApplicableID = previous.AddressSeparatedNotApplicableID
+
+		if entity.AlternateAddress == nil {
+			entity.AlternateAddress = &PhysicalAddress{}
+		}
+		entity.AlternateAddress.ID = previous.AlternateAddressID
+		entity.AlternateAddressID = previous.AlternateAddressID
+
 		if entity.BirthPlace == nil {
 			entity.BirthPlace = &Location{}
 		}

--- a/api/migrations/20181116081814_add_alternate_address_id_to_civilunion.sql
+++ b/api/migrations/20181116081814_add_alternate_address_id_to_civilunion.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+-- +goose StatementBegin
+ALTER TABLE civil_unions ADD COLUMN alternate_address_id bigint REFERENCES physical_addresses(id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+-- +goose StatementBegin
+ALTER TABLE civil_unions DROP COLUMN IF EXISTS alternate_address_id;
+-- +goose StatementEnd

--- a/api/testdata/civilunion.json
+++ b/api/testdata/civilunion.json
@@ -189,6 +189,42 @@
         "validated": false
       }
     },
+    "AlternateAddress": {
+      "type": "physicaladdress",
+      "props": {
+        "HasDifferentAddress": {
+          "type": "branch",
+          "props": {
+            "value": "Yes"
+          }
+        },
+        "Address": {
+          "type": "location",
+          "props": {
+            "layout": "Address",
+            "street": "123 Some Rd",
+            "street2": "",
+            "city": "Arlington",
+            "state": "VA",
+            "zipcode": "22202",
+            "county": "",
+            "country": "United States",
+            "validated": false
+          }
+        },
+        "Telephone": {
+          "type": "telephone",
+          "props": {
+            "timeOfDay": "Both",
+            "type": "Domestic",
+            "numberType": "",
+            "number": "2128675309",
+            "extension": "",
+            "noNumber": false
+          }
+        }
+      }
+    },
     "Telephone": {
       "type": "telephone",
       "props": {

--- a/api/testdata/relationships-status-marital.json
+++ b/api/testdata/relationships-status-marital.json
@@ -221,6 +221,42 @@
             "validated": false
           }
         },
+        "AlternateAddress": {
+          "type": "physicaladdress",
+          "props": {
+            "HasDifferentAddress": {
+              "type": "branch",
+              "props": {
+                "value": "Yes"
+              }
+            },
+            "Address": {
+              "type": "location",
+              "props": {
+                "layout": "Address",
+                "street": "123 Some Rd",
+                "street2": "",
+                "city": "Arlington",
+                "state": "VA",
+                "zipcode": "22202",
+                "county": "",
+                "country": "United States",
+                "validated": false
+              }
+            },
+            "Telephone": {
+              "type": "telephone",
+              "props": {
+                "timeOfDay": "Both",
+                "type": "Domestic",
+                "numberType": "",
+                "number": "2128675309",
+                "extension": "",
+                "noNumber": false
+              }
+            }
+          }
+        },
         "Telephone": {
           "type": "telephone",
           "props": {

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -204,8 +204,7 @@ class CivilUnion extends ValidationElement {
      */
 
     const { country } = this.props.BirthPlace
-    const showForeignBornDocumentation =
-      country && countryString(country) !== 'United States'
+    const showForeignBornDocumentation = country && countryString(country) !== 'United States'
 
     return (
       <div className="civil-union">

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -432,15 +432,13 @@ class CivilUnion extends ValidationElement {
                 required={this.props.required}
               />
             </NotApplicable>
-            <Show when={this.props.UseCurrentAddress.applicable}> 
-              <AlternateAddress
-                address={this.props.AlternateAddress}
-                addressBook="Residence"
-                belongingTo="AlternateAddress"
-                country={this.props.Address.country}
-                onUpdate={this.update}
-              />
-            </Show>
+            <AlternateAddress
+              address={this.props.AlternateAddress}
+              addressBook="Relative"
+              belongingTo="AlternateAddress"
+              country={this.props.Address.country}
+              onUpdate={this.update}
+            />
           </Field>
 
           <Field

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -165,8 +165,10 @@ class CivilUnion extends ValidationElement {
   }
 
   updateUseCurrentAddress(values) {
+    const nextValues = { ...values, applicable: !values.applicable }
+
     this.update({
-      UseCurrentAddress: values,
+      UseCurrentAddress: nextValues,
       Address: !values.applicable ? { ...this.props.currentAddress } : {}
     })
   }
@@ -408,7 +410,7 @@ class CivilUnion extends ValidationElement {
           >
             <NotApplicable
               name="UseCurrentAddress"
-              {...this.props.UseCurrentAddress}
+              applicable={!this.props.UseCurrentAddress.applicable}
               className="current-address"
               label={i18n.t(
                 'relationships.civilUnion.useCurrentAddress.label'
@@ -431,13 +433,15 @@ class CivilUnion extends ValidationElement {
                 required={this.props.required}
               />
             </NotApplicable>
-            <AlternateAddress
-              address={this.props.AlternateAddress}
-              addressBook="Relative"
-              belongingTo="AlternateAddress"
-              country={this.props.Address.country}
-              onUpdate={this.update}
-            />
+            <Show when={!this.props.UseCurrentAddress.applicable}>
+              <AlternateAddress
+                address={this.props.AlternateAddress}
+                addressBook="Relative"
+                belongingTo="AlternateAddress"
+                country={this.props.Address.country}
+                onUpdate={this.update}
+              />
+            </Show>
           </Field>
 
           <Field

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.test.jsx
@@ -89,7 +89,7 @@ describe('<CivilUnion />', () => {
       }
     }
 
-    const component = mount(<CivilUnion {...expected} />)
+    const component = mountComponent(configureMockStore(), CivilUnion, expected)
     expect(component.find('.current-address.button').length).toEqual(1)
     component.find('.current-address.button input').simulate('change')
     component.find('.current-address.button input').simulate('change')
@@ -100,7 +100,7 @@ describe('<CivilUnion />', () => {
 
   describe('with foreign-born spouse', () => {
     const foreignBornDocumentEl = '.foreign-born-documents'
-    const component = mount(<CivilUnion />)
+    const component = mountComponent(configureMockStore(), CivilUnion, {})
 
     it('does not ask for foreign-born documentation in default state', () => {
       const emptyExpected = {
@@ -130,18 +130,14 @@ describe('<CivilUnion />', () => {
     })
   
     it('asks for foreign born documentation if not from the United States', () => {
-      const stringExpected = {
-        BirthPlace: { country: 'Canada' }
-      }
       const objectExpected = {
         BirthPlace: { country: { value: ['Canada'] } }
       }
+      const civilUnion = mountComponent(configureMockStore(), CivilUnion, objectExpected)
 
-      component.setProps(stringExpected)
-      expect(component.find(foreignBornDocumentEl).length).toEqual(1)
-
-      component.setProps(objectExpected)
-      expect(component.find(foreignBornDocumentEl).length).toEqual(1)
+      civilUnion.setProps(objectExpected)
+      console.log(civilUnion.debug())
+      expect(civilUnion.find(foreignBornDocumentEl).length).toEqual(1)
     })
   })
 

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.test.jsx
@@ -136,7 +136,6 @@ describe('<CivilUnion />', () => {
       const civilUnion = mountComponent(configureMockStore(), CivilUnion, objectExpected)
 
       civilUnion.setProps(objectExpected)
-      console.log(civilUnion.debug())
       expect(civilUnion.find(foreignBornDocumentEl).length).toEqual(1)
     })
   })
@@ -170,7 +169,7 @@ describe('<CivilUnion />', () => {
       }
       const component = mountComponent(mockStore, CivilUnion, props)
 
-      expect(component.find('AlternateAddress').length).toBe(1)
+      expect(component.find('AlternateAddress').length).toBe(0)
     })
   })
 })

--- a/src/components/Section/Relationships/RelationshipStatus/Marital.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Marital.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import Marital from './Marital'
+import configureMockStore from 'redux-mock-store'
+import { Provider } from 'react-redux'
 
 describe('The relationship status component', () => {
   it('no error on empty', () => {
@@ -22,7 +24,11 @@ describe('The relationship status component', () => {
       }
     }
 
-    const component = mount(<Marital {...expected} />)
+    const component = mount(
+      <Provider store={configureMockStore()({ application: {addressBooks: {}}})}>
+        <Marital {...expected} />
+      </Provider>
+    )
     expect(component.find('.marital').length).toEqual(1)
     component.find('.status-options input[value="Married"]').simulate('change')
     component.find('.civil-union .civil .first input').simulate('change')


### PR DESCRIPTION
Fixes #1157 

Adds an AlternateAddressID to the civil union table. 