### PR TITLE
Allow opting-in to redux logger

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -19,6 +19,7 @@ Here are some of the major directories:
 
 - Use of the [React Developer Tools](https://github.com/facebook/react-devtools) and [Redux DevTools Extension](http://extension.remotedev.io/) are recommended for frontend work.
 - With the React extension, the Redux store can be inspected by running `$r.store.getState();` in your browser's JavaScript console.
+- In the development environment, you may opt in to [Logger for Redux](https://github.com/evgenyrodionov/redux-logger) by appending `?reduxLogger=true` to the url on initial load.
 
 ## Tests
 

--- a/src/services/store.js
+++ b/src/services/store.js
@@ -3,8 +3,10 @@ import rootReducer from '../reducers'
 import { createStore, applyMiddleware } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
 import { createLogger } from 'redux-logger'
+import queryString from 'query-string'
 
 const middleware = [thunk]
+const params = location.search
 
 // Creates a redux store that defines the state tree for the application.
 // See rootReducer for all sub-states.
@@ -17,7 +19,13 @@ switch (process.env.NODE_ENV) {
     store = createStore(rootReducer, applyMiddleware(...middleware))
     break
   default:
-    middleware.push(createLogger())
+    if (params) {
+      const query = queryString.parse(params)
+
+      if (query.reduxLogger === 'true') {
+        middleware.push(createLogger())
+      }
+    }
     store = createStore(
       rootReducer,
       composeWithDevTools(applyMiddleware(...middleware))


### PR DESCRIPTION
While the redux logger can be helpful, it does create a lot of noise in the console. This turns it off by default and instead allows you to opt-in with a query param in the development environment.

_*I had a PR for this once before (https://github.com/18F/e-QIP-prototype/pull/741), but it was reverted due to the fact that `URLSearchParams` was not supported in older version of IE. This uses the `query-string` package instead, which is compatible with older browsers and already being used elsewhere in the app._