### PR TITLE
Remove middle name and last name initial checkbox from employment verifier

### DIFF
--- a/src/components/Form/Name/Name.jsx
+++ b/src/components/Form/Name/Name.jsx
@@ -44,7 +44,6 @@ export default class Name extends ValidationElement {
       middle: this.props.middle,
       middleInitialOnly: this.props.middleInitialOnly,
       hideMiddleName: this.props.hideMiddleName,
-      hideLastInitialOnly: this.props.hideLastInitialOnly,
       noMiddleName: this.props.noMiddleName,
       suffix: this.props.suffix,
       suffixOther: this.props.suffixOther,
@@ -311,22 +310,20 @@ export default class Name extends ValidationElement {
             required={this.props.required}
             disabled={this.props.disabled}
           />
-          {!this.props.hideLastInitialOnly && (
-            <div className="flags">
-              <Checkbox
-                name="lastInitialOnly"
-                ref="lastInitialOnly"
-                label={i18n.t(`${prefix}.label.initialOnly`)}
-                className="last-initial-only"
-                toggle="false"
-                value={this.props.lastInitialOnly}
-                checked={this.props.lastInitialOnly}
-                onUpdate={this.updateLastInitial}
-                onError={this.handleErrorLast}
-                disabled={this.props.disabled}
-              />
-            </div>
-          )}
+          <div className="flags">
+            <Checkbox
+              name="lastInitialOnly"
+              ref="lastInitialOnly"
+              label={i18n.t(`${prefix}.label.initialOnly`)}
+              className="last-initial-only"
+              toggle="false"
+              value={this.props.lastInitialOnly}
+              checked={this.props.lastInitialOnly}
+              onUpdate={this.updateLastInitial}
+              onError={this.handleErrorLast}
+              disabled={this.props.disabled}
+            />
+          </div>
         </Field>
         <Field
           title={i18n.t(`${prefix}.label.suffix`)}
@@ -501,7 +498,6 @@ Name.defaultProps = {
   middleInitialOnly: false,
   noMiddleName: false,
   hideMiddleName: false,
-  hideLastInitialOnly: false,
   suffix: '',
   suffixOther: '',
   prefix: 'name',

--- a/src/components/Form/Name/Name.jsx
+++ b/src/components/Form/Name/Name.jsx
@@ -309,20 +309,22 @@ export default class Name extends ValidationElement {
             required={this.props.required}
             disabled={this.props.disabled}
           />
-          <div className="flags">
-            <Checkbox
-              name="lastInitialOnly"
-              ref="lastInitialOnly"
-              label={i18n.t(`${prefix}.label.initialOnly`)}
-              className="last-initial-only"
-              toggle="false"
-              value={this.props.lastInitialOnly}
-              checked={this.props.lastInitialOnly}
-              onUpdate={this.updateLastInitial}
-              onError={this.handleErrorLast}
-              disabled={this.props.disabled}
-            />
-          </div>
+          {!this.props.hideLastInitialOnly && (
+            <div className="flags">
+              <Checkbox
+                name="lastInitialOnly"
+                ref="lastInitialOnly"
+                label={i18n.t(`${prefix}.label.initialOnly`)}
+                className="last-initial-only"
+                toggle="false"
+                value={this.props.lastInitialOnly}
+                checked={this.props.lastInitialOnly}
+                onUpdate={this.updateLastInitial}
+                onError={this.handleErrorLast}
+                disabled={this.props.disabled}
+              />
+            </div>
+          )}
         </Field>
         <Field
           title={i18n.t(`${prefix}.label.suffix`)}
@@ -497,6 +499,7 @@ Name.defaultProps = {
   middleInitialOnly: false,
   noMiddleName: false,
   hideMiddleName: false,
+  hideLastInitialOnly: false,
   suffix: '',
   suffixOther: '',
   prefix: 'name',

--- a/src/components/Form/Name/Name.jsx
+++ b/src/components/Form/Name/Name.jsx
@@ -234,56 +234,58 @@ export default class Name extends ValidationElement {
             />
           </div>
         </Field>
-        <Field
-          title={i18n.t(`${prefix}.label.middle`)}
-          titleSize="label"
-          help="identification.name.middle.help"
-          errorPrefix="name"
-          filterErrors={this.filterErrors.bind(this)}
-          scrollIntoView={this.props.scrollIntoView}
-          adjustFor="labels">
-          <Text
-            name="middle"
-            ref="middle"
-            pattern="^[a-zA-Z\-\.' ]*$"
-            minlength={this.props.middleInitialOnly ? 1 : 2}
-            maxlength={maxMiddle}
-            className="middle"
-            value={this.props.middle}
-            disabled={this.props.noMiddleName || this.props.disabled}
-            onUpdate={this.updateMiddle}
-            onError={this.handleErrorMiddle}
-            onFocus={this.props.onFocus}
-            onBlur={this.props.onBlur}
-            required={!this.props.noMiddleName && this.props.required}
-          />
-          <div className="middle-options flags">
-            <Checkbox
-              name="noMiddleName"
-              ref="noMiddleName"
-              label={i18n.t(`${prefix}.label.noMiddle`)}
-              className="middle-none"
-              toggle="false"
-              value={this.props.noMiddleName}
-              checked={this.props.noMiddleName}
-              onUpdate={this.updateMiddleNone}
+        {!this.props.hideMiddleName && (
+          <Field
+            title={i18n.t(`${prefix}.label.middle`)}
+            titleSize="label"
+            help="identification.name.middle.help"
+            errorPrefix="name"
+            filterErrors={this.filterErrors.bind(this)}
+            scrollIntoView={this.props.scrollIntoView}
+            adjustFor="labels">
+            <Text
+              name="middle"
+              ref="middle"
+              pattern="^[a-zA-Z\-\.' ]*$"
+              minlength={this.props.middleInitialOnly ? 1 : 2}
+              maxlength={maxMiddle}
+              className="middle"
+              value={this.props.middle}
+              disabled={this.props.noMiddleName || this.props.disabled}
+              onUpdate={this.updateMiddle}
               onError={this.handleErrorMiddle}
-              disabled={this.props.disabled}
+              onFocus={this.props.onFocus}
+              onBlur={this.props.onBlur}
+              required={!this.props.noMiddleName && this.props.required}
             />
-            <Checkbox
-              name="middleInitialOnly"
-              ref="middleInitialOnly"
-              label={i18n.t(`${prefix}.label.initialOnly`)}
-              className="middle-initial-only"
-              toggle="false"
-              value={this.props.middleInitialOnly}
-              checked={this.props.middleInitialOnly}
-              onUpdate={this.updateMiddleInitial}
-              onError={this.handleErrorMiddle}
-              disabled={this.props.disabled}
-            />
-          </div>
-        </Field>
+            <div className="middle-options flags">
+              <Checkbox
+                name="noMiddleName"
+                ref="noMiddleName"
+                label={i18n.t(`${prefix}.label.noMiddle`)}
+                className="middle-none"
+                toggle="false"
+                value={this.props.noMiddleName}
+                checked={this.props.noMiddleName}
+                onUpdate={this.updateMiddleNone}
+                onError={this.handleErrorMiddle}
+                disabled={this.props.disabled}
+              />
+              <Checkbox
+                name="middleInitialOnly"
+                ref="middleInitialOnly"
+                label={i18n.t(`${prefix}.label.initialOnly`)}
+                className="middle-initial-only"
+                toggle="false"
+                value={this.props.middleInitialOnly}
+                checked={this.props.middleInitialOnly}
+                onUpdate={this.updateMiddleInitial}
+                onError={this.handleErrorMiddle}
+                disabled={this.props.disabled}
+              />
+            </div>
+          </Field>
+        )}
         <Field
           title={i18n.t(`${prefix}.label.last`)}
           titleSize="label"
@@ -494,6 +496,7 @@ Name.defaultProps = {
   middle: '',
   middleInitialOnly: false,
   noMiddleName: false,
+  hideMiddleName: false,
   suffix: '',
   suffixOther: '',
   prefix: 'name',

--- a/src/components/Form/Name/Name.jsx
+++ b/src/components/Form/Name/Name.jsx
@@ -43,6 +43,8 @@ export default class Name extends ValidationElement {
       lastInitialOnly: this.props.lastInitialOnly,
       middle: this.props.middle,
       middleInitialOnly: this.props.middleInitialOnly,
+      hideMiddleName: this.props.hideMiddleName,
+      hideLastInitialOnly: this.props.hideLastInitialOnly,
       noMiddleName: this.props.noMiddleName,
       suffix: this.props.suffix,
       suffixOther: this.props.suffixOther,

--- a/src/components/Form/Name/Name.test.jsx
+++ b/src/components/Form/Name/Name.test.jsx
@@ -334,7 +334,12 @@ describe('The Name component', () => {
   })
 
   it('hides middle name', () => {
-    const component = shallow(<Name hideMiddleName={true} />)
+    const component = shallow(<Name hideMiddleName />)
     expect(component.find('.middle').length).toBe(0)
+  })
+
+  it('hides last initial only checkbox', () => {
+    const component = shallow(<Name hideLastInitialOnly />)
+    expect(component.find('.last-initial-only').length).toBe(0)
   })
 })

--- a/src/components/Form/Name/Name.test.jsx
+++ b/src/components/Form/Name/Name.test.jsx
@@ -337,9 +337,4 @@ describe('The Name component', () => {
     const component = shallow(<Name hideMiddleName />)
     expect(component.find('.middle').length).toBe(0)
   })
-
-  it('hides last initial only checkbox', () => {
-    const component = shallow(<Name hideLastInitialOnly />)
-    expect(component.find('.last-initial-only').length).toBe(0)
-  })
 })

--- a/src/components/Form/Name/Name.test.jsx
+++ b/src/components/Form/Name/Name.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import Name from './Name'
 
 describe('The Name component', () => {
@@ -331,5 +331,10 @@ describe('The Name component', () => {
       component.find({ name: 'middle' }).simulate('change')
       expect(component.find('.usa-input-error').length).toEqual(ex.errors)
     })
+  })
+
+  it('hides middle name', () => {
+    const component = shallow(<Name hideMiddleName={true} />)
+    expect(component.find('.middle').length).toBe(0)
   })
 })

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -471,6 +471,7 @@ export default class EmploymentItem extends ValidationElement {
                 onUpdate={this.updateReferenceName}
                 onError={this.props.onError}
                 required={this.props.required}
+                hideMiddleName={this.props.EmploymentActivity.value === "SelfEmployment"}
               />
             </Field>
 

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -471,7 +471,7 @@ export default class EmploymentItem extends ValidationElement {
                 onUpdate={this.updateReferenceName}
                 onError={this.props.onError}
                 required={this.props.required}
-                hideMiddleName={this.props.EmploymentActivity.value === "SelfEmployment"}
+                hideMiddleName
               />
             </Field>
 

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -472,6 +472,7 @@ export default class EmploymentItem extends ValidationElement {
                 onError={this.props.onError}
                 required={this.props.required}
                 hideMiddleName
+                hideLastInitialOnly
               />
             </Field>
 

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -472,7 +472,6 @@ export default class EmploymentItem extends ValidationElement {
                 onError={this.props.onError}
                 required={this.props.required}
                 hideMiddleName
-                hideLastInitialOnly
               />
             </Field>
 

--- a/src/validators/name.js
+++ b/src/validators/name.js
@@ -22,6 +22,7 @@ export default class NameValidator {
     this.lastInitialOnly = data.lastInitialOnly
     this.middleInitialOnly = data.middleInitialOnly
     this.noMiddleName = data.noMiddleName
+    this.hideMiddleName = data.hideMiddleName
     this.middle = data.middle
     this.suffix = data.suffix
     this.suffixOther = data.suffixOther
@@ -61,6 +62,11 @@ export default class NameValidator {
    * Validates a persons middle name
    */
   validMiddle() {
+
+    if (this.hideMiddleName) {
+      return true
+    }
+
     switch (this.noMiddleName) {
       case true:
         // If user does not have a middle name, make sure middle name is not entered


### PR DESCRIPTION
Fixes #1196 and #1197 

- Removes middle name field from the user interface
- Removes the last name initial checkbox