### PR TITLE
Don't include current spouse if not married

### DIFF
--- a/api/templates/spouse-present-marriage.xml
+++ b/api/templates/spouse-present-marriage.xml
@@ -1,4 +1,3 @@
-{{if text .props.Status | ne "NeverMarried"}}
 <PresentMarriage>
   {{with $Item := .props.CivilUnion.props}}
   <CurrentSpouse ID="1">
@@ -112,4 +111,3 @@
   </CurrentSpouse>
   {{end}}
 </PresentMarriage>
-{{end}}

--- a/api/templates/spouse.xml
+++ b/api/templates/spouse.xml
@@ -1,13 +1,13 @@
 <Spouse Version="1" Type="Pooled">
+  {{tmpl "spouse-marital-status.xml" .Relationships.Marital.props.Status}}
   {{tmpl "spouse-cohabitants.xml" .Relationships.Cohabitants}}
   {{$status := radio .Relationships.Marital.props.Status}}
   {{$divorced := branch .Relationships.Marital.props.CivilUnion.props.Divorced}}
   {{if or ($status | eq "Annulled") ($status | eq "Divorced") ($status | eq "Widowed") ($divorced | eq "Yes")}}
   {{tmpl "spouse-former.xml" .Relationships.Marital.props.DivorcedList}}
-  <HaveFormerSpouse><Answer>Yes</Answer></HaveFormerSpouse>
-  {{else if $status | ne "NeverMarried"}}
-  <HaveFormerSpouse><Answer>No</Answer></HaveFormerSpouse>
-  {{end}}
-  {{tmpl "spouse-marital-status.xml" .Relationships.Marital.props.Status}}
+  {{end}} 
+  {{if or ($status | eq "Married") ($status | eq "Separated")}}
+  <HaveFormerSpouse><Answer>{{$divorced}}</Answer></HaveFormerSpouse>
   {{tmpl "spouse-present-marriage.xml" .Relationships.Marital}}
+  {{end}}
 </Spouse>

--- a/api/testdata/complete-scenarios/test1.xml
+++ b/api/testdata/complete-scenarios/test1.xml
@@ -281,10 +281,10 @@
               </Relatives>
             </RelativesAndAssociates>
             <Spouse Version="1" Type="Pooled">
+              <MaritalStatus>NeverMarried</MaritalStatus>
               <Cohabitants>
                 <Answer>No</Answer>
               </Cohabitants>
-              <MaritalStatus>NeverMarried</MaritalStatus>
             </Spouse>
             <ResidenceHistory Version="1" Type="Pooled">
               <Residencies>

--- a/api/testdata/complete-scenarios/test2.xml
+++ b/api/testdata/complete-scenarios/test2.xml
@@ -281,10 +281,10 @@
               </Relatives>
             </RelativesAndAssociates>
             <Spouse Version="1" Type="Pooled">
+              <MaritalStatus>NeverMarried</MaritalStatus>
               <Cohabitants>
                 <Answer>No</Answer>
               </Cohabitants>
-              <MaritalStatus>NeverMarried</MaritalStatus>
             </Spouse>
             <ResidenceHistory Version="1" Type="Pooled">
               <Residencies>

--- a/api/testdata/complete-scenarios/test3.xml
+++ b/api/testdata/complete-scenarios/test3.xml
@@ -383,6 +383,7 @@
               </Relatives>
             </RelativesAndAssociates>
             <Spouse Version="1" Type="Pooled">
+              <MaritalStatus>Married</MaritalStatus>
               <Cohabitants>
                 <Answer>Yes</Answer>
                 <Cohabitant ID="1">
@@ -466,7 +467,6 @@
               <HaveFormerSpouse>
                 <Answer>No</Answer>
               </HaveFormerSpouse>
-              <MaritalStatus>Married</MaritalStatus>
               <PresentMarriage>
                 <CurrentSpouse ID="1">
                   <Address>

--- a/api/testdata/complete-scenarios/test4.xml
+++ b/api/testdata/complete-scenarios/test4.xml
@@ -281,10 +281,10 @@
               </Relatives>
             </RelativesAndAssociates>
             <Spouse Version="1" Type="Pooled">
+              <MaritalStatus>NeverMarried</MaritalStatus>
               <Cohabitants>
                 <Answer>No</Answer>
               </Cohabitants>
-              <MaritalStatus>NeverMarried</MaritalStatus>
             </Spouse>
             <ResidenceHistory Version="1" Type="Pooled">
               <Residencies>

