### PR TITLE
Allow release forms to be downloaded with ATTACHMENTS_ENABLED disabled

### DIFF
--- a/api/http/attachment.go
+++ b/api/http/attachment.go
@@ -24,12 +24,6 @@ type AttachmentListHandler struct {
 
 // ServeHTTP serves the HTTP response.
 func (service AttachmentListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if !service.Env.True(api.AttachmentsEnabled) {
-		service.Log.Warn(api.AttachmentDenied, api.LogFields{})
-		http.Error(w, "Attachments is not implemented", http.StatusInternalServerError)
-		return
-	}
-
 	account := &api.Account{}
 
 	// Valid token and audience while populating the audience ID
@@ -254,12 +248,6 @@ type AttachmentGetHandler struct {
 
 // ServeHTTP serves the HTTP response.
 func (service AttachmentGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if !service.Env.True(api.AttachmentsEnabled) {
-		service.Log.Warn(api.AttachmentDenied, api.LogFields{})
-		http.Error(w, "Attachments is not implemented", http.StatusInternalServerError)
-		return
-	}
-
 	account := &api.Account{}
 
 	// Valid token and audience while populating the audience ID


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/1010

This removes the conditional logic tied to `ATTACHMENTS_ENABLED` for listing and retrieving attachments. This allows the release form PDFs to be downloaded after an application is submitted even if `ATTACHMENTS_ENABLED` is disabled.

I'm having a hard time figuring out how to test this in a unit test, but am open to suggestions. 