### PR TITLE
Implement hidden logic in navigation

### DIFF
--- a/src/components/Navigation/SectionList.jsx
+++ b/src/components/Navigation/SectionList.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import SectionLink from './SectionLink'
 import ToggleItem from './ToggleItem'
@@ -6,24 +7,36 @@ import ToggleItem from './ToggleItem'
 class SectionList extends React.Component {
   render() {
     const className = `usa-accordion ${this.props.className}`
-    const navItems = this.props.sections.map(section => {
-      if (section.subsections) {
+    console.log(this.props.sections)
+    const navItems = this.props.sections
+      .filter(section => {
+        if (
+          section.hidden ||
+          (section.hiddenFunc && section.hiddenFunc(this.props.application))
+        ) {
+          return false
+        }
+
+        return true
+      })
+      .map(section => {
+        if (section.subsections) {
+          return (
+            <ToggleItem
+              key={section.url}
+              baseUrl={this.props.baseUrl}
+              section={section}
+            />
+          )
+        }
         return (
-          <ToggleItem
+          <SectionLink
             key={section.url}
             baseUrl={this.props.baseUrl}
             section={section}
           />
         )
-      }
-      return (
-        <SectionLink
-          key={section.url}
-          baseUrl={this.props.baseUrl}
-          section={section}
-        />
-      )
-    })
+      })
 
     return <ol className={className}>{navItems}</ol>
   }
@@ -32,6 +45,9 @@ class SectionList extends React.Component {
 SectionList.propTypes = {
   baseUrl: PropTypes.string,
   className: PropTypes.string,
+  application: PropTypes.object.isRequired,
+  completed: PropTypes.object.isRequired,
+  errors: PropTypes.object.isRequired,
   sections: PropTypes.array.isRequired
 }
 
@@ -40,4 +56,15 @@ SectionList.defaultProps = {
   className: 'usa-sidenav-list'
 }
 
-export default SectionList
+function mapStateToProps(state) {
+  const application = state.application || {}
+  const completed = application.Completed || {}
+  const errors = application.Errors || {}
+  return {
+    application,
+    completed,
+    errors
+  }
+}
+
+export default connect(mapStateToProps)(SectionList)

--- a/src/components/Navigation/SectionList.jsx
+++ b/src/components/Navigation/SectionList.jsx
@@ -7,7 +7,6 @@ import ToggleItem from './ToggleItem'
 class SectionList extends React.Component {
   render() {
     const className = `usa-accordion ${this.props.className}`
-    console.log(this.props.sections)
     const navItems = this.props.sections
       .filter(section => {
         if (

--- a/src/components/Navigation/SectionList.test.jsx
+++ b/src/components/Navigation/SectionList.test.jsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router'
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import SectionList from './SectionList'
+import { navigation } from '../../config'
+import * as validators from '../../validators/index'
+
+describe('The SectionList component', () => {
+  const middlewares = [thunk]
+  const mockStore = configureMockStore(middlewares)
+
+  const mountSection = sections => {
+    const store = mockStore({ authentication: { authenticated: true } })
+    return mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <SectionList sections={sections} />
+        </MemoryRouter>
+      </Provider>
+    )
+  }
+
+  it('renders a link', () => {
+    const sections = [
+      {
+        name: 'blah',
+        url: 'blah'
+      }
+    ]
+
+    const component = mountSection(sections)
+    console.log(component.debug())
+    expect(component.find('a').length).toBe(1)
+  })
+
+  it('doesnt show a link with hidden true', () => {
+    const sections = [
+      {
+        name: 'blah',
+        url: 'blah',
+        hidden: true
+      }
+    ]
+
+    const component = mountSection(sections)
+    console.log(component.debug())
+    expect(component.find('a').length).toBe(0)
+  })
+
+  it('doesnt show a link with hiddenFunc true', () => {
+    const sections = [
+      {
+        name: 'blah',
+        url: 'blah',
+        hiddenFunc: () => {
+          return true
+        }
+      }
+    ]
+
+    const component = mountSection(sections)
+    expect(component.find('a').length).toBe(0)
+  })
+})

--- a/src/components/Navigation/__snapshots__/Navigation.test.jsx.snap
+++ b/src/components/Navigation/__snapshots__/Navigation.test.jsx.snap
@@ -676,23 +676,6 @@ exports[`Navigation component renders correctly 1`] = `
             <a
               aria-current={false}
               className="section-link"
-              href="/form/military/disciplinary"
-              onClick={[Function]}
-            >
-              <span
-                className="section-name"
-              >
-                Disciplinary procedures
-              </span>
-              <span
-                className="eapp-status-icon"
-              />
-            </a>
-          </li>
-          <li>
-            <a
-              aria-current={false}
-              className="section-link"
               href="/form/military/foreign"
               onClick={[Function]}
             >
@@ -2216,23 +2199,6 @@ exports[`Navigation component renders correctly 1`] = `
                 className="section-name"
               >
                 Diagnoses
-              </span>
-              <span
-                className="eapp-status-icon"
-              />
-            </a>
-          </li>
-          <li>
-            <a
-              aria-current={false}
-              className="section-link"
-              href="/form/psychological/conditions"
-              onClick={[Function]}
-            >
-              <span
-                className="section-name"
-              >
-                Existing Conditions
               </span>
               <span
                 className="eapp-status-icon"


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/1311

Certain sections are supposed to be conditionally hidden based on answers to previous questions. The `Existing Conditions` section in `Psychology` should only display if the applicant chose `No` to all of the previous sections. This was partially implemented since you could see the "Next" button adjust for this, but the change was not visible in the navigation bar.

This implements logic to hide items in the nav bar if the section is set to `hidden: true` or there is a `hiddenFunc` that evaluates to true.

Added bonus, apparently the `Disciplinary procedures` section of `Military` uses similar logic as `Existing Conditions`, so this fix properly hides/shows that section as well.
