### PR TITLE
Substance use date field validation bug

### DIFF
--- a/src/components/Section/SubstanceUse/Alcohol/ReceivedCounseling.jsx
+++ b/src/components/Section/SubstanceUse/Alcohol/ReceivedCounseling.jsx
@@ -111,7 +111,7 @@ export default class ReceivedCounseling extends ValidationElement {
       endDate = {
         date: date,
         estimated: false,
-        month: String(date.getMonth()),
+        month: String(date.getMonth()+1),
         year: String(date.getFullYear()),
         day: String(date.getDate())
       }

--- a/src/components/Section/SubstanceUse/Alcohol/ReceivedCounseling.jsx
+++ b/src/components/Section/SubstanceUse/Alcohol/ReceivedCounseling.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { i18n } from '../../../../config'
+import { validDate, today } from '../../History/dateranges'
 import {
   Location,
   DateControl,
@@ -139,7 +140,7 @@ export default class ReceivedCounseling extends ValidationElement {
   }
 
   render() {
-    const maxDate = this.props.TreatmentEndDate
+    const maxDate = validDate(this.props.TreatmentEndDate) ? this.props.TreatmentEndDate : today
     const minDate = this.props.TreatmentBeganDate
     return (
       <div className="received-counseling">

--- a/src/components/Section/SubstanceUse/Alcohol/ReceivedCounseling.test.jsx
+++ b/src/components/Section/SubstanceUse/Alcohol/ReceivedCounseling.test.jsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme'
 import configureMockStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
 import ReceivedCounseling from './ReceivedCounseling'
+import { today } from '../../History/dateranges'
 
 describe('The ReceivedCounseling component', () => {
   const mockStore = configureMockStore()
@@ -21,6 +22,13 @@ describe('The ReceivedCounseling component', () => {
   it('Renders without errors', () => {
     const component = createComponent()
     expect(component.find('.voluntary-counseling').length).toBe(0)
+  })
+
+  it('renders start date with max', () => {
+    const component = createComponent()
+    expect(component.find('DateControl').length).toBe(2)
+    expect(component.find('DateControl').at(0).prop('name')).toBe('TreatmentBeganDate')
+    expect(component.find('DateControl').at(0).prop('maxDate')).toBe(today)
   })
 
   it('Renders with action taken marked as yes', () => {

--- a/src/components/Section/SubstanceUse/Alcohol/ReceivedCounseling.test.jsx
+++ b/src/components/Section/SubstanceUse/Alcohol/ReceivedCounseling.test.jsx
@@ -77,16 +77,23 @@ describe('The ReceivedCounseling component', () => {
 
   it('present returns todays date', () => {
     let checked = false
+    let treatmentEndDate = null
     const props = {
       PresentTreatmentEndDate: false,
       onUpdate: values => {
         checked = true
+        treatmentEndDate = values.TreatmentEndDate
       }
     }
 
+    const expectedDate = new Date()
     const component = createComponent(props)
     component.find('.present-treatment-end-date input').simulate('change')
     expect(checked).toBe(true)
+    expect(treatmentEndDate.day).toBe(String(expectedDate.getDate()))
+    expect(treatmentEndDate.month).toBe(String(expectedDate.getMonth()+1))
+    expect(treatmentEndDate.year).toBe(String(expectedDate.getFullYear()))
+    expect(treatmentEndDate.estimated).toBe(false)
   })
 
   it('present can be unchecked', () => {


### PR DESCRIPTION
Fixes 1338. There are two issues, first when checking present on treatment end date the month was filled in but minus one. Second when end date has yet to be filled in undefined was used for the maxDate value for treatment start date which caused strange behavior. The code fixes this by ensuring maxDate is the treatment end date or today. This doesn't fix 1339 which will need to be handled separately.