### PR TITLE
 Refactor financial section to be dynamically generated

### DIFF
--- a/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
@@ -357,6 +357,9 @@ export default class Bankruptcy extends ValidationElement {
                 label={i18n.t('financial.bankruptcy.trustee.address.label')}
                 layout={Location.ADDRESS}
                 geocode={true}
+                dispatch={this.props.dispatch}
+                addressBooks={this.props.addressBooks}
+                addressBook="Court"
                 onError={this.props.onError}
                 onUpdate={this.updateTrusteeAddress}
                 required={this.props.required}

--- a/src/components/Section/Financial/Financial.jsx
+++ b/src/components/Section/Financial/Financial.jsx
@@ -9,8 +9,8 @@ import navigation from './navigation'
 import foreignNav from '../Foreign/navigation'
 
 class Financial extends SectionElement {
-  getReviewGroupProps(subsection) {
-    const props = super.getReviewGroupProps(subsection)
+  getSubsectionProps(subsection) {
+    const props = super.getSubsectionProps(subsection)
     switch (subsection.url) {
       case 'bankruptcy':
         props.addressBooks = this.props.AddressBooks

--- a/src/components/Section/Financial/Financial.jsx
+++ b/src/components/Section/Financial/Financial.jsx
@@ -4,254 +4,32 @@ import { i18n } from '../../../config'
 import { SectionViews, SectionView } from '../SectionView'
 import SectionElement from '../SectionElement'
 import AuthenticatedView from '../../../views/AuthenticatedView'
-import { Field } from '../../Form'
-import Gambling from './Gambling'
-import Bankruptcies from './Bankruptcy'
-import Taxes from './Taxes'
-import Card from './Card'
-import Credit from './Credit'
-import Delinquent from './Delinquent'
-import Nonpayment from './Nonpayment'
+import { addDividers, createPrintSubsectionViews } from '../generators'
+import navigation from './navigation'
+import foreignNav from '../Foreign/navigation'
 
 class Financial extends SectionElement {
+  getReviewGroupProps(subsection) {
+    const props = super.getReviewGroupProps(subsection)
+    switch (subsection.url) {
+      case 'bankruptcy':
+        props.addressBooks = this.props.AddressBooks
+        break
+      case 'card':
+        props.addressBooks = this.props.AddressBooks
+        break
+      case 'credit':
+        props.addressBooks = this.props.AddressBooks
+        break
+      case 'delinquent':
+        props.addressBooks = this.props.AddressBooks
+        break
+    }
+    return props
+  }
+
   render() {
-    return (
-      <div>
-        <SectionViews
-          current={this.props.subsection}
-          dispatch={this.props.dispatch}
-          update={this.props.update}>
-          <SectionView
-            name="intro"
-            back="foreign/review"
-            backLabel={i18n.t('foreign.destination.review')}
-            next="financial/bankruptcy"
-            nextLabel={i18n.t('financial.destination.bankruptcy')}>
-            <Field
-              title={i18n.t('financial.intro.title')}
-              titleSize="h2"
-              optional={true}
-              className="no-margin-bottom">
-              {i18n.m('financial.intro.body')}
-            </Field>
-          </SectionView>
-
-          <SectionView
-            name="review"
-            title={i18n.t('review.title')}
-            para={i18n.m('review.para')}
-            showTop={true}
-            back="financial/nonpayment"
-            backLabel={i18n.t('financial.destination.nonpayment')}
-            next="substance/intro"
-            nextLabel={i18n.t('substance.destination.intro')}>
-            <Bankruptcies
-              name="bankruptcy"
-              {...this.props.Bankruptcy}
-              section="financial"
-              subsection="bankruptcy"
-              addressBooks={this.props.AddressBooks}
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Bankruptcy')}
-              onError={this.handleError}
-              required={true}
-              scrollIntoView={false}
-            />
-            <hr className="section-divider" />
-            <Gambling
-              name="gambling"
-              {...this.props.Gambling}
-              section="financial"
-              subsection="gambling"
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Gambling')}
-              onError={this.handleError}
-              required={true}
-              scrollIntoView={false}
-            />
-            <hr className="section-divider" />
-            <Taxes
-              name="taxes"
-              {...this.props.Taxes}
-              section="financial"
-              subsection="taxes"
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Taxes')}
-              onError={this.handleError}
-              required={true}
-              scrollIntoView={false}
-            />
-            <hr className="section-divider" />
-            <Card
-              name="card"
-              {...this.props.Card}
-              section="financial"
-              subsection="card"
-              addressBooks={this.props.AddressBooks}
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Card')}
-              onError={this.handleError}
-              required={true}
-              scrollIntoView={false}
-            />
-            <hr className="section-divider" />
-            <Credit
-              name="credit"
-              {...this.props.Credit}
-              section="financial"
-              subsection="credit"
-              addressBooks={this.props.AddressBooks}
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Credit')}
-              onError={this.handleError}
-              required={true}
-              scrollIntoView={false}
-            />
-            <hr className="section-divider" />
-            <Delinquent
-              name="delinquent"
-              {...this.props.Delinquent}
-              section="financial"
-              subsection="delinquent"
-              addressBooks={this.props.AddressBooks}
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Delinquent')}
-              onError={this.handleError}
-              required={true}
-              scrollIntoView={false}
-            />
-            <hr className="section-divider" />
-            <Nonpayment
-              name="nonpayment"
-              {...this.props.Nonpayment}
-              section="financial"
-              subsection="nonpayment"
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Nonpayment')}
-              onError={this.handleError}
-              required={true}
-              scrollIntoView={false}
-            />
-          </SectionView>
-
-          <SectionView
-            name="bankruptcy"
-            back="financial/intro"
-            backLabel={i18n.t('financial.destination.intro')}
-            next="financial/gambling"
-            nextLabel={i18n.t('financial.destination.gambling')}>
-            <Bankruptcies
-              name="bankruptcy"
-              {...this.props.Bankruptcy}
-              addressBooks={this.props.AddressBooks}
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Bankruptcy')}
-              onError={this.handleError}
-              scrollToBottom={this.props.scrollToBottom}
-            />
-          </SectionView>
-
-          <SectionView
-            name="gambling"
-            back="financial/bankruptcy"
-            backLabel={i18n.t('financial.destination.bankruptcy')}
-            next="financial/taxes"
-            nextLabel={i18n.t('financial.destination.taxes')}>
-            <Gambling
-              name="gambling"
-              {...this.props.Gambling}
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Gambling')}
-              onError={this.handleError}
-              scrollToBottom={this.props.scrollToBottom}
-            />
-          </SectionView>
-
-          <SectionView
-            name="taxes"
-            back="financial/gambling"
-            backLabel={i18n.t('financial.destination.gambling')}
-            next="financial/card"
-            nextLabel={i18n.t('financial.destination.card')}>
-            <Taxes
-              name="taxes"
-              {...this.props.Taxes}
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Taxes')}
-              onError={this.handleError}
-              scrollToBottom={this.props.scrollToBottom}
-            />
-          </SectionView>
-
-          <SectionView
-            name="card"
-            back="financial/taxes"
-            backLabel={i18n.t('financial.destination.taxes')}
-            next="financial/credit"
-            nextLabel={i18n.t('financial.destination.credit')}>
-            <Card
-              name="card"
-              {...this.props.Card}
-              addressBooks={this.props.AddressBooks}
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Card')}
-              onError={this.handleError}
-              scrollToBottom={this.props.scrollToBottom}
-            />
-          </SectionView>
-
-          <SectionView
-            name="credit"
-            back="financial/card"
-            backLabel={i18n.t('financial.destination.card')}
-            next="financial/delinquent"
-            nextLabel={i18n.t('financial.destination.delinquent')}>
-            <Credit
-              name="credit"
-              {...this.props.Credit}
-              addressBooks={this.props.AddressBooks}
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Credit')}
-              onError={this.handleError}
-              scrollToBottom={this.props.scrollToBottom}
-            />
-          </SectionView>
-
-          <SectionView
-            name="delinquent"
-            back="financial/credit"
-            backLabel={i18n.t('financial.destination.credit')}
-            next="financial/nonpayment"
-            nextLabel={i18n.t('financial.destination.nonpayment')}>
-            <Delinquent
-              name="delinquent"
-              {...this.props.Delinquent}
-              addressBooks={this.props.AddressBooks}
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Delinquent')}
-              onError={this.handleError}
-              scrollToBottom={this.props.scrollToBottom}
-            />
-          </SectionView>
-
-          <SectionView
-            name="nonpayment"
-            back="financial/delinquent"
-            backLabel={i18n.t('financial.destination.delinquent')}
-            next="financial/review"
-            nextLabel={i18n.t('financial.destination.review')}>
-            <Nonpayment
-              name="nonpayment"
-              {...this.props.Nonpayment}
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Nonpayment')}
-              onError={this.handleError}
-              scrollToBottom={this.props.scrollToBottom}
-            />
-          </SectionView>
-        </SectionViews>
-      </div>
-    )
+    return this.createSection(navigation, 'substance', foreignNav)
   }
 }
 
@@ -284,89 +62,55 @@ Financial.defaultProps = {
 }
 
 export class FinancialSections extends React.Component {
+  getSubsectionProps(subsection) {
+    const extraProps = {
+      ...this.props[subsection.store],
+      dispatch: this.props.dispatch,
+      onError: this.props.onError
+    }
+
+    switch (subsection.url) {
+      case 'bankruptcy':
+        extraProps.addressBooks = this.props.AddressBooks
+        extraProps.defaultState = false
+        break
+      case 'gambling':
+        extraProps.defaultState = false
+        break
+      case 'taxes':
+        extraProps.defaultState = false
+        break
+      case 'card':
+        extraProps.addressBooks = this.props.AddressBooks
+        extraProps.defaultState = false
+        break
+      case 'credit':
+        extraProps.addressBooks = this.props.AddressBooks
+        extraProps.defaultState = false
+        break
+      case 'delinquent':
+        extraProps.addressBooks = this.props.AddressBooks
+        extraProps.defaultState = false
+        break
+      case 'nonpayment':
+        extraProps.defaultState = false
+        break
+    }
+
+    return extraProps
+  }
+
+  createSubsections() {
+    return createPrintSubsectionViews(navigation, subsection => {
+      return this.getSubsectionProps(subsection)
+    })
+  }
+
   render() {
-    return (
-      <div>
-        <Bankruptcies
-          name="bankruptcy"
-          {...this.props.Bankruptcy}
-          addressBooks={this.props.AddressBooks}
-          dispatch={this.props.dispatch}
-          onError={this.props.onError}
-          defaultState={false}
-          required={true}
-          scrollIntoView={false}
-        />
-        <hr className="section-divider" />
-        <Gambling
-          name="gambling"
-          {...this.props.Gambling}
-          dispatch={this.props.dispatch}
-          onError={this.props.onError}
-          defaultState={false}
-          required={true}
-          scrollIntoView={false}
-        />
+    const components = addDividers(this.createSubsections())
 
-        <hr className="section-divider" />
-        <Taxes
-          name="taxes"
-          {...this.props.Taxes}
-          dispatch={this.props.dispatch}
-          onError={this.props.onError}
-          defaultState={false}
-          required={true}
-          scrollIntoView={false}
-        />
-
-        <hr className="section-divider" />
-        <Card
-          name="card"
-          {...this.props.Card}
-          addressBooks={this.props.AddressBooks}
-          dispatch={this.props.dispatch}
-          onError={this.props.onError}
-          defaultState={false}
-          required={true}
-          scrollIntoView={false}
-        />
-
-        <hr className="section-divider" />
-        <Credit
-          name="credit"
-          {...this.props.Credit}
-          addressBooks={this.props.AddressBooks}
-          dispatch={this.props.dispatch}
-          onError={this.props.onError}
-          defaultState={false}
-          required={true}
-          scrollIntoView={false}
-        />
-
-        <hr className="section-divider" />
-        <Delinquent
-          name="delinquent"
-          {...this.props.Delinquent}
-          addressBooks={this.props.AddressBooks}
-          dispatch={this.props.dispatch}
-          onError={this.props.onError}
-          defaultState={false}
-          required={true}
-          scrollIntoView={false}
-        />
-
-        <hr className="section-divider" />
-        <Nonpayment
-          name="nonpayment"
-          {...this.props.Nonpayment}
-          dispatch={this.props.dispatch}
-          onError={this.props.onError}
-          defaultState={false}
-          required={true}
-          scrollIntoView={false}
-        />
-      </div>
-    )
+    return <div>{components}</div>
   }
 }
+
 export default connect(mapStateToProps)(AuthenticatedView(Financial))

--- a/src/components/Section/Financial/Financial.test.jsx
+++ b/src/components/Section/Financial/Financial.test.jsx
@@ -1,14 +1,22 @@
 import React from 'react'
-import MockAdapter from 'axios-mock-adapter'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import { Provider } from 'react-redux'
-import Financial from './Financial'
+import Financial, { FinancialSections } from './Financial'
 import { mount } from 'enzyme'
+import { testSnapshot } from '../../test-helpers'
 
 const applicationState = {
   Financial: {}
 }
+
+// give a fake GUID so the field IDs don't differ between snapshots
+// https://github.com/facebook/jest/issues/936#issuecomment-404246102
+jest.mock('../../Form/ValidationElement/helpers', () =>
+  Object.assign(require.requireActual('../../Form/ValidationElement/helpers'), {
+    newGuid: jest.fn().mockReturnValue('MOCK-GUID')
+  })
+)
 
 describe('The financial section', () => {
   // Setup
@@ -73,5 +81,9 @@ describe('The financial section', () => {
       )
       expect(component.find('div').length).toBeGreaterThan(0)
     })
+  })
+
+  it('renders the FinancialSections component', () => {
+    testSnapshot(<FinancialSections />)
   })
 })

--- a/src/components/Section/Financial/__snapshots__/Financial.test.jsx.snap
+++ b/src/components/Section/Financial/__snapshots__/Financial.test.jsx.snap
@@ -1,0 +1,1139 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The financial section renders the FinancialSections component 1`] = `
+<div>
+  <div
+    className="section-content bankruptcies"
+    data-section="financial"
+    data-subsection="bankruptcy"
+  >
+    <div
+      aria-label="In the last seven (7) years have you filed a petition under any chapter of the bankruptcy code?"
+      className="field required  branch bankruptcy-branch"
+      data-uuid="field-MOCK-GUID"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
+      />
+      <h2
+        className="title h2"
+      >
+        In the last seven (7) years have you filed a petition under any chapter of the bankruptcy code?
+      </h2>
+      <span
+        className="icon"
+      >
+        <a
+          aria-label="Show help for In the last seven (7) years have you filed a petition under any chapter of the bankruptcy code?"
+          className="toggle h2  adjust-for-buttons"
+          href="javascript:;"
+          onClick={[Function]}
+          title="Show help for In the last seven (7) years have you filed a petition under any chapter of the bankruptcy code?"
+        >
+          <svg
+            alt="Scalable vector graphic"
+            focusable="false"
+            height="14.57px"
+            tabIndex="-1"
+            viewBox="0 0 14.57 14.57"
+            width="14.57px"
+          >
+            <g>
+              <path
+                className="eapp-help-icon"
+                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+              />
+            </g>
+          </svg>
+        </a>
+      </span>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error usa-alert usa-alert-error"
+            role="alert"
+          >
+            <div
+              className="usa-alert-body"
+            >
+              <div
+                data-i18n="error.required"
+              >
+                <h5
+                  className="usa-alert-heading"
+                >
+                  Your response is required
+                </h5>
+                
+                
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component shrink"
+          >
+            <div
+              className="content"
+            />
+            <div
+              className="blocks option-list branch usa-input-error"
+            >
+              <div
+                className="yes block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_bankruptcydebt-MOCK-GUID"
+                >
+                  <input
+                    aria-label="Yes for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_bankruptcydebt-MOCK-GUID"
+                    name="has_bankruptcydebt-MOCK-GUID"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="Yes"
+                  />
+                  <span>
+                    Yes
+                  </span>
+                </label>
+              </div>
+              <div
+                className="no block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_bankruptcydebt-MOCK-GUID"
+                >
+                  <input
+                    aria-label="No for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_bankruptcydebt-MOCK-GUID"
+                    name="has_bankruptcydebt-MOCK-GUID"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="No"
+                  />
+                  <span>
+                    No
+                  </span>
+                </label>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="section-divider"
+  />
+  <div
+    className="section-content gambling"
+    data-section="financial"
+    data-subsection="gambling"
+  >
+    <div
+      aria-label="Have you ever experienced financial problems due to gambling?"
+      className="field required  branch has-gambling-debt"
+      data-uuid="field-MOCK-GUID"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
+      />
+      <h2
+        className="title h2"
+      >
+        Have you ever experienced financial problems due to gambling?
+      </h2>
+      <span
+        className="icon"
+      />
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error usa-alert usa-alert-error"
+            role="alert"
+          >
+            <div
+              className="usa-alert-body"
+            >
+              <div
+                data-i18n="error.required"
+              >
+                <h5
+                  className="usa-alert-heading"
+                >
+                  Your response is required
+                </h5>
+                
+                
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component shrink"
+          >
+            <div
+              className="content"
+            />
+            <div
+              className="blocks option-list branch usa-input-error"
+            >
+              <div
+                className="yes block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_gamblingdebt-MOCK-GUID"
+                >
+                  <input
+                    aria-label="Yes for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_gamblingdebt-MOCK-GUID"
+                    name="has_gamblingdebt-MOCK-GUID"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="Yes"
+                  />
+                  <span>
+                    Yes
+                  </span>
+                </label>
+              </div>
+              <div
+                className="no block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_gamblingdebt-MOCK-GUID"
+                >
+                  <input
+                    aria-label="No for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_gamblingdebt-MOCK-GUID"
+                    name="has_gamblingdebt-MOCK-GUID"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="No"
+                  />
+                  <span>
+                    No
+                  </span>
+                </label>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="section-divider"
+  />
+  <div
+    className="section-content taxes"
+    data-section="financial"
+    data-subsection="taxes"
+  >
+    <div
+      aria-label="In the last seven (7) years have you failed to file or pay Federal, state, or other taxes when required by law or ordinance?"
+      className="field required  branch taxes-branch"
+      data-uuid="field-MOCK-GUID"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
+      />
+      <h2
+        className="title h2"
+      >
+        In the last seven (7) years have you failed to file or pay Federal, state, or other taxes when required by law or ordinance?
+      </h2>
+      <span
+        className="icon"
+      />
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error usa-alert usa-alert-error"
+            role="alert"
+          >
+            <div
+              className="usa-alert-body"
+            >
+              <div
+                data-i18n="error.required"
+              >
+                <h5
+                  className="usa-alert-heading"
+                >
+                  Your response is required
+                </h5>
+                
+                
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component shrink"
+          >
+            <div
+              className="content"
+            />
+            <div
+              className="blocks option-list branch usa-input-error"
+            >
+              <div
+                className="yes block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_taxes-MOCK-GUID"
+                >
+                  <input
+                    aria-label="Yes for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_taxes-MOCK-GUID"
+                    name="has_taxes-MOCK-GUID"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="Yes"
+                  />
+                  <span>
+                    Yes
+                  </span>
+                </label>
+              </div>
+              <div
+                className="no block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_taxes-MOCK-GUID"
+                >
+                  <input
+                    aria-label="No for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_taxes-MOCK-GUID"
+                    name="has_taxes-MOCK-GUID"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="No"
+                  />
+                  <span>
+                    No
+                  </span>
+                </label>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="section-divider"
+  />
+  <div
+    className="section-content card-abuse"
+    data-section="financial"
+    data-subsection="card"
+  >
+    <div
+      aria-label="In the last seven (7) years have you been counseled, warned, or disciplined for violating the terms of agreement for your travel or credit card provided by your employer?"
+      className="field required  branch card-branch"
+      data-uuid="field-MOCK-GUID"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
+      />
+      <h2
+        className="title h2"
+      >
+        In the last seven (7) years have you been counseled, warned, or disciplined for violating the terms of agreement for your travel or credit card provided by your employer?
+      </h2>
+      <span
+        className="icon"
+      />
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error usa-alert usa-alert-error"
+            role="alert"
+          >
+            <div
+              className="usa-alert-body"
+            >
+              <div
+                data-i18n="error.required"
+              >
+                <h5
+                  className="usa-alert-heading"
+                >
+                  Your response is required
+                </h5>
+                
+                
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component shrink"
+          >
+            <div
+              className="content"
+            />
+            <div
+              className="blocks option-list branch usa-input-error"
+            >
+              <div
+                className="yes block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_cardabuse-MOCK-GUID"
+                >
+                  <input
+                    aria-label="Yes for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_cardabuse-MOCK-GUID"
+                    name="has_cardabuse-MOCK-GUID"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="Yes"
+                  />
+                  <span>
+                    Yes
+                  </span>
+                </label>
+              </div>
+              <div
+                className="no block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_cardabuse-MOCK-GUID"
+                >
+                  <input
+                    aria-label="No for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_cardabuse-MOCK-GUID"
+                    name="has_cardabuse-MOCK-GUID"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="No"
+                  />
+                  <span>
+                    No
+                  </span>
+                </label>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="section-divider"
+  />
+  <div
+    className="section-content credit-counseling"
+    data-section="financial"
+    data-subsection="credit"
+  >
+    <div
+      aria-label="Are you currently utilizing, or seeking assistance from, a credit counseling service or other similar resource to resolve your financial difficulties?"
+      className="field required  branch credit-branch"
+      data-uuid="field-MOCK-GUID"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
+      />
+      <h2
+        className="title h2"
+      >
+        Are you currently utilizing, or seeking assistance from, a credit counseling service or other similar resource to resolve your financial difficulties?
+      </h2>
+      <span
+        className="icon"
+      />
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error usa-alert usa-alert-error"
+            role="alert"
+          >
+            <div
+              className="usa-alert-body"
+            >
+              <div
+                data-i18n="error.required"
+              >
+                <h5
+                  className="usa-alert-heading"
+                >
+                  Your response is required
+                </h5>
+                
+                
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component shrink"
+          >
+            <div
+              className="content"
+            />
+            <div
+              className="blocks option-list branch usa-input-error"
+            >
+              <div
+                className="yes block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_credit-MOCK-GUID"
+                >
+                  <input
+                    aria-label="Yes for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_credit-MOCK-GUID"
+                    name="has_credit-MOCK-GUID"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="Yes"
+                  />
+                  <span>
+                    Yes
+                  </span>
+                </label>
+              </div>
+              <div
+                className="no block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_credit-MOCK-GUID"
+                >
+                  <input
+                    aria-label="No for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_credit-MOCK-GUID"
+                    name="has_credit-MOCK-GUID"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="No"
+                  />
+                  <span>
+                    No
+                  </span>
+                </label>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="section-divider"
+  />
+  <div
+    className="section-content delinquent"
+    data-section="financial"
+    data-subsection="delinquent"
+  >
+    <div
+      aria-label="Other than previously listed, have any of the following happened to you?"
+      className="field required  branch delinquent-branch eapp-field-wrap"
+      data-uuid="field-MOCK-GUID"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
+      />
+      <h2
+        className="title h2"
+      >
+        Other than previously listed, have any of the following happened to you?
+      </h2>
+      <span
+        className="icon"
+      />
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error usa-alert usa-alert-error"
+            role="alert"
+          >
+            <div
+              className="usa-alert-body"
+            >
+              <div
+                data-i18n="error.required"
+              >
+                <h5
+                  className="usa-alert-heading"
+                >
+                  Your response is required
+                </h5>
+                
+                
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component shrink"
+          >
+            <div
+              className="content"
+            >
+              <div>
+                <p>
+                  You will be asked to provide details about each financial obligation that pertains to the items identified below.
+                </p>
+              </div>
+              <ul>
+                <li>
+                  <div>
+                    <p>
+                      <strong>
+                        In the last seven (7) years,
+                      </strong>
+                       you have been delinquent on alimony or child support payments.
+                    </p>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <p>
+                      <strong>
+                        In the last seven (7) years,
+                      </strong>
+                       you had a judgement entered against you. (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                    </p>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <p>
+                      <strong>
+                        In the last seven (7) years,
+                      </strong>
+                       you had a lien placed against your property for failing to pay taxes or other debts. (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                    </p>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <p>
+                      You are currently delinquent on any Federal debt. (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                    </p>
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <div
+              className="blocks option-list branch usa-input-error"
+            >
+              <div
+                className="yes block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_delinquent-MOCK-GUID"
+                >
+                  <input
+                    aria-label="Yes for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_delinquent-MOCK-GUID"
+                    name="has_delinquent-MOCK-GUID"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="Yes"
+                  />
+                  <span>
+                    Yes
+                  </span>
+                </label>
+              </div>
+              <div
+                className="no block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_delinquent-MOCK-GUID"
+                >
+                  <input
+                    aria-label="No for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_delinquent-MOCK-GUID"
+                    name="has_delinquent-MOCK-GUID"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="No"
+                  />
+                  <span>
+                    No
+                  </span>
+                </label>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="section-divider"
+  />
+  <div
+    className="section-content nonpayment"
+    data-section="financial"
+    data-subsection="nonpayment"
+  >
+    <div
+      aria-label="Other than previously listed, have any of the following happened?"
+      className="field required  branch nonpayment-branch"
+      data-uuid="field-MOCK-GUID"
+    >
+      <a
+        aria-hidden="true"
+        className="anchor"
+        id="field-MOCK-GUID"
+        name="field-MOCK-GUID"
+      />
+      <h2
+        className="title h2"
+      >
+        Other than previously listed, have any of the following happened?
+      </h2>
+      <span
+        className="icon"
+      />
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages help-messages"
+        />
+      </div>
+      <div
+        className="table expand"
+      >
+        <span
+          aria-live="polite"
+          className="messages error-messages"
+          role="alert"
+        >
+          <div
+            aria-live="polite"
+            className="message error usa-alert usa-alert-error"
+            role="alert"
+          >
+            <div
+              className="usa-alert-body"
+            >
+              <div
+                data-i18n="error.required"
+              >
+                <h5
+                  className="usa-alert-heading"
+                >
+                  Your response is required
+                </h5>
+                
+                
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+      <div
+        className="table"
+      >
+        <span
+          className="content"
+        >
+          <span
+            className="component shrink"
+          >
+            <div
+              className="content"
+            >
+              <ul>
+                <li>
+                  <div>
+                    <p>
+                      <strong>
+                        In the last seven (7) years,
+                      </strong>
+                       you had any possessions or property voluntarily or involuntarily repossessed or foreclosed? (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                    </p>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <p>
+                      <strong>
+                        In the last seven (7) years,
+                      </strong>
+                       you defaulted on any type of loan? (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                    </p>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <p>
+                      <strong>
+                        In the last seven (7) years,
+                      </strong>
+                       you had bills or debts turned over to a collection agency? (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                    </p>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <p>
+                      <strong>
+                        In the last seven (7) years,
+                      </strong>
+                       you had any account or credit card suspended, charged off, or cancelled for failing to pay as agreed? (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                    </p>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <p>
+                      <strong>
+                        In the last seven (7) years,
+                      </strong>
+                       you were evicted for non-payment?
+                    </p>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <p>
+                      <strong>
+                        In the last seven (7) years,
+                      </strong>
+                       you had your wages, benefits, or assets garnished or attached for any reason?
+                    </p>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <p>
+                      <strong>
+                        In the last seven (7) years,
+                      </strong>
+                       you have been over 120 days delinquent on any debt not previously entered? (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                    </p>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <p>
+                      You are currently over 120 days delinquent on any debt? (Include financial obligations for which you were the sole debtor, as well as those for which you were a cosigner or guarantor).
+                    </p>
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <div
+              className="blocks option-list branch usa-input-error"
+            >
+              <div
+                className="yes block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_nonpayment-MOCK-GUID"
+                >
+                  <input
+                    aria-label="Yes for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_nonpayment-MOCK-GUID"
+                    name="has_nonpayment-MOCK-GUID"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="Yes"
+                  />
+                  <span>
+                    Yes
+                  </span>
+                </label>
+              </div>
+              <div
+                className="no block"
+              >
+                <label
+                  className=""
+                  htmlFor="has_nonpayment-MOCK-GUID"
+                >
+                  <input
+                    aria-label="No for null"
+                    checked={false}
+                    className="usa-input-success"
+                    disabled={false}
+                    id="has_nonpayment-MOCK-GUID"
+                    name="has_nonpayment-MOCK-GUID"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    type="radio"
+                    value="No"
+                  />
+                  <span>
+                    No
+                  </span>
+                </label>
+              </div>
+            </div>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Section/Financial/subsections.js
+++ b/src/components/Section/Financial/subsections.js
@@ -1,0 +1,19 @@
+import Bankruptcy from './Bankruptcy'
+import Card from './Card'
+import Credit from './Credit'
+import Delinquent from './Delinquent'
+import Gambling from './Gambling'
+import Nonpayment from './Nonpayment'
+import Taxes from './Taxes'
+
+const storeToComponentMap = {
+  Bankruptcy,
+  Card,
+  Credit,
+  Delinquent,
+  Gambling,
+  Nonpayment,
+  Taxes
+}
+
+export default storeToComponentMap

--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -7,8 +7,8 @@ import { addDividers, createPrintSubsectionViews } from '../generators'
 import navigation from './navigation'
 
 class Identification extends SectionElement {
-  getReviewGroupProps(subsection) {
-    const props = super.getReviewGroupProps(subsection)
+  getSubsectionProps(subsection) {
+    const props = super.getSubsectionProps(subsection)
     if (subsection.url === 'contacts') {
       props.shouldFilterEmptyItems = true
     }

--- a/src/components/Section/SectionElement.jsx
+++ b/src/components/Section/SectionElement.jsx
@@ -32,6 +32,7 @@ export default class SectionElement extends React.Component {
     this.props.dispatch(updateApplication(this.props.store, field, values))
   }
 
+  // meant to be overridden
   getSubsectionProps(subsection) {
     return {
       ...this.props[subsection.store],
@@ -41,14 +42,9 @@ export default class SectionElement extends React.Component {
     }
   }
 
-  // meant to be overridden
-  getReviewGroupProps(subsection) {
-    return this.getSubsectionProps(subsection)
-  }
-
   createReviewGroups(navigation) {
     return createReviewGroups(navigation, subsection => {
-      return this.getReviewGroupProps(subsection)
+      return this.getSubsectionProps(subsection)
     })
   }
 

--- a/src/components/Section/SectionElement.jsx
+++ b/src/components/Section/SectionElement.jsx
@@ -81,8 +81,8 @@ export default class SectionElement extends React.Component {
     })
   }
 
-  createSection(navigation, nextSection) {
-    const introSubsection = createIntroSubsection(this.props.section)
+  createSection(navigation, nextSection, prevSection = undefined) {
+    const introSubsection = createIntroSubsection(navigation, prevSection)
     const sectionViews = this.createSectionViews(navigation)
     const reviewSubsection = this.createReviewSubsection(
       navigation,

--- a/src/components/Section/generators.jsx
+++ b/src/components/Section/generators.jsx
@@ -79,18 +79,31 @@ export const addDividers = components => {
   return componentsWithDividers
 }
 
-export const createIntroSubsection = section => {
+export const createIntroSubsection = (section, prevSection = undefined) => {
+  const nextSubsection = section.subsections[1]
+
+  const backProps = {}
+  if (prevSection) {
+    const numPrevSubsections = prevSection.subsections.length
+    const prevSubsection = prevSection.subsections[numPrevSubsections - 1]
+    backProps.back = `${prevSection.url}/${prevSubsection.url}`
+    backProps.backLabel = i18n.t(
+      `${prevSection.url}.destination.${prevSubsection.url}`
+    )
+  }
+
   return (
     <SectionView
       name="intro"
-      next={`${section}/name`}
-      nextLabel={i18n.t(`${section}.destination.name`)}>
+      {...backProps}
+      next={`${section.url}/${nextSubsection.url}`}
+      nextLabel={i18n.t(`${section.url}.destination.${nextSubsection.url}`)}>
       <Field
-        title={i18n.t(`${section}.intro.title`)}
+        title={i18n.t(`${section.url}.intro.title`)}
         titleSize="h2"
         optional={true}
         className="no-margin-bottom">
-        {i18n.m(`${section}.intro.body`)}
+        {i18n.m(`${section.url}.intro.body`)}
       </Field>
     </SectionView>
   )

--- a/src/components/Section/generators.jsx
+++ b/src/components/Section/generators.jsx
@@ -4,10 +4,12 @@ import { Field } from '../Form'
 import { SectionView } from './SectionView'
 
 import identification from './Identification/subsections'
+import financial from './Financial/subsections'
 
 // section name (lower case) -> subsection store name -> subsection component
 const componentsBySectionAndStore = {
-  identification
+  identification,
+  financial
 }
 
 export const getComponentByName = (storeToComponentMap, name) => {


### PR DESCRIPTION
Partially addresses https://github.com/18F/e-QIP-prototype/issues/614

Picking up from Aidan's work on https://github.com/18F/e-QIP-prototype/pull/616, this completes the transition of the Financial section into a dynamically generated section similar to Identification. I kept all of the relevant changes to a single commit for easier reference of the required for the other sections, and plan to continue refactoring them in followup PRs and/or provide documentation on the required changes. I think know that I know the process, the others should move more quickly.