### PR TITLE
Adds text for employment types to match e-QIP

### DIFF
--- a/src/components/Section/History/Employment/EmploymentActivity.jsx
+++ b/src/components/Section/History/Employment/EmploymentActivity.jsx
@@ -102,7 +102,7 @@ export default class EmploymentActivity extends ValidationElement {
                 onFocus={this.props.onFocus}
               />
               <Radio
-                label={i18n.t(
+                label={i18n.m(
                   'history.employment.default.activity.type.stateGovernment'
                 )}
                 value="StateGovernment"
@@ -127,7 +127,7 @@ export default class EmploymentActivity extends ValidationElement {
               />
               <div>Other employment</div>
               <Radio
-                label={i18n.t(
+                label={i18n.m(
                   'history.employment.default.activity.type.nonGovernment'
                 )}
                 value="NonGovernment"
@@ -176,7 +176,7 @@ export default class EmploymentActivity extends ValidationElement {
           </Field>
           <Show when={this.props.value === 'Other'}>
             <Field
-              title={i18n.t('history.employment.default.activity.other.label')}
+              title={i18n.m('history.employment.default.activity.other.label')}
               titleSize="label"
               adjustFor="labels"
               scrollIntoView={this.props.scrollIntoView}>

--- a/src/components/Section/History/Employment/EmploymentItem.scss
+++ b/src/components/Section/History/Employment/EmploymentItem.scss
@@ -1,10 +1,10 @@
 .history {
   .employment-activity {
     .block label {
-      height: 8rem;
+      height: 11rem;
       width: 18rem;
       padding-top: 2rem;
-      line-height: 1.1 !important;
+      line-height: 1.5 !important;
     }
   }
 
@@ -22,10 +22,6 @@
   .employment-activity-nongovernment {
     &.block label {
       padding-top: 0;
-    }
-
-    p:first-of-type {
-      line-height: 1.1;
     }
   }
 

--- a/src/components/Section/History/Employment/EmploymentItem.scss
+++ b/src/components/Section/History/Employment/EmploymentItem.scss
@@ -1,14 +1,13 @@
 .history {
   .employment-activity {
     .block label {
-      height: 8rem;
+      height: 12rem;
       width: 18rem;
       padding-top: 2rem;
       line-height: 1.4 !important;
     }
   }
 
-  .employment-activity-state-government,
   .employment-activity-federal-contractor,
   .employment-activity-self,
   .employment-activity-unemployment,
@@ -17,6 +16,15 @@
       padding-top: 2.5rem;
     }
   }
+
+  // Hack
+  .employment-activity-state-government,
+  .employment-activity-nongovernment {
+    &.block label {
+      padding-top: 0;
+    }
+  }
+
 
   .employment-left {
     .block label {

--- a/src/components/Section/History/Employment/EmploymentItem.scss
+++ b/src/components/Section/History/Employment/EmploymentItem.scss
@@ -29,7 +29,6 @@
     }
   }
 
-
   .employment-left {
     .block label {
       height: 8rem !important;

--- a/src/components/Section/History/Employment/EmploymentItem.scss
+++ b/src/components/Section/History/Employment/EmploymentItem.scss
@@ -1,10 +1,10 @@
 .history {
   .employment-activity {
     .block label {
-      height: 12rem;
+      height: 8rem;
       width: 18rem;
       padding-top: 2rem;
-      line-height: 1.4 !important;
+      line-height: 1.1 !important;
     }
   }
 
@@ -17,11 +17,15 @@
     }
   }
 
-  // Hack
+  // Entire block is a hack
   .employment-activity-state-government,
   .employment-activity-nongovernment {
     &.block label {
       padding-top: 0;
+    }
+
+    p:first-of-type {
+      line-height: 1.1;
     }
   }
 

--- a/src/config/locales/en/history.js
+++ b/src/config/locales/en/history.js
@@ -214,9 +214,9 @@ export const history = {
           nationalGuard: 'National Guard/Reserve',
           usphs: 'USPHS Commissioned Corps',
           otherFederal: 'Other federal employment',
-          stateGovernment: 'State Government',
+          stateGovernment: ['State Government', '(Non-Federal employment)'],
           federalContractor: 'Federal contractor',
-          nonGovernment: 'Non-government employment',
+          nonGovernment: ['Non-government employment', '(excluding self-employment)'],
           selfEmployment: 'Self-employment',
           unemployment: 'Unemployment',
           other: 'Other'


### PR DESCRIPTION
Fixes #1198 

Adds the correct radio button labels for State Government and Non-government employment. Also adds styles so things are more consistent.