--- a/api/testdata/complete-scenarios/test5.xml
+++ b/api/testdata/complete-scenarios/test5.xml
@@ -554,6 +554,7 @@
               </Relatives>
             </RelativesAndAssociates>
             <Spouse Version="1" Type="Pooled">
+              <MaritalStatus>Married</MaritalStatus>
               <Cohabitants>
                 <Answer>Yes</Answer>
                 <Cohabitant ID="1">
@@ -726,7 +727,6 @@
               <HaveFormerSpouse>
                 <Answer>Yes</Answer>
               </HaveFormerSpouse>
-              <MaritalStatus>Married</MaritalStatus>
               <PresentMarriage>
                 <CurrentSpouse ID="1">
                   <Address UseMyCurrentAddress="True"/>

--- a/api/testdata/complete-scenarios/test6.json
+++ b/api/testdata/complete-scenarios/test6.json
@@ -1549,7 +1549,6 @@
                       "first": "",
                       "firstInitialOnly": false,
                       "middle": "",
-                      "hideMiddleName": true,
                       "middleInitialOnly": false,
                       "noMiddleName": false,
                       "last": "",
@@ -1731,7 +1730,6 @@
                       "first": "",
                       "firstInitialOnly": false,
                       "middle": "",
-                      "hideMiddleName": true,
                       "middleInitialOnly": false,
                       "noMiddleName": false,
                       "last": "",
@@ -3014,12 +3012,6 @@
             "value": "Yes"
           }
         },
-        "HasRegisteredNotApplicable": {
-          "type": "notapplicable",
-          "props": {
-            "applicable": true
-          }
-        },
         "RegistrationNumber": {
           "type": "text",
           "props": {
@@ -3030,6 +3022,12 @@
           "type": "textarea",
           "props": {
             "value": ""
+          }
+        },
+        "HasRegisteredNotApplicable": {
+          "type": "notapplicable",
+          "props": {
+            "applicable": true
           }
         }
       }
@@ -3199,7 +3197,10 @@
           "type": "collection",
           "props": {
             "branch": {
-              "type": ""
+              "type": "branch",
+              "props": {
+                "value": ""
+              }
             },
             "items": []
           }
@@ -3212,8 +3213,7 @@
         "Status": {
           "type": "radio",
           "props": {
-            "value": "NeverMarried",
-            "checked": true
+            "value": "Divorced"
           }
         },
         "CivilUnion": {
@@ -3427,10 +3427,127 @@
             "branch": {
               "type": "branch",
               "props": {
-                "value": ""
+                "value": "No"
               }
             },
-            "items": []
+            "items": [
+              {
+                "Item": {
+                  "Address": {
+                    "type": "location",
+                    "props": {
+                      "layout": "Birthplace without County",
+                      "city": "Las Vegas",
+                      "state": "NV",
+                      "country": "United States"
+                    }
+                  },
+                  "BirthPlace": {
+                    "type": "location",
+                    "props": {
+                      "layout": "Birthplace without County",
+                      "city": "Salem",
+                      "state": "CA",
+                      "country": "United States"
+                    }
+                  },
+                  "Birthdate": {
+                    "type": "datecontrol",
+                    "props": {
+                      "month": "11",
+                      "day": "07",
+                      "year": "1985",
+                      "estimated": false
+                    }
+                  },
+                  "Citizenship": {
+                    "type": "country",
+                    "props": {
+                      "value": [
+                        "United States"
+                      ]
+                    }
+                  },
+                  "DateDivorced": {
+                    "type": "datecontrol",
+                    "props": {
+                      "month": "02",
+                      "day": "13",
+                      "year": "2004",
+                      "estimated": false
+                    }
+                  },
+                  "Deceased": {
+                    "type": "radio",
+                    "props": {
+                      "value": "DK"
+                    }
+                  },
+                  "DeceasedAddress": {
+                    "type": "location",
+                    "props": {
+                      "layout": "",
+                      "country": ""
+                    }
+                  },
+                  "DeceasedAddressNotApplicable": {
+                    "type": "notapplicable",
+                    "props": {
+                      "applicable": false
+                    }
+                  },
+                  "DivorceLocation": {
+                    "type": "location",
+                    "props": {
+                      "layout": "US City, State, Zipcode International city",
+                      "city": "Las Vegas",
+                      "state": "NV",
+                      "zipcode": "88901",
+                      "country": "United States"
+                    }
+                  },
+                  "Name": {
+                    "type": "name",
+                    "props": {
+                      "first": "Joanne",
+                      "firstInitialOnly": false,
+                      "middle": "Mary",
+                      "middleInitialOnly": false,
+                      "noMiddleName": false,
+                      "last": "Roderick",
+                      "suffix": "",
+                      "suffixOther": ""
+                    }
+                  },
+                  "Recognized": {
+                    "type": "datecontrol",
+                    "props": {
+                      "month": "01",
+                      "day": "22",
+                      "year": "2003",
+                      "estimated": false
+                    }
+                  },
+                  "Status": {
+                    "type": "radio",
+                    "props": {
+                      "value": "Divorced"
+                    }
+                  },
+                  "Telephone": {
+                    "type": "telephone",
+                    "props": {
+                      "timeOfDay": "",
+                      "type": "Domestic",
+                      "numberType": "",
+                      "number": "",
+                      "extension": "",
+                      "noNumber": true
+                    }
+                  }
+                }
+              }
+            ]
           }
         }
       }
