### PR TITLE
Fix margin around Gap error CTA

### DIFF
--- a/src/components/Form/Accordion/Accordion.scss
+++ b/src/components/Form/Accordion/Accordion.scss
@@ -339,6 +339,10 @@ button.usa-button-outline {
   }
 }
 
+.gap button.usa-button-outline {
+  margin: 1rem 0;
+}
+
 @media screen and (min-width: 1000px) {
   .accordion > .items > .item.sticky-accordion {
     .summary-container {


### PR DESCRIPTION
Fixes #1324. Fixed the margin around the gap error CTA so that it was not misaligned. 