### PR TITLE
Fix date control to stop validating the date too early

### DIFF
--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -91,27 +91,6 @@ class DateControl extends ValidationElement {
     this.setState(
       { month: month, day: day, year: year, estimated: estimated, touched: touched },
       () => {
-        // Estimate touches the day so we need to toggle focus
-        const toggleForEstimation = changed.estimated
-
-        // Potential for typical day out-of-bounds (including leap year)
-        const toggleForDay = changed.year || changed.month
-
-        // Any external influence (i.e. clicking `Present` in a date range)
-        const toggleForExternal =
-          el === null && changed.year && changed.month && changed.day
-
-        // This will force a blur/validation
-        if (toggleForEstimation || toggleForDay || toggleForExternal) {
-          this.props.toggleFocus(
-            window,
-            changed,
-            el,
-            this.refs.day.refs.number.refs.input,
-            this.refs.month.refs.number.refs.input
-          )
-        }
-
         this.props.onUpdate({
           name: this.props.name,
           month: `${month}`,
@@ -401,18 +380,6 @@ DateControl.defaultProps = {
   minDate: null,
   minDateEqualTo: false,
   relationship: '',
-  toggleFocus: (w, changed, el, day, month) => {
-    day.focus()
-    day.blur()
-
-    if (el) {
-      if (changed.month) {
-        month.focus()
-      } else if (el.focus) {
-        el.focus()
-      }
-    }
-  },
   onUpdate: values => {},
   onError: (value, arr) => {
     return arr

--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -80,14 +80,6 @@ class DateControl extends ValidationElement {
   }
 
   update(el, year, month, day, estimated, touched) {
-    const changed = {
-      year: year !== this.state.year,
-      month: month !== this.state.month,
-      day: day !== this.state.day,
-      estimated: estimated !== this.state.estimated,
-      touched: touched !== this.state.touched
-    }
-
     this.setState(
       { month: month, day: day, year: year, estimated: estimated, touched: touched },
       () => {

--- a/src/components/Form/DateControl/DateControl.test.jsx
+++ b/src/components/Form/DateControl/DateControl.test.jsx
@@ -85,6 +85,26 @@ describe('The date component', () => {
     expect(component.find('.usa-input-error').length).toBe(1)
   })
 
+  it('renders error after blur', () => {
+    const expected = {
+      name: 'input-error',
+      label: 'DateControl input error',
+      disabled: false,
+      error: true,
+      focus: false,
+      valid: false,
+      month: '1',
+      day: '12',
+      year: ''
+    }
+    const component = mount(<DateControl {...expected} />)
+    component.find('.year input').simulate('change', { target: { value: '1'}})
+    component.find('.year input').simulate('blur')
+    expect(component.find('.year input').length).toEqual(1)
+    expect(component.find('.usa-input-error').length).toBe(1)
+  })
+
+
   it('can override overall error', () => {
     const expected = {
       name: 'input-error',
@@ -363,24 +383,5 @@ describe('The date component', () => {
       .find('.day input')
       .simulate('keydown', { keyCode: 8, target: { value: '' } })
     expect(tabbed).toBe(true)
-  })
-
-  it('populates empty day on estimate click', () => {
-    let toggled = false
-    const props = {
-      month: '1',
-      day: '',
-      year: '2000',
-      showEstimated: true,
-      toggleFocus: (w, changed, el, day, month) => {
-        toggled = true
-      }
-    }
-
-    let component = mount(<DateControl {...props} />)
-    component
-      .find('.estimated input')
-      .simulate('change', { target: { checked: true } })
-    expect(toggled).toBe(true)
   })
 })


### PR DESCRIPTION
Fixes #1307 

Turns out the date control toggled focus of the day field of a date control when some change was made forcing the validation to trigger. The purpose of this seems to have been made obsolete as removing the code does not change the interaction but does fix the bug. One of the tests implies that the day field should have been automatically filled in, but that no longer happens so I am removing the offending code and test, added new test to check for the bug and have verified that this works for single date field and date ranges.