@@ -3885,6 +4002,35 @@
                       ]
                     }
                   },
+                  "AlternateAddress": {
+                    "type": "physicaladdress",
+                    "props": {
+                      "HasDifferentAddress": {
+                        "type": "branch",
+                        "props": {
+                          "value": ""
+                        }
+                      },
+                      "Address": {
+                        "type": "location",
+                        "props": {
+                          "layout": "",
+                          "country": ""
+                        }
+                      },
+                      "Telephone": {
+                        "type": "telephone",
+                        "props": {
+                          "timeOfDay": "",
+                          "type": "",
+                          "numberType": "",
+                          "number": "",
+                          "extension": "",
+                          "noNumber": false
+                        }
+                      }
+                    }
+                  },
                   "Birthdate": {
                     "type": "datecontrol",
                     "props": {
@@ -4009,6 +4155,12 @@
                       "value": ""
                     }
                   },
+                  "FrequencyComments": {
+                    "type": "radio",
+                    "props": {
+                      "value": ""
+                    }
+                  },
                   "HasAffiliation": {
                     "type": "branch",
                     "props": {
@@ -4072,6 +4224,12 @@
                       "last": "Chris",
                       "suffix": "",
                       "suffixOther": ""
+                    }
+                  },
+                  "OtherCitizenshipDocumentation": {
+                    "type": "textarea",
+                    "props": {
+                      "value": ""
                     }
                   },
                   "Relation": {
@@ -4165,6 +4323,35 @@
                           }
                         }
                       ]
+                    }
+                  },
+                  "AlternateAddress": {
+                    "type": "physicaladdress",
+                    "props": {
+                      "HasDifferentAddress": {
+                        "type": "branch",
+                        "props": {
+                          "value": ""
+                        }
+                      },
+                      "Address": {
+                        "type": "location",
+                        "props": {
+                          "layout": "",
+                          "country": ""
+                        }
+                      },
+                      "Telephone": {
+                        "type": "telephone",
+                        "props": {
+                          "timeOfDay": "",
+                          "type": "",
+                          "numberType": "",
+                          "number": "",
+                          "extension": "",
+                          "noNumber": false
+                        }
+                      }
                     }
                   },
                   "Birthdate": {
@@ -4291,6 +4478,12 @@
                       "value": ""
                     }
                   },
