### PR TITLE
Date range validating too early

### DIFF
--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -28,6 +28,7 @@ class DateControl extends ValidationElement {
       month: props.hideMonth ? '1' : props.month,
       day: props.hideDay ? '1' : props.day,
       year: props.year,
+      touched: props.month >= 1 && props.day >= 1 && props.year >= 1,
       errors: []
     }
 
@@ -74,16 +75,17 @@ class DateControl extends ValidationElement {
     this.setState(updates)
   }
 
-  update(el, year, month, day, estimated) {
+  update(el, year, month, day, estimated, touched) {
     const changed = {
       year: year !== this.state.year,
       month: month !== this.state.month,
       day: day !== this.state.day,
-      estimated: estimated !== this.state.estimated
+      estimated: estimated !== this.state.estimated,
+      touched: touched !== this.state.touched
     }
 
     this.setState(
-      { month: month, day: day, year: year, estimated: estimated },
+      { month: month, day: day, year: year, estimated: estimated, touched: touched },
       () => {
         // Estimate touches the day so we need to toggle focus
         const toggleForEstimation = changed.estimated
@@ -106,12 +108,16 @@ class DateControl extends ValidationElement {
           )
         }
 
+        // Only mark this date control touched when all 3 parts of the date are set
+        const touched = month >= 1 && day >= 1 && year >= 1
+
         this.props.onUpdate({
           name: this.props.name,
           month: `${month}`,
           day: `${day}`,
           year: `${year}`,
-          estimated: estimated
+          estimated: estimated,
+          touched: touched
         })
       }
     )
@@ -123,7 +129,8 @@ class DateControl extends ValidationElement {
       this.state.year,
       values.value,
       this.state.day,
-      this.state.estimated
+      this.state.estimated,
+      this.state.touched
     )
   }
 
@@ -133,7 +140,8 @@ class DateControl extends ValidationElement {
       this.state.year,
       this.state.month,
       values.value,
-      this.state.estimated
+      this.state.estimated,
+      this.state.touched
     )
   }
 
@@ -143,7 +151,8 @@ class DateControl extends ValidationElement {
       values.value,
       this.state.month,
       this.state.day,
-      this.state.estimated
+      this.state.estimated,
+      this.state.touched
     )
   }
 
@@ -153,7 +162,8 @@ class DateControl extends ValidationElement {
       this.state.year,
       this.state.month,
       this.state.day,
-      values.checked
+      values.checked,
+      this.state.touched
     )
   }
 

--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -28,7 +28,7 @@ class DateControl extends ValidationElement {
       month: props.hideMonth ? '1' : props.month,
       day: props.hideDay ? '1' : props.day,
       year: props.year,
-      touched: props.month >= 1 && props.day >= 1 && props.year >= 1,
+      touched: this.isTouched(props.year, props.month, props.day),
       errors: []
     }
 
@@ -45,6 +45,10 @@ class DateControl extends ValidationElement {
     this.updateEstimated = this.updateEstimated.bind(this)
     this.handleDisable = this.handleDisable.bind(this)
     this.errors = []
+  }
+
+  isTouched(year, month, day) {
+    return month >= 1 && day >= 1 && year >= 1
   }
 
   componentWillReceiveProps(next) {
@@ -108,16 +112,13 @@ class DateControl extends ValidationElement {
           )
         }
 
-        // Only mark this date control touched when all 3 parts of the date are set
-        const touched = month >= 1 && day >= 1 && year >= 1
-
         this.props.onUpdate({
           name: this.props.name,
           month: `${month}`,
           day: `${day}`,
           year: `${year}`,
           estimated: estimated,
-          touched: touched
+          touched: touched || this.isTouched(year, month, day)
         })
       }
     )

