### PR TITLE
Add "I don't know" option to Selective Service

### DIFF
--- a/api/migrations/20190116164719_add_idk_selective_service.sql
+++ b/api/migrations/20190116164719_add_idk_selective_service.sql
@@ -1,0 +1,12 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+-- +goose StatementBegin
+ALTER TABLE military_selectives ADD COLUMN has_registered_not_applicable_id bigint REFERENCES not_applicables(id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+-- +goose StatementBegin
+ALTER TABLE military_selectives DROP COLUMN IF EXISTS has_registered_not_applicable_id;
+-- +goose StatementEnd

--- a/api/templates/military-selective.xml
+++ b/api/templates/military-selective.xml
@@ -9,6 +9,12 @@
     <LegalExemptionExplanation>{{textarea .props.Explanation}}</LegalExemptionExplanation>
     <LegalExemptionExplanationComment></LegalExemptionExplanationComment>
     <NumberComment></NumberComment>
+    <DNKExplanation></DNKExplanation>
+    <DNKExplanationComment></DNKExplanationComment>
+    {{- else if notApplicable .props.HasRegisteredNotApplicable | eq "True"}}
+    <LegalExemptionExplanation></LegalExemptionExplanation>
+    <LegalExemptionExplanationComment></LegalExemptionExplanationComment>
+    <NumberComment></NumberComment>
     <DNKExplanation>{{textarea .props.Explanation}}</DNKExplanation>
     <DNKExplanationComment></DNKExplanationComment>
     {{end}}

--- a/api/testdata/complete-scenarios/test1.json
+++ b/api/testdata/complete-scenarios/test1.json
@@ -2246,6 +2246,12 @@
             "value": "Yes"
           }
         },
+        "HasRegisteredNotApplicable": {
+          "type": "notapplicable",
+          "props": {
+            "applicable": true
+          }
+        },
         "RegistrationNumber": {
           "type": "text",
           "props": {

--- a/api/testdata/complete-scenarios/test2.json
+++ b/api/testdata/complete-scenarios/test2.json
@@ -3253,6 +3253,12 @@
             "value": "Yes"
           }
         },
+        "HasRegisteredNotApplicable": {
+          "type": "notapplicable",
+          "props": {
+            "applicable": true
+          }
+        },
         "RegistrationNumber": {
           "type": "text",
           "props": {

--- a/api/testdata/complete-scenarios/test3.json
+++ b/api/testdata/complete-scenarios/test3.json
@@ -6564,6 +6564,12 @@
             "value": ""
           }
         },
+        "HasRegisteredNotApplicable": {
+          "type": "notapplicable",
+          "props": {
+            "applicable": true
+          }
+        },
         "RegistrationNumber": {
           "type": "text",
           "props": {

--- a/api/testdata/complete-scenarios/test4.json
+++ b/api/testdata/complete-scenarios/test4.json
@@ -3537,6 +3537,12 @@
             "value": "Yes"
           }
         },
+        "HasRegisteredNotApplicable": {
+          "type": "notapplicable",
+          "props": {
+            "applicable": true
+          }
+        },
         "RegistrationNumber": {
           "type": "text",
           "props": {

--- a/api/testdata/complete-scenarios/test5.json
+++ b/api/testdata/complete-scenarios/test5.json
@@ -14704,6 +14704,12 @@
             "value": "Yes"
           }
         },
+        "HasRegisteredNotApplicable": {
+          "type": "notapplicable",
+          "props": {
+            "applicable": true
+          }
+        },
         "RegistrationNumber": {
           "type": "text",
           "props": {

--- a/api/testdata/complete-scenarios/test6.json
+++ b/api/testdata/complete-scenarios/test6.json
@@ -3014,6 +3014,12 @@
             "value": "Yes"
           }
         },
+        "HasRegisteredNotApplicable": {
+          "type": "notapplicable",
+          "props": {
+            "applicable": true
+          }
+        },
         "RegistrationNumber": {
           "type": "text",
           "props": {

--- a/api/testdata/complete-scenarios/test7.json
+++ b/api/testdata/complete-scenarios/test7.json
@@ -12333,6 +12333,12 @@
             "value": "Yes"
           }
         },
+        "HasRegisteredNotApplicable": {
+          "type": "notapplicable",
+          "props": {
+            "applicable": true
+          }
+        },
         "RegistrationNumber": {
           "type": "text",
           "props": {

--- a/api/testdata/complete-scenarios/test8.json
+++ b/api/testdata/complete-scenarios/test8.json
@@ -2131,6 +2131,12 @@
             "value": "Yes"
           }
         },
+        "HasRegisteredNotApplicable": {
+          "type": "notapplicable",
+          "props": {
+            "applicable": true
+          }
+        },
         "RegistrationNumber": {
           "type": "text",
           "props": {

--- a/api/testdata/complete-scenarios/test9.json
+++ b/api/testdata/complete-scenarios/test9.json
@@ -3886,6 +3886,12 @@
             "value": "Yes"
           }
         },
