### PR TITLE
Add from and to prefixes to additional employment date i18n strings

### DIFF
--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -127,65 +127,137 @@ export const error = {
     }
   },
   additionalActivity: {
-    month: {
-      notfound: {
-        title: 'There is a problem with the Month',
-        message: 'The month should be between 01 (January) and 12 (December).',
-        note: ''
+    to: {
+      month: {
+        notfound: {
+          title: 'There is a problem with the Month',
+          message:
+            'The month should be between 01 (January) and 12 (December).',
+          note: ''
+        },
+        min: {
+          title: 'There is a problem with the Month',
+          message:
+            'The month should be between 01 (January) and 12 (December).',
+          note: ''
+        },
+        max: {
+          title: 'There is a problem with the Month',
+          message:
+            'The month should be between 01 (January) and 12 (December).',
+          note: ''
+        }
       },
-      min: {
-        title: 'There is a problem with the Month',
-        message: 'The month should be between 01 (January) and 12 (December).',
-        note: ''
+      day: {
+        length: {
+          title: 'There is a problem with the Day',
+          message: 'There is not that many days in this month.',
+          note: ''
+        },
+        min: {
+          title: 'There is a problem with the Day',
+          message: 'There are not that many days in this month.',
+          note: ''
+        },
+        max: {
+          title: 'There is a problem with the Day',
+          message: 'There are not that many days in this month.',
+          note: ''
+        }
       },
-      max: {
-        title: 'There is a problem with the Month',
-        message: 'The month should be between 01 (January) and 12 (December).',
-        note: ''
-      }
-    },
-    day: {
-      length: {
-        title: 'There is a problem with the Day',
-        message: 'There is not that many days in this month.',
-        note: ''
+      year: {
+        max: {
+          title: 'There is a problem with the date',
+          message:
+            "For the **additional employment** date range, the dates should be before the main entry's **from** date.",
+          note: ''
+        },
+        min: {
+          title: 'There is a problem with the Year',
+          message: 'This year is too far in the past.',
+          note: ''
+        }
       },
-      min: {
-        title: 'There is a problem with the Day',
-        message: 'There are not that many days in this month.',
-        note: ''
-      },
-      max: {
-        title: 'There is a problem with the Day',
-        message: 'There are not that many days in this month.',
-        note: ''
-      }
-    },
-    year: {
       max: {
         title: 'There is a problem with the date',
         message:
-          "For the **additional employment** date range, the dates should be before the main entry's **from** date.",
-        note: ''
+          "For the **additional employment** date range, the dates should be before the main entry's **from** date."
       },
       min: {
-        title: 'There is a problem with the Year',
-        message: 'This year is too far in the past.',
-        note: ''
+        title: 'There is a problem with the date',
+        message: 'The date should be after your date of birth.'
+      },
+      required: {
+        title: 'Your response is required',
+        message:
+          'All parts of the date are required even if it is **estimated**.'
       }
     },
-    max: {
-      title: 'There is a problem with the date',
-      message:
-        "For the **additional employment** date range, the dates should be before the main entry's **from** date."
-    },
-    min: {
-      title: 'There is a problem with the date',
-      message: 'The date should be after your date of birth.'
-    },
-    required: {
-      title: 'Your response is required',
-      message: 'All parts of the date are required even if it is **estimated**.'
+    from: {
+      month: {
+        notfound: {
+          title: 'There is a problem with the Month',
+          message:
+            'The month should be between 01 (January) and 12 (December).',
+          note: ''
+        },
+        min: {
+          title: 'There is a problem with the Month',
+          message:
+            'The month should be between 01 (January) and 12 (December).',
+          note: ''
+        },
+        max: {
+          title: 'There is a problem with the Month',
+          message:
+            'The month should be between 01 (January) and 12 (December).',
+          note: ''
+        }
+      },
+      day: {
+        length: {
+          title: 'There is a problem with the Day',
+          message: 'There is not that many days in this month.',
+          note: ''
+        },
+        min: {
+          title: 'There is a problem with the Day',
+          message: 'There are not that many days in this month.',
+          note: ''
+        },
+        max: {
+          title: 'There is a problem with the Day',
+          message: 'There are not that many days in this month.',
+          note: ''
+        }
+      },
+      year: {
+        max: {
+          title: 'There is a problem with the date',
+          message:
+            "For the **additional employment** date range, the dates should be before the main entry's **from** date.",
+          note: ''
+        },
+        min: {
+          title: 'There is a problem with the Year',
+          message: 'This year is too far in the past.',
+          note: ''
+        }
+      },
+      max: {
+        title: 'There is a problem with the date',
+        message:
+          "For the **additional employment** date range, the dates should be before the main entry's **from** date."
+      },
+      min: {
+        title: 'There is a problem with the date',
+        message: 'The date should be after your date of birth.'
+      },
+      required: {
+        title: 'Your response is required',
+        message:
+          'All parts of the date are required even if it is **estimated**.'
+      }
     }
   },
   date: {


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/1341

The date range component listed under `Additional periods of activity with this employer` requires the associated i18n strings to have a `to` and `from` prefix to properly target the correct string.