### PR TITLE
Remove defaultState to open up Accordions on review pages

### DIFF
--- a/src/components/Form/Accordion/Accordion.jsx
+++ b/src/components/Form/Accordion/Accordion.jsx
@@ -103,9 +103,10 @@ export default class Accordion extends ValidationElement {
       if (item.open !== true && item.open !== false) {
         item.open = this.props.defaultState
         dirty = true
+      } else {
+        item.open = this.props.items.length > 1 ? false : this.props.defaultState
       }
 
-      item.open = this.props.items.length > 1 ? false : this.props.defaultState
       return item
     })
 

--- a/src/components/Section/Citizenship/Citizenship.jsx
+++ b/src/components/Section/Citizenship/Citizenship.jsx
@@ -48,7 +48,6 @@ class Citizenship extends SectionElement {
               {...this.props.Status}
               section="citizenship"
               subsection="status"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.handleUpdate.bind(this, 'Status')}
               onError={this.handleError}
@@ -61,7 +60,6 @@ class Citizenship extends SectionElement {
               {...this.props.Multiple}
               section="citizenship"
               subsection="multiple"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.handleUpdate.bind(this, 'Multiple')}
               onError={this.handleError}
@@ -74,7 +72,6 @@ class Citizenship extends SectionElement {
               {...this.props.Passports}
               section="citizenship"
               subsection="passports"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.handleUpdate.bind(this, 'Passports')}
               onError={this.handleError}

