### PR TITLE
Add "blank" AlternateAddress to CivilUnion section

### DIFF
--- a/api/testdata/complete-scenarios/test1.json
+++ b/api/testdata/complete-scenarios/test1.json
@@ -2473,6 +2473,35 @@
                 "applicable": false
               }
             },
+            "AlternateAddress": {
+              "type": "physicaladdress",
+              "props": {
+                "HasDifferentAddress": {
+                  "type": "branch",
+                  "props": {
+                    "value": ""
+                  }
+                },
+                "Address": {
+                  "type": "location",
+                  "props": {
+                    "layout": "",
+                    "country": ""
+                  }
+                },
+                "Telephone": {
+                  "type": "telephone",
+                  "props": {
+                    "timeOfDay": "",
+                    "type": "",
+                    "numberType": "",
+                    "number": "",
+                    "extension": "",
+                    "noNumber": false
+                  }
+                }
+              }
+            },
             "BirthPlace": {
               "type": "location",
               "props": {

--- a/api/testdata/complete-scenarios/test2.json
+++ b/api/testdata/complete-scenarios/test2.json
@@ -4603,6 +4603,35 @@
                 "applicable": false
               }
             },
+            "AlternateAddress": {
+              "type": "physicaladdress",
+              "props": {
+                "HasDifferentAddress": {
+                  "type": "branch",
+                  "props": {
+                    "value": ""
+                  }
+                },
+                "Address": {
+                  "type": "location",
+                  "props": {
+                    "layout": "",
+                    "country": ""
+                  }
+                },
+                "Telephone": {
+                  "type": "telephone",
+                  "props": {
+                    "timeOfDay": "",
+                    "type": "",
+                    "numberType": "",
+                    "number": "",
+                    "extension": "",
+                    "noNumber": false
+                  }
+                }
+              }
+            },
             "BirthPlace": {
               "type": "location",
               "props": {

--- a/api/testdata/complete-scenarios/test3.json
+++ b/api/testdata/complete-scenarios/test3.json
@@ -7180,6 +7180,35 @@
                 "applicable": true
               }
             },
+            "AlternateAddress": {
+              "type": "physicaladdress",
+              "props": {
+                "HasDifferentAddress": {
+                  "type": "branch",
+                  "props": {
+                    "value": ""
+                  }
+                },
+                "Address": {
+                  "type": "location",
+                  "props": {
+                    "layout": "",
+                    "country": ""
+                  }
+                },
+                "Telephone": {
+                  "type": "telephone",
+                  "props": {
+                    "timeOfDay": "",
+                    "type": "",
+                    "numberType": "",
+                    "number": "",
+                    "extension": "",
+                    "noNumber": false
+                  }
+                }
+              }
+            },
             "BirthPlace": {
               "type": "location",
               "props": {

--- a/api/testdata/complete-scenarios/test4.json
+++ b/api/testdata/complete-scenarios/test4.json
@@ -3765,6 +3765,35 @@
                 "applicable": false
               }
             },
+            "AlternateAddress": {
+              "type": "physicaladdress",
+              "props": {
+                "HasDifferentAddress": {
+                  "type": "branch",
+                  "props": {
+                    "value": ""
+                  }
+                },
+                "Address": {
+                  "type": "location",
+                  "props": {
+                    "layout": "",
+                    "country": ""
+                  }
+                },
+                "Telephone": {
+                  "type": "telephone",
+                  "props": {
+                    "timeOfDay": "",
+                    "type": "",
+                    "numberType": "",
+                    "number": "",
+                    "extension": "",
+                    "noNumber": false
+                  }
+                }
+              }
+            },
             "BirthPlace": {
               "type": "location",
               "props": {

--- a/api/testdata/complete-scenarios/test5.json
+++ b/api/testdata/complete-scenarios/test5.json
@@ -16172,6 +16172,35 @@
                 "applicable": true
               }
             },
