### PR TITLE
Show reason for leaving, not just within 7 years

### DIFF
--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -541,7 +541,7 @@ export default class EmploymentItem extends ValidationElement {
           />
         </Show>
 
-        <Show when={this.showEmployed() && this.showLeaving()}>
+        <Show when={this.showEmployed()}>
           <ReasonLeft
             name="ReasonLeft"
             {...this.props.ReasonLeft}


### PR DESCRIPTION
ReasonLeft was recently fixed to appropriately show/hide fields in https://github.com/18F/e-QIP-prototype/pull/1100. However, there was redundant and incorrect logic at the EmploymentItem level that this removes.