--- a/src/components/Form/DateControl/DateControl.test.jsx
+++ b/src/components/Form/DateControl/DateControl.test.jsx
@@ -5,6 +5,67 @@ import { DateControl } from './DateControl'
 describe('The date component', () => {
   const children = 4
 
+  it('incomplete dates do not count as touched', () => {
+    const tests = [
+      {
+        name: 'input-error',
+        label: 'DateControl input error',
+        disabled: false,
+        error: true,
+        focus: false,
+        valid: false,
+        month: '1',
+        day: '24',
+        year: ''
+      },
+      {
+        name: 'input-error',
+        label: 'DateControl input error',
+        disabled: false,
+        error: true,
+        focus: false,
+        valid: false,
+        month: '1',
+        day: '',
+        year: '2001'
+      },
+      {
+        name: 'input-error',
+        label: 'DateControl input error',
+        disabled: false,
+        error: true,
+        focus: false,
+        valid: false,
+        month: '',
+        day: '2',
+        year: '2002'
+      }
+    ]
+
+    tests.forEach(expected => {
+      const component = mount(<DateControl {...expected} />)
+      component.first('input').simulate('change')
+      expect(component.state('touched')).toBe(false)
+    })
+  })
+
+  it('updates touched when dates are set', () => {
+    const expected = {
+      name: 'input-error',
+      label: 'DateControl input error',
+      disabled: false,
+      error: true,
+      focus: false,
+      valid: false,
+      month: '1',
+      day: '24',
+      year: '2000'
+    }
+    const component = mount(<DateControl {...expected} />)
+    component.find('.year input').simulate('change')
+    expect(component.state('touched')).toBe(true)
+  })
+
   it('renders appropriately with an error', () => {
     const expected = {
       name: 'input-error',

--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -10,11 +10,11 @@ import DateRangeValidator from '../../../validators/daterange'
 export default class DateRange extends ValidationElement {
   constructor(props) {
     super(props)
-
+    const touched = this.isTouched(props.to.year, props.to.month, props.to.day) || this.isTouched(props.from.year, props.from.month, props.from.day)
     this.state = {
       uid: `${this.props.name}-${super.guid()}`,
-      from: props.from,
-      to: props.to,
+      from: {...props.from, touched: touched},
+      to: {...props.to, touched: touched},
       present: props.present,
       presentClicked: false,
       title: props.title || 'Date Range',
@@ -32,6 +32,10 @@ export default class DateRange extends ValidationElement {
     this.handleErrorPresent = this.handleErrorPresent.bind(this)
     this.handleDisable = this.handleDisable.bind(this)
     this.errors = []
+  }
+
+  isTouched(year, month, day) {
+    return year != '' && month != '' && day != '' && month >= 1 && day >= 1 && year >= 1
   }
 
   componentWillReceiveProps(nextProps) {
@@ -59,8 +63,8 @@ export default class DateRange extends ValidationElement {
   update(queue) {
     this.props.onUpdate({
       name: this.props.name,
-      from: this.state.from,
-      to: this.state.to,
+      from: {...this.state.from, touched: true},
+      to: {...this.state.to, touched: true},
       present: this.state.present,
       ...queue
     })

--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -307,10 +307,7 @@ DateRange.errors = [
     code: 'required',
     func: (value, props) => {
       if (props.required && !props.disabled) {
-        const hasParts = dateObj => {
-          return validDate(dateObj)
-        }
-        return hasParts(value.from) && hasParts(value.to)
+        return validDate(value.from) && validDate(value.to)
       }
       return true
     }

--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -3,9 +3,9 @@ import ValidationElement from '../ValidationElement'
 import DateControl from '../DateControl'
 import Checkbox from '../Checkbox'
 import Svg from '../Svg'
-import { now } from '../../Section/History/dateranges'
 import Show from '../Show'
-import { extractDate, validDate } from '../../Section/History/dateranges'
+import { now, extractDate, validDate } from '../../Section/History/dateranges'
+import DateRangeValidator from '../../../validators/daterange'
 
 export default class DateRange extends ValidationElement {
   constructor(props) {
@@ -67,12 +67,14 @@ export default class DateRange extends ValidationElement {
   }
 
   updateFrom(values) {
+    values.touched = true
     this.setState({ from: values, presentClicked: false }, () => {
       this.update({ from: values })
     })
   }
 
   updateTo(values) {
+    values.touched = true
     this.setState({ to: values, presentClicked: false }, () => {
       this.update({ to: values })
     })
@@ -285,8 +287,12 @@ export default class DateRange extends ValidationElement {
 }
 
 DateRange.defaultProps = {
-  from: {},
-  to: {},
+  from: {
+    touched: false
+  },
+  to: {
+    touched: false
+  },
   present: false,
   prefix: '',
   dateRangePrefix: '',
@@ -318,7 +324,7 @@ DateRange.errors = [
       if (!props.from || !props.to) {
         return null
       }
-      return extractDate(props.from) <= extractDate(props.to)
+      return new DateRangeValidator(props).isValid()
     }
   }
 ]

--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -67,14 +67,12 @@ export default class DateRange extends ValidationElement {
   }
 
   updateFrom(values) {
-    values.touched = true
     this.setState({ from: values, presentClicked: false }, () => {
       this.update({ from: values })
     })
   }
 
   updateTo(values) {
-    values.touched = true
     this.setState({ to: values, presentClicked: false }, () => {
       this.update({ to: values })
     })

--- a/src/components/Form/DateRange/DateRange.test.jsx
+++ b/src/components/Form/DateRange/DateRange.test.jsx
@@ -76,7 +76,7 @@ describe('The date range component', () => {
     expect(component.find('.to.usa-input-error').length).toBe(1)
   })
 
-  it('does not validate date order before dates are touched', () => {
+  it('does validate date order before dates are touched', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
@@ -87,9 +87,35 @@ describe('The date range component', () => {
       present: true,
       from: {
         day: '1',
-        month: '4',
+        month: '1',
         year: '2010',
         touched: true
+      },
+      to: {
+        day: '',
+        month: '',
+        year: '',
+        touched: true
+      }
+    }
+    const component = createComponent(expected)
+    expect(component.find('.to.usa-input-error').length).toBe(1)
+  })
+
+  it('does not validate date order before dates are touched', () => {
+    const expected = {
+      name: 'input-error',
+      label: 'Text input error',
+      help: 'Helpful error message',
+      error: true,
+      focus: false,
+      valid: false,
+      present: true,
+      from: {
+        day: '',
+        month: '',
+        year: '',
+        touched: false
       },
       to: {
         day: '',

--- a/src/components/Form/DateRange/DateRange.test.jsx
+++ b/src/components/Form/DateRange/DateRange.test.jsx
@@ -35,12 +35,14 @@ describe('The date range component', () => {
       from: {
         day: '1',
         month: '4',
-        year: '2010'
+        year: '2010',
+        touched: true
       },
       to: {
         day: '1',
         month: '1',
-        year: '2000'
+        year: '2000',
+        touched: true
       }
     }
     const component = createComponent(expected)
@@ -60,16 +62,44 @@ describe('The date range component', () => {
       from: {
         day: '1',
         month: '4',
-        year: '2010'
+        year: '2010',
+        touched: true
       },
       to: {
         day: '1',
         month: '1',
-        year: '2000'
+        year: '2000',
+        touched: true
       }
     }
     const component = createComponent(expected)
     expect(component.find('.to.usa-input-error').length).toBe(1)
+  })
+
+  it('does not validate date order before dates are touched', () => {
+    const expected = {
+      name: 'input-error',
+      label: 'Text input error',
+      help: 'Helpful error message',
+      error: true,
+      focus: false,
+      valid: false,
+      present: true,
+      from: {
+        day: '1',
+        month: '4',
+        year: '2010',
+        touched: true
+      },
+      to: {
+        day: '',
+        month: '',
+        year: '',
+        touched: false
+      }
+    }
+    const component = createComponent(expected)
+    expect(component.find('.to.usa-input-error').length).toBe(0)
   })
 
   it('loads data', () => {

--- a/src/validators/daterange.js
+++ b/src/validators/daterange.js
@@ -19,6 +19,10 @@ export default class DateRangeValidator {
    * Validates the date ranges
    */
   isValid() {
+    if (!this.from.touched || !this.to.touched) {
+      return true
+    }
+
     if (!new DateControlValidator(this.from).validDate()) {
       return false
     }

--- a/src/validators/daterange.js
+++ b/src/validators/daterange.js
@@ -15,11 +15,15 @@ export default class DateRangeValidator {
     this.present = data.present
   }
 
+  hasNotBeenTouched(date) {
+    return date && date.touched !== undefined && date.touched !== null && !date.touched
+  }
+
   /**
    * Validates the date ranges
    */
   isValid() {
-    if (!this.from.touched || !this.to.touched) {
+    if (this.hasNotBeenTouched(this.from) || this.hasNotBeenTouched(this.to)) {
       return true
     }
 

--- a/src/validators/daterange.test.js
+++ b/src/validators/daterange.test.js
@@ -1,19 +1,21 @@
 import DateRangeValidator from './daterange'
 
 describe('Date range validator', function() {
-  it('should validate date ranges', function() {
+  it('allows date ranges that are not touched', function() {
     const tests = [
       {
         data: {
           from: {
             month: '1',
             day: '1',
-            year: '2010'
+            year: '2010',
+            touched: true
           },
           to: {
             month: '1',
             day: '1',
-            year: '2012'
+            year: '2012',
+            touched: true
           },
           present: false
         },
@@ -24,20 +26,90 @@ describe('Date range validator', function() {
           from: {
             month: '1',
             day: '1',
-            year: '2010'
+            year: '2010',
+            touched: true
           },
           to: {},
+          present: false
+        },
+        expected: true
+      },
+      {
+        data: {
+          from: {
+            month: '',
+            day: '',
+            year: '',
+            touched: true
+          },
+          to: {
+            month: '1',
+            day: '1',
+            year: '2010',
+            touched: true
+          },
+          present: false
+        },
+        expected: false
+      }
+    ]
+
+    tests.forEach(test => {
+      expect(new DateRangeValidator(test.data).isValid()).toBe(test.expected)
+    })
+  })
+
+  it('should validate date ranges', function() {
+    const tests = [
+      {
+        data: {
+          from: {
+            month: '1',
+            day: '1',
+            year: '2010',
+            touched: true
+          },
+          to: {
+            month: '1',
+            day: '1',
+            year: '2012',
+            touched: true
+          },
+          present: false
+        },
+        expected: true
+      },
+      {
+        data: {
+          from: {
+            month: '1',
+            day: '1',
+            year: '2010',
+            touched: true
+          },
+          to: {
+            month: '',
+            day: '',
+            year: '',
+            touched: true
+          },
           present: false
         },
         expected: false
       },
       {
         data: {
-          from: {},
+          from: {
+            month: '',
+            day: '',
+            year: '',
+            touched: true
+          },
           to: {
             month: '1',
             day: '1',
-            year: '2010'
+            year: '2010',
+            touched: true
           },
           present: false
         },
@@ -48,12 +120,14 @@ describe('Date range validator', function() {
           from: {
             month: '1',
             day: '1',
-            year: '2012'
+            year: '2012',
+            touched: true
           },
           to: {
             month: '1',
             day: '1',
-            year: '2010'
+            year: '2010',
+            touched: true
           },
           present: false
         },

--- a/src/validators/daterange.test.js
+++ b/src/validators/daterange.test.js
@@ -29,10 +29,28 @@ describe('Date range validator', function() {
             year: '2010',
             touched: true
           },
-          to: {},
+          to: {
+            month: '',
+            day: '',
+            year: '',
+            touched: false
+          },
           present: false
         },
         expected: true
+      },
+      {
+        data: {
+          from: {
+            month: '1',
+            day: '1',
+            year: '2010',
+            touched: true
+          },
+          to: {},
+          present: false
+        },
+        expected: false
       },
       {
         data: {


### PR DESCRIPTION
Fixes #1286 by making date range validations only validate if both fields have been touched by the user to avoid showing the error too early.