### PR TITLE
Right align dates in accordion

### DIFF
--- a/src/components/Form/Accordion/Accordion.scss
+++ b/src/components/Form/Accordion/Accordion.scss
@@ -173,7 +173,7 @@ $breakpoints: (
     .summary-item-content {
       .context {
         display: inline-block;
-        max-width: 70%;
+        max-width: 49%;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -207,7 +207,7 @@ $breakpoints: (
       }
 
       .dates {
-        margin-left: 2rem;
+        float: right;
       }
 
       // All but the first anchor
@@ -369,9 +369,6 @@ button.usa-button-outline {
           transition: width 300ms ease-out;
           vertical-align: middle;
 
-          .button-with-icon {
-            margin-left: 2rem;
-          }
         }
       }
     }


### PR DESCRIPTION
Fixes #1239 
Now the text generates the ellipsis `...` sooner so the date and text can all be on one line with the dates aligned right

Tested in IE 11 and Chrome Mac

![screen shot 2018-12-04 at 9 22 52 am](https://user-images.githubusercontent.com/1449852/49448618-4be99b00-f7a7-11e8-8a9b-1ff5a76a0ac2.png)
![screen shot 2018-12-04 at 9 23 04 am](https://user-images.githubusercontent.com/1449852/49448619-4be99b00-f7a7-11e8-888a-25b8a13817cb.png)
![screen shot 2018-12-04 at 9 23 16 am](https://user-images.githubusercontent.com/1449852/49448621-4c823180-f7a7-11e8-8b0f-9f684af2e2f2.png)
![screen shot 2018-12-04 at 9 26 58 am](https://user-images.githubusercontent.com/1449852/49448622-4c823180-f7a7-11e8-815a-973f3cedf3d7.png)
![screen shot 2018-12-04 at 9 27 14 am](https://user-images.githubusercontent.com/1449852/49448624-4c823180-f7a7-11e8-9b9c-ced8182ea1bc.png)
![screen shot 2018-12-04 at 9 27 34 am](https://user-images.githubusercontent.com/1449852/49448625-4c823180-f7a7-11e8-8e32-ed46e7ffd9ef.png)
