### PR TITLE
Update i18n format for date ranges

### DIFF
--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -10,11 +10,13 @@ import DateRangeValidator from '../../../validators/daterange'
 export default class DateRange extends ValidationElement {
   constructor(props) {
     super(props)
-    const touched = this.isTouched(props.to.year, props.to.month, props.to.day) || this.isTouched(props.from.year, props.from.month, props.from.day)
+    const touched =
+      this.isTouched(props.to.year, props.to.month, props.to.day) ||
+      this.isTouched(props.from.year, props.from.month, props.from.day)
     this.state = {
       uid: `${this.props.name}-${super.guid()}`,
-      from: {...props.from, touched: touched},
-      to: {...props.to, touched: touched},
+      from: { ...props.from, touched: touched },
+      to: { ...props.to, touched: touched },
       present: props.present,
       presentClicked: false,
       title: props.title || 'Date Range',
@@ -35,7 +37,14 @@ export default class DateRange extends ValidationElement {
   }
 
   isTouched(year, month, day) {
-    return year != '' && month != '' && day != '' && month >= 1 && day >= 1 && year >= 1
+    return (
+      year != '' &&
+      month != '' &&
+      day != '' &&
+      month >= 1 &&
+      day >= 1 &&
+      year >= 1
+    )
   }
 
   componentWillReceiveProps(nextProps) {
@@ -63,8 +72,8 @@ export default class DateRange extends ValidationElement {
   update(queue) {
     this.props.onUpdate({
       name: this.props.name,
-      from: {...this.state.from, touched: true},
-      to: {...this.state.to, touched: true},
+      from: { ...this.state.from, touched: true },
+      to: { ...this.state.to, touched: true },
       present: this.state.present,
       ...queue
     })
@@ -154,7 +163,9 @@ export default class DateRange extends ValidationElement {
   handleError(code, value, arr) {
     arr = arr.map(err => {
       return {
-        code: `${this.props.dateRangePrefix ? this.props.dateRangePrefix : 'daterange'}.${err.code.replace('date.', '')}`,
+        code: `${
+          this.props.dateRangePrefix ? this.props.dateRangePrefix : 'daterange'
+        }.${code}.${err.code.replace('date.', '')}`,
         valid: err.valid,
         uid: err.uid
       }
@@ -240,7 +251,7 @@ export default class DateRange extends ValidationElement {
           />
         </div>
         <div className="arrow">
-          <i className="fa fa-long-arrow-right fa-2x"></i>
+          <i className="fa fa-long-arrow-right fa-2x" />
         </div>
         <div className="to-grid">
           <div className="from-label">To date</div>

--- a/src/components/Section/Foreign/Business/Sponsorship.test.jsx
+++ b/src/components/Section/Foreign/Business/Sponsorship.test.jsx
@@ -194,7 +194,7 @@ describe('The foreign business sponsorship component', () => {
       expect(
         component
           .find(
-            '.error-messages [data-i18n="error.daterange.foreignNationalSponsorship.min"]'
+            '.error-messages [data-i18n="error.daterange.from.foreignNationalSponsorship.min"]'
           )
           .text()
       ).toEqual(

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -164,7 +164,8 @@ export const error = {
     year: {
       max: {
         title: 'There is a problem with the date',
-        message: "For the **additional employment** date range, the dates should be before the main entry's **from** date.",
+        message:
+          "For the **additional employment** date range, the dates should be before the main entry's **from** date.",
         note: ''
       },
       min: {
@@ -175,7 +176,8 @@ export const error = {
     },
     max: {
       title: 'There is a problem with the date',
-      message: "For the **additional employment** date range, the dates should be before the main entry's **from** date.",
+      message:
+        "For the **additional employment** date range, the dates should be before the main entry's **from** date."
     },
     min: {
       title: 'There is a problem with the date',
@@ -299,7 +301,7 @@ export const error = {
     },
     min: {
       title: 'There is a problem with the date',
-      message: "This date is before either you or your relative was born."
+      message: 'This date is before either you or your relative was born.'
     },
     required: {
       title: 'Your response is required',
@@ -561,22 +563,13 @@ export const error = {
       foreignNationalSponsorship: {
         min: {
           title: 'There is a problem with your entry',
-          message: 'For the **from** date, the date should be after their date of birth.'
+          message:
+            'For the **from** date, the date should be after their date of birth.'
         },
         required: {
           title: 'Your response is required',
           message: ''
-       }
-      }
-    },
-    foreignNationalSponsorship: {
-      min: {
-        title: 'There is a problem with your entry',
-        message: 'For the **from** date, the date should be after their date of birth.'
-      },
-      required: {
-        title: 'Your response is required',
-        message: ''
+        }
       }
     },
     order: {
@@ -1167,7 +1160,7 @@ export const error = {
   civilUnion: {
     min: {
       title: 'There is a problem with the date',
-      message: "This date is before either you or your partner was born."
+      message: 'This date is before either you or your partner was born.'
     },
     max: {
       title: 'There is a problem with the date',
@@ -1181,7 +1174,8 @@ export const error = {
   divorceDate: {
     min: {
       title: 'There is a problem with the date',
-      message: "This date is before the date your civil marriage, civil union, or domestic partnership was legally recognized"
+      message:
+        'This date is before the date your civil marriage, civil union, or domestic partnership was legally recognized'
     },
     max: {
       title: 'There is a problem with the date',
@@ -1195,7 +1189,7 @@ export const error = {
   cohabitant: {
     min: {
       title: 'There is a problem with the date',
-      message: "This date is before either you or your cohabitant was born."
+      message: 'This date is before either you or your cohabitant was born.'
     },
     max: {
       title: 'There is a problem with the date',
@@ -1209,7 +1203,8 @@ export const error = {
   foreignContact: {
     min: {
       title: 'There is a problem with the date',
-      message: "This date is before either you or your foriegn contact was born."
+      message:
+        'This date is before either you or your foriegn contact was born.'
     },
     max: {
       title: 'There is a problem with the date',
@@ -1251,7 +1246,8 @@ export const error = {
     },
     min: {
       title: 'There is a problem with your entry',
-      message: 'The date satisfied is before the date you failed to file or pay.'
+      message:
+        'The date satisfied is before the date you failed to file or pay.'
     }
   },
   drugUsage: {


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/1304
Fixes https://github.com/18F/e-QIP-prototype/issues/1316

**Before:**
<img width="713" alt="screen shot 2019-01-09 at 10 47 52 am" src="https://user-images.githubusercontent.com/1178494/50910578-15cdb580-13fc-11e9-918b-79f1ea84a14b.png">

**After:**
<img width="700" alt="screen shot 2019-01-09 at 10 45 06 am" src="https://user-images.githubusercontent.com/1178494/50910592-1f571d80-13fc-11e9-9de2-c2c78fdfb241.png">

Disregard all of the formatting changes, I have `prettier` run automatically in my code editor, the relevant change is just one line here: https://github.com/18F/e-QIP-prototype/compare/bh_i18n_dateranges?expand=1#diff-8a05580c2ab70edf4c8cd246a42c6795R168

At some point `code` got left off the concatenated i18n string, so `to` and `from` were missing which was causing the strings not to be found. Adding `code` back in seems to resolve this.