+        "HasRegisteredNotApplicable": {
+          "type": "notapplicable",
+          "props": {
+            "applicable": true
+          }
+        },
         "RegistrationNumber": {
           "type": "text",
           "props": {

--- a/api/testdata/military-selective.json
+++ b/api/testdata/military-selective.json
@@ -13,6 +13,12 @@
         "value": "No"
       }
     },
+    "HasRegisteredNotApplicable": {
+      "type": "notapplicable",
+      "props": {
+        "applicable": true
+      }
+    },
     "RegistrationNumber": {
       "type": "text",
       "props": {

--- a/src/components/Section/Military/Selective/Selective.test.jsx
+++ b/src/components/Section/Military/Selective/Selective.test.jsx
@@ -46,6 +46,20 @@ describe('The selective service component', () => {
     expect(component.find('.registration-number').length).toBe(0)
   })
 
+  it('selects "I dont know" on registered and is presented with explanation', () => {
+    const expected = {
+      name: 'selective',
+      WasBornAfter: { value: 'Yes' },
+      HasRegisteredNotApplicable: { applicable: false }
+    }
+    const component = mount(<Selective {...expected} />)
+    component.find('.born .yes input').simulate('change')
+    component.find('.registered .no input').simulate('change')
+    component.find('.explanation textarea').simulate('change')
+    expect(component.find('.explanation').length).toBe(1)
+    expect(component.find('.registration-number').length).toBe(0)
+  })
+
   it('selects yes on registered and is presented with registration number', () => {
     const expected = {
       name: 'selective',

--- a/src/config/locales/en/military.js
+++ b/src/config/locales/en/military.js
@@ -25,7 +25,11 @@ export const military = {
         'Have you registered with the Selective Service System (SSS)?',
       number: 'Provide registration number'
     },
+    para: {
+      or: 'or'
+    },
     label: {
+      idk: "I don't know",
       number:
         'Note: Selective Service Number is not your Social Security Number',
       explanation: 'Provide an explanation'

--- a/src/schema/section/military-selective.js
+++ b/src/schema/section/military-selective.js
@@ -4,6 +4,9 @@ export const militarySelective = (data = {}) => {
   return {
     WasBornAfter: form.branch(data.WasBornAfter),
     HasRegistered: form.branch(data.HasRegistered),
+    HasRegisteredNotApplicable: form.notapplicable(
+      data.HasRegisteredNotApplicable
+    ),
     RegistrationNumber: form.text(data.RegistrationNumber),
     Explanation: form.textarea(data.Explanation)
   }

--- a/src/schema/section/military-selective.test.js
+++ b/src/schema/section/military-selective.test.js
@@ -6,6 +6,7 @@ describe('Schema for financial taxes', () => {
     const data = {
       WasBornAfter: {},
       HasRegistered: {},
+      HasRegisteredNotApplicable: {},
       RegistrationNumber: {},
       Explanation: {}
     }

--- a/src/validators/selectiveservice.js
+++ b/src/validators/selectiveservice.js
@@ -14,6 +14,7 @@ export default class SelectiveServiceValidator {
   constructor(data = {}) {
     this.wasBornAfter = (data.WasBornAfter || {}).value
     this.hasRegistered = (data.HasRegistered || {}).value
+    this.hasRegisteredNotApplicable = data.HasRegisteredNotApplicable
     this.registrationNumber = data.RegistrationNumber
     this.explanation = data.Explanation
   }
@@ -26,7 +27,9 @@ export default class SelectiveServiceValidator {
     return (
       this.wasBornAfter === 'No' ||
       (this.wasBornAfter === 'Yes' &&
-        (this.hasRegistered === 'Yes' || this.hasRegistered === 'No'))
+        (this.hasRegistered === 'Yes' ||
+          this.hasRegistered === 'No' ||
+          !this.hasRegisteredNotApplicable.applicable))
     )
   }
 
@@ -43,7 +46,11 @@ export default class SelectiveServiceValidator {
   }
 
   validExplanation() {
-    if (this.wasBornAfter === 'Yes' && this.hasRegistered === 'No') {
+    if (
+      this.wasBornAfter === 'Yes' &&
+      (this.hasRegistered === 'No' ||
+        !this.hasRegisteredNotApplicable.applicable)
+    ) {
       return validGenericTextfield(this.explanation)
     }
 

--- a/src/validators/selectiveservice.test.js
+++ b/src/validators/selectiveservice.test.js
@@ -102,21 +102,32 @@ describe('Selective service validation', function() {
       {
         state: {
           WasBornAfter: { value: 'Yes' },
-          HasRegistered: { value: '' }
+          HasRegistered: { value: '' },
+          HasRegisteredNotApplicable: { applicable: true }
         },
         expected: false
       },
       {
         state: {
           WasBornAfter: { value: 'Yes' },
-          HasRegistered: { value: 'No' }
+          HasRegistered: { value: 'No' },
+          HasRegisteredNotApplicable: { applicable: true }
         },
         expected: true
       },
       {
         state: {
           WasBornAfter: { value: 'Yes' },
-          HasRegistered: { value: 'Yes' }
+          HasRegistered: { value: 'Yes' },
+          HasRegisteredNotApplicable: { applicable: true }
+        },
+        expected: true
+      },
+      {
+        state: {
+          WasBornAfter: { value: 'Yes' },
+          HasRegistered: { value: '' },
+          HasRegisteredNotApplicable: { applicable: false }
         },
         expected: true
       }
@@ -135,6 +146,7 @@ describe('Selective service validation', function() {
         state: {
           WasBornAfter: { value: 'Yes' },
           HasRegistered: { value: 'Yes' },
+          HasRegisteredNotApplicable: { applicable: true },
           RegistrationNumber: null
         },
         expected: false
@@ -143,6 +155,7 @@ describe('Selective service validation', function() {
         state: {
           WasBornAfter: { value: 'Yes' },
           HasRegistered: { value: 'Yes' },
+          HasRegisteredNotApplicable: { applicable: true },
           RegistrationNumber: {
             value: ''
           }
@@ -153,6 +166,7 @@ describe('Selective service validation', function() {
         state: {
           WasBornAfter: { value: 'Yes' },
           HasRegistered: { value: 'Yes' },
+          HasRegisteredNotApplicable: { applicable: true },
           RegistrationNumber: {
             value: '123abc7890'
           }
@@ -163,6 +177,7 @@ describe('Selective service validation', function() {
         state: {
           WasBornAfter: { value: 'Yes' },
           HasRegistered: { value: 'Yes' },
+          HasRegisteredNotApplicable: { applicable: true },
           RegistrationNumber: {
             value: '1234567890'
           }
@@ -187,6 +202,7 @@ describe('Selective service validation', function() {
         state: {
           WasBornAfter: { value: 'Yes' },
           HasRegistered: { value: 'No' },
+          HasRegisteredNotApplicable: { applicable: true },
           Explanation: null
         },
         expected: false
@@ -195,6 +211,7 @@ describe('Selective service validation', function() {
         state: {
           WasBornAfter: { value: 'Yes' },
           HasRegistered: { value: 'No' },
+          HasRegisteredNotApplicable: { applicable: true },
           Explanation: {
             value: ''
           }
@@ -205,6 +222,29 @@ describe('Selective service validation', function() {
         state: {
           WasBornAfter: { value: 'Yes' },
           HasRegistered: { value: 'No' },
+          HasRegisteredNotApplicable: { applicable: true },
+          Explanation: {
+            value: 'Never knew about it'
+          }
+        },
+        expected: true
+      },
+      {
+        state: {
+          WasBornAfter: { value: 'Yes' },
+          HasRegistered: { value: '' },
+          HasRegisteredNotApplicable: { applicable: false },
+          Explanation: {
+            value: ''
+          }
+        },
+        expected: false
+      },
+      {
+        state: {
+          WasBornAfter: { value: 'Yes' },
+          HasRegistered: { value: '' },
+          HasRegisteredNotApplicable: { applicable: false },
           Explanation: {
             value: 'Never knew about it'
           }
@@ -226,6 +266,7 @@ describe('Selective service validation', function() {
         state: {
           WasBornAfter: { value: 'Yes' },
           HasRegistered: { value: 'Yes' },
+          HasRegisteredNotApplicable: { applicable: true },
           RegistrationNumber: {
             value: '1234567890'
           }
@@ -236,6 +277,18 @@ describe('Selective service validation', function() {
         state: {
           WasBornAfter: { value: 'Yes' },
           HasRegistered: { value: 'No' },
+          HasRegisteredNotApplicable: { applicable: true },
+          Explanation: {
+            value: 'Never knew about it'
+          }
+        },
+        expected: true
+      },
+      {
+        state: {
+          WasBornAfter: { value: 'Yes' },
+          HasRegistered: { value: '' },
+          HasRegisteredNotApplicable: { applicable: false },
           Explanation: {
             value: 'Never knew about it'
           }


### PR DESCRIPTION
Fixes #1320 

Uses the `NotApplicable` component to add an "I don't  know" option to Selective Service record.

Includes a new database migration, so make sure to restart the server when testing.

![screen shot 2019-01-17 at 10 47 34 am](https://user-images.githubusercontent.com/1178494/51330670-f0692900-1a45-11e9-9343-16c858386b03.png)