### PR TITLE
Fix #1036 time period addl employment overlap

### DIFF
--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -151,7 +151,7 @@ export default class DateRange extends ValidationElement {
   handleError(code, value, arr) {
     arr = arr.map(err => {
       return {
-        code: `daterange.${code}.${err.code.replace('date.', '')}`,
+        code: `${this.props.dateRangePrefix ? this.props.dateRangePrefix : 'daterange'}.${err.code.replace('date.', '')}`,
         valid: err.valid,
         uid: err.uid
       }
@@ -291,6 +291,7 @@ DateRange.defaultProps = {
   to: {},
   present: false,
   prefix: '',
+  dateRangePrefix: '',
   minDate: null,
   minDateEqualTo: false,
   maxDate: new Date(),

--- a/src/components/Form/DateRange/DateRange.test.jsx
+++ b/src/components/Form/DateRange/DateRange.test.jsx
@@ -18,6 +18,30 @@ describe('The date range component', () => {
       )
   })
 
+  it('handles custom dateRangePrefix', () => {
+    const result = []
+    const expected = {
+      name: 'input-error',
+      label: 'Text input error',
+      help: 'Helpful error message',
+      dateRangePrefix: 'customPrefix',
+      error: true,
+      focus: false,
+      valid: false,
+      present: true,
+      onError: jest.fn(() => { return this }),
+      from: {
+        date: new Date('4/1/2010')
+      },
+      to: {
+        date: new Date('1/1/2000')
+      }
+    }
+    const component = createComponent(expected)
+    expect(expected.onError.mock.calls[1][1][0].code).toContain('customPrefix')
+    expect(component.find('.to.usa-input-error').length).toBe(1)
+  })
+
   it('handles dates in reversed order', () => {
     const expected = {
       name: 'input-error',

--- a/src/components/Section/History/Employment/AdditionalActivity.jsx
+++ b/src/components/Section/History/Employment/AdditionalActivity.jsx
@@ -92,6 +92,7 @@ export default class AdditionalActivity extends ValidationElement {
                 minDateEqualTo={true}
                 dateRangePrefix="additionalActivity"
                 maxDate={this.props.employmentFromDate.date}
+                maxDateEqualTo={true}
                 allowPresent={false}
                 required={this.props.required}
               />

--- a/src/components/Section/History/Employment/AdditionalActivity.jsx
+++ b/src/components/Section/History/Employment/AdditionalActivity.jsx
@@ -90,6 +90,8 @@ export default class AdditionalActivity extends ValidationElement {
                 name="DatesEmployed"
                 bind={true}
                 minDateEqualTo={true}
+                dateRangePrefix="additionalActivity"
+                maxDate={this.props.employmentFromDate.date}
                 allowPresent={false}
                 required={this.props.required}
               />
@@ -103,6 +105,7 @@ export default class AdditionalActivity extends ValidationElement {
 
 AdditionalActivity.defaultProps = {
   List: {},
+  employmentFromDate: { date: new Date() },
   onUpdate: queue => {},
   onError: (value, arr) => {
     return arr

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -538,6 +538,7 @@ export default class EmploymentItem extends ValidationElement {
           <AdditionalActivity
             name="Additional"
             {...this.props.Additional}
+            employmentFromDate={this.props.Dates.from}
             onUpdate={this.updateAdditional}
             onError={this.props.onError}
             required={this.props.required}

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -126,6 +126,66 @@ export const error = {
       note: ''
     }
   },
+  additionalActivity: {
+    month: {
+      notfound: {
+        title: 'There is a problem with the Month',
+        message: 'The month should be between 01 (January) and 12 (December).',
+        note: ''
+      },
+      min: {
+        title: 'There is a problem with the Month',
+        message: 'The month should be between 01 (January) and 12 (December).',
+        note: ''
+      },
+      max: {
+        title: 'There is a problem with the Month',
+        message: 'The month should be between 01 (January) and 12 (December).',
+        note: ''
+      }
+    },
+    day: {
+      length: {
+        title: 'There is a problem with the Day',
+        message: 'There is not that many days in this month.',
+        note: ''
+      },
+      min: {
+        title: 'There is a problem with the Day',
+        message: 'There are not that many days in this month.',
+        note: ''
+      },
+      max: {
+        title: 'There is a problem with the Day',
+        message: 'There are not that many days in this month.',
+        note: ''
+      }
+    },
+    year: {
+      max: {
+        title: 'There is a problem with the date',
+        message: "For the **additional employment** date range, the dates should be before the main entry's **from** date.",
+        note: ''
+      },
+      min: {
+        title: 'There is a problem with the Year',
+        message: 'This year is too far in the past.',
+        note: ''
+      }
+    },
+    max: {
+      title: 'There is a problem with the date',
+      message: "For the **additional employment** date range, the dates should be before the main entry's **from** date.",
+    },
+    min: {
+      title: 'There is a problem with the date',
+      message: 'The date should be after your date of birth.'
+    },
+    required: {
+      title: 'Your response is required',
+      message: 'All parts of the date are required even if it is **estimated**.'
+    }
+  },
   date: {
     month: {
       notfound: {


### PR DESCRIPTION
Fix for #1036 Validate that Additional Activity under Employment does not overlap with the main Employment date range.