--- a/src/components/Section/Financial/Financial.jsx
+++ b/src/components/Section/Financial/Financial.jsx
@@ -54,7 +54,6 @@ class Financial extends SectionElement {
               dispatch={this.props.dispatch}
               onUpdate={this.handleUpdate.bind(this, 'Bankruptcy')}
               onError={this.handleError}
-              defaultState={false}
               required={true}
               scrollIntoView={false}
             />
@@ -67,7 +66,6 @@ class Financial extends SectionElement {
               dispatch={this.props.dispatch}
               onUpdate={this.handleUpdate.bind(this, 'Gambling')}
               onError={this.handleError}
-              defaultState={false}
               required={true}
               scrollIntoView={false}
             />
@@ -80,7 +78,6 @@ class Financial extends SectionElement {
               dispatch={this.props.dispatch}
               onUpdate={this.handleUpdate.bind(this, 'Taxes')}
               onError={this.handleError}
-              defaultState={false}
               required={true}
               scrollIntoView={false}
             />
@@ -94,7 +91,6 @@ class Financial extends SectionElement {
               dispatch={this.props.dispatch}
               onUpdate={this.handleUpdate.bind(this, 'Card')}
               onError={this.handleError}
-              defaultState={false}
               required={true}
               scrollIntoView={false}
             />
@@ -108,7 +104,6 @@ class Financial extends SectionElement {
               dispatch={this.props.dispatch}
               onUpdate={this.handleUpdate.bind(this, 'Credit')}
               onError={this.handleError}
-              defaultState={false}
               required={true}
               scrollIntoView={false}
             />
@@ -122,7 +117,6 @@ class Financial extends SectionElement {
               dispatch={this.props.dispatch}
               onUpdate={this.handleUpdate.bind(this, 'Delinquent')}
               onError={this.handleError}
-              defaultState={false}
               required={true}
               scrollIntoView={false}
             />
@@ -135,7 +129,6 @@ class Financial extends SectionElement {
               dispatch={this.props.dispatch}
               onUpdate={this.handleUpdate.bind(this, 'Nonpayment')}
               onError={this.handleError}
-              defaultState={false}
               required={true}
               scrollIntoView={false}
             />

--- a/src/components/Section/Foreign/Foreign.jsx
+++ b/src/components/Section/Foreign/Foreign.jsx
@@ -175,7 +175,6 @@ class Foreign extends SectionElement {
               {...this.props.Contacts}
               section="foreign"
               subsection="contacts"
-              defaultState={false}
               addressBooks={this.props.AddressBooks}
               dispatch={this.props.dispatch}
               onUpdate={this.updateContacts}
@@ -189,7 +188,6 @@ class Foreign extends SectionElement {
               {...this.props.DirectActivity}
               section="foreign"
               subsection="activities/direct"
-              defaultState={false}
               addressBooks={this.props.AddressBooks}
               dispatch={this.props.dispatch}
               onUpdate={this.updateDirectActivity}
@@ -217,7 +215,6 @@ class Foreign extends SectionElement {
               {...this.props.RealEstateActivity}
               section="foreign"
               subsection="activities/realestate"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateRealEstateActivity}
               onError={this.handleError}
@@ -230,7 +227,6 @@ class Foreign extends SectionElement {
               {...this.props.BenefitActivity}
               section="foreign"
               subsection="activities/benefits"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateBenefitActivity}
               onError={this.handleError}
@@ -243,7 +239,6 @@ class Foreign extends SectionElement {
               {...this.props.Support}
               section="foreign"
               subsection="activities/support"
-              defaultState={false}
               addressBooks={this.props.AddressBooks}
               dispatch={this.props.dispatch}
               onUpdate={this.updateSupport}
@@ -257,7 +252,6 @@ class Foreign extends SectionElement {
               {...this.props.Advice}
               section="foreign"
               subsection="business/advice"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateAdvice}
               onError={this.handleError}
@@ -270,7 +264,6 @@ class Foreign extends SectionElement {
               {...this.props.Family}
               section="foreign"
               subsection="business/family"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateFamily}
               onError={this.handleError}
@@ -283,7 +276,6 @@ class Foreign extends SectionElement {
               {...this.props.Employment}
               section="foreign"
               subsection="business/employment"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateEmployment}
               onError={this.handleError}
@@ -296,7 +288,6 @@ class Foreign extends SectionElement {
               {...this.props.Ventures}
               section="foreign"
               subsection="business/ventures"
-              defaultState={false}
               addressBooks={this.props.AddressBooks}
               dispatch={this.props.dispatch}
               onUpdate={this.updateVentures}
@@ -310,7 +301,6 @@ class Foreign extends SectionElement {
               {...this.props.Conferences}
               section="foreign"
               subsection="business/conferences"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateConferences}
               onError={this.handleError}
@@ -323,7 +313,6 @@ class Foreign extends SectionElement {
               {...this.props.Contact}
               section="foreign"
               subsection="business/contact"
-              defaultState={false}
               addressBooks={this.props.AddressBooks}
               dispatch={this.props.dispatch}
               onUpdate={this.updateContact}
@@ -337,7 +326,6 @@ class Foreign extends SectionElement {
               {...this.props.Sponsorship}
               section="foreign"
               subsection="business/sponsorship"
-              defaultState={false}
               addressBooks={this.props.AddressBooks}
               dispatch={this.props.dispatch}
               onUpdate={this.updateSponsorship}
@@ -351,7 +339,6 @@ class Foreign extends SectionElement {
               {...this.props.Political}
               section="foreign"
               subsection="business/political"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updatePolitical}
               onError={this.handleError}
@@ -364,7 +351,6 @@ class Foreign extends SectionElement {
               {...this.props.Voting}
               section="foreign"
               subsection="business/voting"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateVoting}
               onError={this.handleError}
@@ -377,7 +363,6 @@ class Foreign extends SectionElement {
               {...this.props.Travel}
               section="foreign"
               subsection="business/travel"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateTravel}
               onError={this.handleError}

--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -393,8 +393,6 @@ class History extends SectionElement {
               {...this.props.Residence}
               section="history"
               subsection="residence"
-              defaultState={false}
-              realtime={true}
               sort={sort}
               totalYears={totalYears(this.props.Birthdate)}
               overrideInitial={this.overrideInitial}
@@ -403,7 +401,9 @@ class History extends SectionElement {
               addressBooks={this.props.AddressBooks}
               dispatch={this.props.dispatch}
               scrollIntoView={false}
-              required={true}
+              realtime
+              required
+              defaultState
             />
 
             <hr className="section-divider" />
@@ -418,8 +418,6 @@ class History extends SectionElement {
               {...this.props.Employment}
               section="history"
               subsection="employment"
-              defaultState={false}
-              realtime={true}
               sort={sort}
               totalYears={totalYears(this.props.Birthdate)}
               overrideInitial={this.overrideInitial}
@@ -428,7 +426,9 @@ class History extends SectionElement {
               addressBooks={this.props.AddressBooks}
               dispatch={this.props.dispatch}
               scrollIntoView={false}
-              required={true}
+              realtime
+              required
+              defaultState
             />
 
             <hr className="section-divider" />
@@ -479,7 +479,6 @@ class History extends SectionElement {
                   {...this.props.Education}
                   section="history"
                   subsection="education"
-                  defaultState={false}
                   realtime={true}
                   sort={sort}
                   totalYears={totalYears(this.props.Birthdate)}
@@ -500,7 +499,6 @@ class History extends SectionElement {
               {...this.props.Federal}
               section="history"
               subsection="federal"
-              defaultState={false}
               addressBooks={this.props.AddressBooks}
               dispatch={this.props.dispatch}
               onUpdate={this.handleUpdate.bind(this, 'Federal')}
@@ -742,7 +740,6 @@ export class HistorySections extends React.Component {
         />
 
         <Employment
-          {...this.props.Employment}
           {...this.props.Employment}
           defaultState={false}
           realtime={true}

--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -403,7 +403,6 @@ class History extends SectionElement {
               scrollIntoView={false}
               realtime
               required
-              defaultState
             />
 
             <hr className="section-divider" />
@@ -428,7 +427,6 @@ class History extends SectionElement {
               scrollIntoView={false}
               realtime
               required
-              defaultState
             />
 
             <hr className="section-divider" />

--- a/src/components/Section/Legal/Legal.jsx
+++ b/src/components/Section/Legal/Legal.jsx
@@ -524,7 +524,6 @@ class Legal extends SectionElement {
               section="legal"
               subsection="police/offenses"
               addressBooks={this.props.AddressBooks}
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updatePoliceOffenses}
               onError={this.handleError}
@@ -539,7 +538,6 @@ class Legal extends SectionElement {
               section="legal"
               subsection="police/additionaloffenses"
               addressBooks={this.props.AddressBooks}
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updatePoliceOtherOffenses}
               onError={this.handleError}
@@ -554,7 +552,6 @@ class Legal extends SectionElement {
               section="legal"
               subsection="police/domesticviolence"
               addressBooks={this.props.AddressBooks}
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updatePoliceDomesticViolence}
               onError={this.handleError}
@@ -568,7 +565,6 @@ class Legal extends SectionElement {
               {...this.props.History}
               section="legal"
               subsection="investigations/history"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateHistory}
               onError={this.handleError}
@@ -582,7 +578,6 @@ class Legal extends SectionElement {
               {...this.props.Revoked}
               section="legal"
               subsection="investigations/revoked"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateRevoked}
               onError={this.handleError}
@@ -596,7 +591,6 @@ class Legal extends SectionElement {
               {...this.props.Debarred}
               section="legal"
               subsection="investigations/debarred"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateDebarred}
               onError={this.handleError}
@@ -611,7 +605,6 @@ class Legal extends SectionElement {
               section="legal"
               subsection="court"
               addressBooks={this.props.AddressBooks}
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateNonCriminalCourtActions}
               onError={this.handleError}
@@ -640,7 +633,6 @@ class Legal extends SectionElement {
               section="legal"
               subsection="technology/manipulating"
               addressBooks={this.props.AddressBooks}
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateManipulating}
               onError={this.handleError}
@@ -655,7 +647,6 @@ class Legal extends SectionElement {
               section="legal"
               subsection="technology/unlawful"
               addressBooks={this.props.AddressBooks}
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateUnlawful}
               onError={this.handleError}
@@ -670,7 +661,6 @@ class Legal extends SectionElement {
               section="legal"
               subsection="associations/terrorist-organization"
               addressBooks={this.props.AddressBooks}
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateTerroristOrganization}
               onError={this.handleError}
@@ -684,7 +674,6 @@ class Legal extends SectionElement {
               {...this.props.EngagedInTerrorism}
               section="legal"
               subsection="associations/engaged-in-terrorism"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateEngagedInTerrorism}
               onError={this.handleError}
@@ -698,7 +687,6 @@ class Legal extends SectionElement {
               {...this.props.Advocating}
               section="legal"
               subsection="associations/advocating"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateAdvocating}
               onError={this.handleError}
@@ -712,7 +700,6 @@ class Legal extends SectionElement {
               {...this.props.MembershipOverthrow}
               section="legal"
               subsection="associations/membership-overthrow"
-              defaultState={false}
               addressBooks={this.props.AddressBooks}
               dispatch={this.props.dispatch}
               onUpdate={this.updateMembershipOverthrow}
@@ -742,7 +729,6 @@ class Legal extends SectionElement {
               {...this.props.ActivitiesToOverthrow}
               section="legal"
               subsection="associations/activities-to-overthrow"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateActivitiesToOverthrow}
               onError={this.handleError}

--- a/src/components/Section/Military/Military.jsx
+++ b/src/components/Section/Military/Military.jsx
@@ -97,7 +97,6 @@ class Military extends SectionElement {
               {...this.props.History}
               section="military"
               subsection="history"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateHistory}
               onError={this.handleError}
@@ -112,7 +111,6 @@ class Military extends SectionElement {
                 {...this.props.Disciplinary}
                 section="military"
                 subsection="disciplinary"
-                defaultState={false}
                 dispatch={this.props.dispatch}
                 onUpdate={this.updateDisciplinary}
                 onError={this.handleError}
@@ -128,7 +126,6 @@ class Military extends SectionElement {
               section="military"
               subsection="foreign"
               addressBooks={this.props.AddressBooks}
-              defaultState={false}
               dispatch={this.props.dispatch}
               onUpdate={this.updateForeign}
               onError={this.handleError}

--- a/src/components/Section/Psychological/Psychological.jsx
+++ b/src/components/Section/Psychological/Psychological.jsx
@@ -161,7 +161,6 @@ class Psychological extends SectionElement {
               {...this.props.Competence}
               section="psychological"
               subsection="competence"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onError={this.handleError}
               required={true}
@@ -175,7 +174,6 @@ class Psychological extends SectionElement {
               {...this.props.Consultations}
               section="psychological"
               subsection="consultations"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onError={this.handleError}
               required={true}
@@ -189,7 +187,6 @@ class Psychological extends SectionElement {
               {...this.props.Hospitalizations}
               section="psychological"
               subsection="hospitalizations"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onError={this.handleError}
               required={true}
@@ -203,7 +200,6 @@ class Psychological extends SectionElement {
               {...this.props.Diagnoses}
               section="psychological"
               subsection="diagnoses"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onError={this.handleError}
               required={true}
@@ -219,7 +215,6 @@ class Psychological extends SectionElement {
                   {...this.props.ExistingConditions}
                   section="psychological"
                   subsection="conditions"
-                  defaultState={false}
                   dispatch={this.props.dispatch}
                   onError={this.handleError}
                   onUpdate={this.handleUpdate.bind(this, 'ExistingConditions')}

--- a/src/components/Section/Relationships/Relationships.jsx
+++ b/src/components/Section/Relationships/Relationships.jsx
@@ -154,7 +154,6 @@ class Relationships extends SectionElement {
               {...this.props.Marital}
               section="relationships"
               subsection="status/marital"
-              defaultState={false}
               addressBooks={this.props.AddressBooks}
               dispatch={this.props.dispatch}
               onUpdate={this.updateMarital}
@@ -171,7 +170,6 @@ class Relationships extends SectionElement {
               {...this.props.Cohabitants}
               section="relationships"
               subsection="status/cohabitant"
-              defaultState={false}
               spouse={this.props.Spouse}
               dispatch={this.props.dispatch}
               onUpdate={this.updateCohabitants}
@@ -186,7 +184,6 @@ class Relationships extends SectionElement {
               {...this.props.People}
               section="relationships"
               subsection="people"
-              defaultState={false}
               addressBooks={this.props.AddressBooks}
               dispatch={this.props.dispatch}
               onUpdate={this.updatePeople}
@@ -201,7 +198,6 @@ class Relationships extends SectionElement {
               {...this.props.Relatives}
               section="relationships"
               subsection="relatives"
-              defaultState={false}
               addressBooks={this.props.AddressBooks}
               dispatch={this.props.dispatch}
               onUpdate={this.updateRelatives}

--- a/src/components/Section/SubstanceUse/SubstanceUse.jsx
+++ b/src/components/Section/SubstanceUse/SubstanceUse.jsx
@@ -306,7 +306,6 @@ class SubstanceUse extends SectionElement {
               {...this.props.DrugUses}
               section="substance"
               subsection="substance/drugs/usage"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onError={this.handleError}
               onUpdate={this.updateDrugUses}
@@ -320,7 +319,6 @@ class SubstanceUse extends SectionElement {
               {...this.props.DrugInvolvements}
               section="substance"
               subsection="substance/drugs/purchase"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onError={this.handleError}
               onUpdate={this.updateDrugInvolvements}
@@ -334,7 +332,6 @@ class SubstanceUse extends SectionElement {
               {...this.props.DrugClearanceUses}
               section="substance"
               subsection="substance/drugs/clearance"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onError={this.handleError}
               onUpdate={this.updateDrugClearanceUses}
@@ -348,7 +345,6 @@ class SubstanceUse extends SectionElement {
               {...this.props.DrugPublicSafetyUses}
               section="substance"
               subsection="substance/drugs/publicsafety"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onError={this.handleError}
               onUpdate={this.updateDrugPublicSafetyUses}
@@ -362,7 +358,6 @@ class SubstanceUse extends SectionElement {
               {...this.props.PrescriptionUses}
               section="substance"
               subsection="substance/drugs/misuse"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onError={this.handleError}
               onUpdate={this.updatePrescriptionUses}
@@ -376,7 +371,6 @@ class SubstanceUse extends SectionElement {
               {...this.props.OrderedTreatments}
               section="substance"
               subsection="substance/drugs/ordered"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onError={this.handleError}
               onUpdate={this.updateOrderedTreatments}
@@ -390,7 +384,6 @@ class SubstanceUse extends SectionElement {
               {...this.props.VoluntaryTreatments}
               section="substance"
               subsection="substance/drugs/voluntary"
-              defaultState={false}
               dispatch={this.props.dispatch}
               onError={this.handleError}
               onUpdate={this.updateVoluntaryTreatments}
@@ -401,7 +394,6 @@ class SubstanceUse extends SectionElement {
             <hr className="section-divider" />
             <NegativeImpacts
               name="negative"
-              defaultState={false}
               {...this.props.NegativeImpacts}
               section="substance"
               subsection="substance/alcohol/negative"
@@ -415,7 +407,6 @@ class SubstanceUse extends SectionElement {
             <hr className="section-divider" />
             <OrderedCounselings
               name="ordered"
-              defaultState={false}
               {...this.props.OrderedCounselings}
               section="substance"
               subsection="substance/alcohol/ordered"
@@ -429,7 +420,6 @@ class SubstanceUse extends SectionElement {
             <hr className="section-divider" />
             <VoluntaryCounselings
               name="voluntary"
-              defaultState={false}
               {...this.props.VoluntaryCounselings}
               section="substance"
               subsection="substance/alcohol/voluntary"
@@ -443,7 +433,6 @@ class SubstanceUse extends SectionElement {
             <hr className="section-divider" />
             <ReceivedCounselings
               name="additional"
-              defaultState={false}
               {...this.props.ReceivedCounselings}
               section="substance"
               subsection="substance/alcohol/additional"


### PR DESCRIPTION
Fixes #1176 

When clicking on an error on a review page, it will scroll down to the error. This often created scrolling errors because the Accordion component would be collapsed. By removing the `defaultState={false}` prop for subsections within `<SectionView name="review" {...} />`, this will cause accordions to be open by default *only* for the review pages.

This is not a perfect solution because by opening up all the accordions, it will cause the length of the page to be _very_ tall. However, all of the inaccurate scrolling woes will be gone.

We can revisit a better implementation once #1211 is complete. Once that is complete, we might be able to come up with a solution where only accordions with errors will be expanded.