### PR TITLE
Update employment items to sort more like a resume

### DIFF
--- a/src/components/Section/History/Employment/Employment.jsx
+++ b/src/components/Section/History/Employment/Employment.jsx
@@ -62,10 +62,10 @@ export default class Employment extends SubsectionElement {
       if (
         a.Item &&
         a.Item.Dates &&
-        a.Item.Dates.from
+        a.Item.Dates.to
       ) {
-        const aDateObj = a.Item.Dates.from
-        const bDateObj = b.Item.Dates.from
+        const aDateObj = a.Item.Dates.to
+        const bDateObj = b.Item.Dates.to
         const aDate = new Date(aDateObj.year, aDateObj.month - 1, aDateObj.day)
         const bDate = new Date(bDateObj.year, bDateObj.month - 1, bDateObj.day)
 

--- a/src/components/Section/History/Employment/Employment.test.jsx
+++ b/src/components/Section/History/Employment/Employment.test.jsx
@@ -143,8 +143,8 @@ describe('The employment section', () => {
       .instance()
       .sortEmploymentItems(props.List.items)
 
-    expect(sortedEmploymentItems[0].Item.Dates.from.year).toEqual('2014')
-    expect(sortedEmploymentItems[1].Item.Dates.from.year).toEqual('2005')
-    expect(sortedEmploymentItems[2].Item.Dates.from.year).toEqual('2000')
+    expect(sortedEmploymentItems[0].Item.Dates.to.year).toEqual('2018')
+    expect(sortedEmploymentItems[1].Item.Dates.to.year).toEqual('2007')
+    expect(sortedEmploymentItems[2].Item.Dates.to.year).toEqual('2004')
   })
 })


### PR DESCRIPTION
Fixes #1179 

This issue was reopened to resolve the miscommunication of how employment items were sorted. The employment items should sort like a resume does; with most recent employment ending date as first (or present). Reference the conversation [here](https://github.com/18F/e-QIP-prototype/issues/1179#issuecomment-445102251)

After the fix:
![screen shot 2018-12-07 at 9 41 06 am](https://user-images.githubusercontent.com/8367504/49663917-0d511c00-fa05-11e8-8c59-873e5f93c510.png)
