### PR TITLE
Increase timeout for loading initial form data

### DIFF
--- a/src/actions/ApplicationActions.js
+++ b/src/actions/ApplicationActions.js
@@ -48,10 +48,8 @@ export function getApplicationState(done) {
           done()
         }
       })
-      .catch(() => {
-        if (console && console.warn) {
-          console.warn('Failed to retrieve form saved data')
-        }
+      .catch(error => {
+        env.History().push('/error')
       })
   }
 }

--- a/src/components/Main/Main.jsx
+++ b/src/components/Main/Main.jsx
@@ -7,6 +7,7 @@ import {
   Loading,
   AccessDenied,
   Locked,
+  Error,
   TokenRefresh,
   Help
 } from '../../views'
@@ -44,6 +45,7 @@ class Main extends React.Component {
           <Route exact path="/login" component={Login} />
           <Route exact path="/accessdenied" component={AccessDenied} />
           <Route exact path="/locked" component={Locked} />
+          <Route exact path="/error" component={Error} />
           <Route exact path="/token" component={TokenRefresh} />
         </Switch>
       </Router>

--- a/src/config/locales/en/application.js
+++ b/src/config/locales/en/application.js
@@ -135,7 +135,12 @@ export const application = {
     logout: 'Make sure you save and/or print your responses before logging out'
   },
   loading: {
-    title: '#### We are loading your data'
+    title: '#### We are loading your data',
+    error: {
+      title: 'Oops, there’s a problem.',
+      para: ['There was a problem loading your data, please try again.'],
+      button: 'Back to login'
+    }
   },
   timeout: {
     title: 'Are you still working?',

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -39,7 +39,7 @@ class Api {
   constructor() {
     this.proxy = axios.create({
       baseURL: env ? env.ApiBaseURL() : '/api',
-      timeout: 10000
+      timeout: 30000
     })
   }
 

--- a/src/views/Error/Error.jsx
+++ b/src/views/Error/Error.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { i18n } from '../../config'
+
+class Error extends React.Component {
+  render() {
+    return (
+      <div className="login eapp-core" id="login">
+        <div id="seal-header" className="seal-header text-center">
+          <div className="content">
+            <img
+              src="/img/nbis-seal.png"
+              alt="National Background Investigation Services"
+            />
+            <h2>{i18n.t('login.title')}</h2>
+          </div>
+        </div>
+        <div className="content">
+          <div className="table one">
+            <div id="error" className="auth error">
+              <h3>{i18n.t('application.loading.error.title')}</h3>
+              {i18n.m('application.loading.error.para')}
+              <a href="/" title={i18n.t('application.loading.error.button')}>
+                {i18n.t('application.loading.error.button')}
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+Error.defaultProps = {}
+
+function mapStateToProps(state) {
+  return {}
+}
+
+export default connect(mapStateToProps)(Error)

--- a/src/views/Error/Error.test.jsx
+++ b/src/views/Error/Error.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import MockAdapter from 'axios-mock-adapter'
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import { MemoryRouter } from 'react-router'
+import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
+import Error from './Error'
+import { i18n } from '../../config'
+
+describe('The Error view', () => {
+  // Setup
+  const middlewares = [thunk]
+  const mockStore = configureMockStore(middlewares)
+
+  it('is visible with context', () => {
+    const store = mockStore({ authentication: {} })
+    const component = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Error />
+        </MemoryRouter>
+      </Provider>
+    )
+    expect(component.find('.auth.error').length).toEqual(1)
+    expect(component.find('.auth.error h3').text()).toEqual(
+      i18n.t('application.loading.error.title')
+    )
+    expect(component.find('.auth.error p').text()).toEqual(
+      i18n.t('application.loading.error.para')
+    )
+    expect(component.find('.auth.error a').text()).toEqual(
+      i18n.t('application.loading.error.button')
+    )
+  })
+})

--- a/src/views/Error/index.js
+++ b/src/views/Error/index.js
@@ -1,0 +1,2 @@
+import Error from './Error'
+export { Error }

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -2,8 +2,9 @@ import { Login } from './Login'
 import { Loading } from './Loading'
 import { AccessDenied } from './AccessDenied'
 import { Locked } from './Locked'
+import { Error } from './Error'
 import { TokenRefresh } from './TokenRefresh'
 import { Help } from './Help'
 import { Form } from './Form'
 
-export { Login, Loading, AccessDenied, Locked, TokenRefresh, Help, Form }
+export { Login, Loading, AccessDenied, Locked, Error, TokenRefresh, Help, Form }


### PR DESCRIPTION
Fixes #952 

Rather than removing the axios timeout (the default is `0` which removes the timeout), I've increased it from 10 seconds to 30 seconds to allow extra time for the initial application state to load. I also created a basic error page that will load if the timeout threshold is met, rather than leaving the loading page hanging.

To test, you can dial back the timeout to something like `1000` here https://github.com/18F/e-QIP-prototype/blob/develop/src/services/api.js#L42

**Error page:**
<img width="639" alt="screen shot 2018-11-29 at 11 08 35 am" src="https://user-images.githubusercontent.com/1178494/49235062-32bba580-f3c7-11e8-9286-4bdee84700ea.png">