+            "AlternateAddress": {
+              "type": "physicaladdress",
+              "props": {
+                "HasDifferentAddress": {
+                  "type": "branch",
+                  "props": {
+                    "value": ""
+                  }
+                },
+                "Address": {
+                  "type": "location",
+                  "props": {
+                    "layout": "",
+                    "country": ""
+                  }
+                },
+                "Telephone": {
+                  "type": "telephone",
+                  "props": {
+                    "timeOfDay": "",
+                    "type": "",
+                    "numberType": "",
+                    "number": "",
+                    "extension": "",
+                    "noNumber": false
+                  }
+                }
+              }
+            },
             "BirthPlace": {
               "type": "location",
               "props": {

--- a/api/testdata/complete-scenarios/test6.json
+++ b/api/testdata/complete-scenarios/test6.json
@@ -2850,6 +2850,35 @@
                 "applicable": false
               }
             },
+            "AlternateAddress": {
+              "type": "physicaladdress",
+              "props": {
+                "HasDifferentAddress": {
+                  "type": "branch",
+                  "props": {
+                    "value": ""
+                  }
+                },
+                "Address": {
+                  "type": "location",
+                  "props": {
+                    "layout": "",
+                    "country": ""
+                  }
+                },
+                "Telephone": {
+                  "type": "telephone",
+                  "props": {
+                    "timeOfDay": "",
+                    "type": "",
+                    "numberType": "",
+                    "number": "",
+                    "extension": "",
+                    "noNumber": false
+                  }
+                }
+              }
+            },
             "BirthPlace": {
               "type": "location",
               "props": {

--- a/api/testdata/complete-scenarios/test7.json
+++ b/api/testdata/complete-scenarios/test7.json
@@ -14214,6 +14214,35 @@
                 "applicable": true
               }
             },
+            "AlternateAddress": {
+              "type": "physicaladdress",
+              "props": {
+                "HasDifferentAddress": {
+                  "type": "branch",
+                  "props": {
+                    "value": ""
+                  }
+                },
+                "Address": {
+                  "type": "location",
+                  "props": {
+                    "layout": "",
+                    "country": ""
+                  }
+                },
+                "Telephone": {
+                  "type": "telephone",
+                  "props": {
+                    "timeOfDay": "",
+                    "type": "",
+                    "numberType": "",
+                    "number": "",
+                    "extension": "",
+                    "noNumber": false
+                  }
+                }
+              }
+            },
             "BirthPlace": {
               "type": "location",
               "props": {

--- a/api/testdata/complete-scenarios/test8.json
+++ b/api/testdata/complete-scenarios/test8.json
@@ -2584,6 +2584,35 @@
                 "applicable": false
               }
             },
+            "AlternateAddress": {
+              "type": "physicaladdress",
+              "props": {
+                "HasDifferentAddress": {
+                  "type": "branch",
+                  "props": {
+                    "value": ""
+                  }
+                },
+                "Address": {
+                  "type": "location",
+                  "props": {
+                    "layout": "",
+                    "country": ""
+                  }
+                },
+                "Telephone": {
+                  "type": "telephone",
+                  "props": {
+                    "timeOfDay": "",
+                    "type": "",
+                    "numberType": "",
+                    "number": "",
+                    "extension": "",
+                    "noNumber": false
+                  }
+                }
+              }
+            },
             "BirthPlace": {
               "type": "location",
               "props": {

--- a/api/testdata/complete-scenarios/test9.json
+++ b/api/testdata/complete-scenarios/test9.json
@@ -4123,6 +4123,35 @@
                 "applicable": true
               }
             },
+            "AlternateAddress": {
+              "type": "physicaladdress",
+              "props": {
+                "HasDifferentAddress": {
+                  "type": "branch",
+                  "props": {
+                    "value": ""
+                  }
+                },
+                "Address": {
+                  "type": "location",
+                  "props": {
+                    "layout": "",
+                    "country": ""
+                  }
+                },
+                "Telephone": {
+                  "type": "telephone",
+                  "props": {
+                    "timeOfDay": "",
+                    "type": "",
+                    "numberType": "",
+                    "number": "",
+                    "extension": "",
+                    "noNumber": false
+                  }
+                }
+              }
+            },
             "BirthPlace": {
               "type": "location",
               "props": {


### PR DESCRIPTION
Fixes #1214. Syncs existing NBIB test cases with recent change to current spouse (https://github.com/18F/e-QIP-prototype/issues/1157)