### PR TITLE
Use correct date for residence item test

### DIFF
--- a/src/components/Section/History/Residence/ResidenceItem.test.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.test.jsx
@@ -55,7 +55,7 @@ describe('The residence component', () => {
           year: '2000'
         },
         to: {
-          month: `${new Date().getMonth()}`,
+          month: `${new Date().getMonth() + 1}`,
           day: `${new Date().getDate()}`,
           year: `${new Date().getFullYear()}`
         }


### PR DESCRIPTION
This test was missing the `+1` for `new Date().getMonth()` which is currently causing the test to return the date as `0/2/2019`. `getMonth()` begins the count at `0`.