+                  "FrequencyComments": {
+                    "type": "radio",
+                    "props": {
+                      "value": ""
+                    }
+                  },
                   "HasAffiliation": {
                     "type": "branch",
                     "props": {
@@ -4354,6 +4547,12 @@
                       "last": "Chris",
                       "suffix": "",
                       "suffixOther": ""
+                    }
+                  },
+                  "OtherCitizenshipDocumentation": {
+                    "type": "textarea",
+                    "props": {
+                      "value": ""
                     }
                   },
                   "Relation": {

--- a/api/testdata/complete-scenarios/test6.xml
+++ b/api/testdata/complete-scenarios/test6.xml
@@ -280,10 +280,66 @@
               </Relatives>
             </RelativesAndAssociates>
             <Spouse Version="1" Type="Pooled">
+              <MaritalStatus>Divorced</MaritalStatus>
               <Cohabitants>
                 <Answer>No</Answer>
               </Cohabitants>
-              <MaritalStatus>NeverMarried</MaritalStatus>
+              <FormerSpouses>
+                <FormerSpouse ID="1">
+                  <Birth>
+                    <Date>
+                      <Month>11</Month>
+                      <Day>07</Day>
+                      <Year>1985</Year>
+                    </Date>
+                    <Place>
+                      <City>Salem</City>
+                      <State>CA</State>
+                      <Country>United States</Country>
+                    </Place>
+                  </Birth>
+                  <CountriesOfCitizenship>
+                    <Citizenship ID="1">
+                      <Country>United States</Country>
+                    </Citizenship>
+                  </CountriesOfCitizenship>
+                  <Deceased>
+                    <Answer>IDontKnow</Answer>
+                  </Deceased>
+                  <LegalName>
+                    <Last>Roderick</Last>
+                    <First>Joanne</First>
+                    <Middle>Mary</Middle>
+                  </LegalName>
+                  <Marriage>
+                    <Date>
+                      <Month>01</Month>
+                      <Day>22</Day>
+                      <Year>2003</Year>
+                    </Date>
+                    <Place>
+                      <City>Las Vegas</City>
+                      <State>NV</State>
+                    </Place>
+                  </Marriage>
+                  <Separation Type="Divorced">
+                    <Date>
+                      <Month>02</Month>
+                      <Day>13</Day>
+                      <Year>2004</Year>
+                    </Date>
+                    <DivorceRecordLocation>
+                      <Place>
+                        <City>Las Vegas</City>
+                        <State>NV</State>
+                        <ZipCode>88901</ZipCode>
+                      </Place>
+                    </DivorceRecordLocation>
+                  </Separation>
+                  <Telephone DoNotKnow="True"/>
+                </FormerSpouse>
+                <HaveAdditionalEntryAnswer>No</HaveAdditionalEntryAnswer>
+              </FormerSpouses>
             </Spouse>
             <ResidenceHistory Version="1" Type="Pooled">
               <Residencies>

--- a/api/testdata/complete-scenarios/test7.xml
+++ b/api/testdata/complete-scenarios/test7.xml
@@ -666,6 +666,7 @@ in the case. What has occurred in this case!</Relationship>
               </Relatives>
             </RelativesAndAssociates>
             <Spouse Version="1" Type="Pooled">
+              <MaritalStatus>Married</MaritalStatus>
               <Cohabitants>
                 <Answer>Yes</Answer>
                 <Cohabitant ID="1">
@@ -744,7 +745,6 @@ in the case. What has occurred in this case!</Relationship>
               <HaveFormerSpouse>
                 <Answer>No</Answer>
               </HaveFormerSpouse>
-              <MaritalStatus>Married</MaritalStatus>
               <PresentMarriage>
                 <CurrentSpouse ID="1">
                   <Address UseMyCurrentAddress="True"/>

--- a/api/testdata/complete-scenarios/test8.xml
+++ b/api/testdata/complete-scenarios/test8.xml
@@ -271,10 +271,10 @@
               </Relatives>
             </RelativesAndAssociates>
             <Spouse Version="1" Type="Pooled">
+              <MaritalStatus>NeverMarried</MaritalStatus>
               <Cohabitants>
                 <Answer>No</Answer>
               </Cohabitants>
-              <MaritalStatus>NeverMarried</MaritalStatus>
             </Spouse>
             <ResidenceHistory Version="1" Type="Pooled">
               <Residencies>

--- a/api/testdata/complete-scenarios/test9.xml
+++ b/api/testdata/complete-scenarios/test9.xml
@@ -359,13 +359,13 @@
               </Relatives>
             </RelativesAndAssociates>
             <Spouse Version="1" Type="Pooled">
+              <MaritalStatus>Married</MaritalStatus>
               <Cohabitants>
                 <Answer>No</Answer>
               </Cohabitants>
               <HaveFormerSpouse>
                 <Answer>No</Answer>
               </HaveFormerSpouse>
-              <MaritalStatus>Married</MaritalStatus>
               <PresentMarriage>
                 <CurrentSpouse ID="1">
                   <Address>

--- a/api/xml/xml_test.go
+++ b/api/xml/xml_test.go
@@ -290,8 +290,12 @@ func TestScenario5(t *testing.T) {
 	executeScenario(t, "test5")
 }
 
-// `test6` is a basic smoke test, a bare bones application plus:
+// `test6` is a basic smoke test, originally just created for NBIB to reject.
+// `test6` is a good coarse-grained test case to extend for newly discovered
+// edge cases if specific fine-grained tests don't exist. It is a bare bones
+// application plus:
 // * Other Foreign Benefit with Other Frequency Type and received at Other interval
+// * Divorced and not currently married
 func TestScenario6(t *testing.T) {
 	executeScenario(t, "test6")
 }


### PR DESCRIPTION
Fixes #1377. Also: encode HaveFormerSpouse in alignment with validation matrix. Side effect: marital status is moved to top of Spouse section in all test cases.

Extended test6 to include triggering scenario (divorced but not currently married). All test scenarios re-submitted to e-QIP successfully (modulo test4, which has 100+ year old applicant now).