### PR TITLE
Fix addresses bug to default to United States

### DIFF
--- a/src/components/Form/Location/Address.jsx
+++ b/src/components/Form/Location/Address.jsx
@@ -12,10 +12,7 @@ import ApoFpo from '../ApoFpo'
 import Show from '../Show'
 import Suggestions from '../Suggestions'
 import { AddressSuggestion } from './AddressSuggestion'
-import LocationValidator, {
-  countryString,
-  isInternational
-} from '../../../validators/location'
+import LocationValidator, { countryString } from '../../../validators/location'
 import { countryValueResolver } from './Location'
 
 export default class Address extends ValidationElement {

--- a/src/components/Form/Location/Address.jsx
+++ b/src/components/Form/Location/Address.jsx
@@ -163,13 +163,23 @@ export default class Address extends ValidationElement {
   }
 
   addressType() {
-    const country = countryString(this.props.country)
+    let country = this.props.country
+    if (typeof country === 'object') {
+      country = countryString(this.props.country)
+      if (country === '') {
+        return 'International'
+      } else if (country === null) {
+        return 'United States'
+      }
+    }
 
     if (['United States', 'POSTOFFICE'].includes(country)) {
       return country
+    } else if (country === '') {
+      return 'United States'
     }
 
-    return "International"
+    return 'International'
   }
 
   openAddressBook() {
@@ -317,7 +327,7 @@ export default class Address extends ValidationElement {
         </Show>
 
         <div className="fields">
-          <Show when={locationValidator.isDomestic()}>
+          <Show when={this.addressType() === 'United States'}>
             <div>
               <div className="usa-form-control">
                 <Street
@@ -394,7 +404,7 @@ export default class Address extends ValidationElement {
               </div>
             </div>
           </Show>
-          <Show when={isInternational(this.props)}>
+          <Show when={this.addressType() === 'International'}>
             <div className="usa-form-control">
               <Street
                 name="street"
@@ -454,7 +464,7 @@ export default class Address extends ValidationElement {
               />
             </div>
           </Show>
-          <Show when={locationValidator.isPostOffice()}>
+          <Show when={this.addressType() === 'POSTOFFICE'}>
             <div>
               <div className="usa-form-control">
                 <Street

--- a/src/components/Form/Location/Address.test.jsx
+++ b/src/components/Form/Location/Address.test.jsx
@@ -174,4 +174,32 @@ describe('The Address component', () => {
     const component = shallow(<Address {...props} />)
     expect(component.find('.reuse-address').length).toEqual(1)
   })
+
+  it('defaults to United States when country is an empty string', () => {
+    const component = shallow(
+      <Address country="" />
+    )
+    expect(component.instance().addressType()).toEqual('United States')
+  })
+
+  it('defaults to International when country object is empty string', () => {
+    const component = shallow(
+      <Address country={{ value: '' }} />
+    )
+    expect(component.instance().addressType()).toEqual('International')
+  })
+
+  it('defaults to United States when country is an object with US', () => {
+    const component = shallow(
+      <Address country={{ value: 'United States'}} />
+    )
+    expect(component.instance().addressType()).toEqual('United States')
+  })
+
+  it('defaults to United States when country is a string  with US', () => {
+    const component = shallow(
+      <Address country="United States" />
+    )
+    expect(component.instance().addressType()).toEqual('United States')
+  })
 })

--- a/src/components/Form/Location/ToggleableLocation.jsx
+++ b/src/components/Form/Location/ToggleableLocation.jsx
@@ -345,7 +345,7 @@ export default class ToggleableLocation extends ValidationElement {
 const branchValue = value => {
   let country = value
   if (typeof country === 'object') {
-    country = countryString(value)
+    country = country.value
     if (country === '') {
       return 'No'
     } else if (country === null) {

--- a/src/components/Form/Location/ToggleableLocation.jsx
+++ b/src/components/Form/Location/ToggleableLocation.jsx
@@ -121,7 +121,7 @@ export default class ToggleableLocation extends ValidationElement {
   addressType() {
     let country = this.props.country
     if (typeof country === 'object') {
-      country = countryString(this.props.country)
+      country = country.value
       if (country === '') {
         return 'International'
       }
@@ -131,9 +131,9 @@ export default class ToggleableLocation extends ValidationElement {
       return ''
     } else if (country === 'United States') {
       return country
+    } else if (country) {
+      return 'International'
     }
-
-    return 'International'
   }
 
   render() {

--- a/src/components/Form/Location/ToggleableLocation.jsx
+++ b/src/components/Form/Location/ToggleableLocation.jsx
@@ -9,8 +9,6 @@ import Country from '../Country'
 import County from '../County'
 import ZipCode from '../ZipCode'
 import Show from '../Show'
-import Radio from '../Radio'
-import RadioGroup from '../RadioGroup'
 import { country, countryValueResolver } from './Location'
 import LocationValidator, { countryString } from '../../../validators/location'
 import Layouts from './Layouts'
@@ -121,7 +119,7 @@ export default class ToggleableLocation extends ValidationElement {
   addressType() {
     let country = this.props.country
     if (typeof country === 'object') {
-      country = country.value
+      country = countryString(country)
       if (country === '') {
         return 'International'
       }
@@ -345,7 +343,7 @@ export default class ToggleableLocation extends ValidationElement {
 const branchValue = value => {
   let country = value
   if (typeof country === 'object') {
-    country = country.value
+    country = countryString(value)
     if (country === '') {
       return 'No'
     } else if (country === null) {

--- a/src/components/Form/Location/ToggleableLocation.jsx
+++ b/src/components/Form/Location/ToggleableLocation.jsx
@@ -36,7 +36,7 @@ export default class ToggleableLocation extends ValidationElement {
     this.updateZipcode = this.updateZipcode.bind(this)
     this.zipcodeInstate = this.zipcodeInstate.bind(this)
     this.onError = this.onError.bind(this)
-
+    this.addressType = this.addressType.bind(this)
     this.state = {
       suggestions: [],
       uid: `${this.props.name}-${super.guid()}`
@@ -116,6 +116,24 @@ export default class ToggleableLocation extends ValidationElement {
     const validator = new LocationValidator(this.props)
 
     return validator.validZipcodeState()
+  }
+
+  addressType() {
+    let country = this.props.country
+    if (typeof country === 'object') {
+      country = countryString(this.props.country)
+      if (country === '') {
+        return 'International'
+      }
+    }
+
+    if (country === '') {
+      return ''
+    } else if (country === 'United States') {
+      return country
+    }
+
+    return 'International'
   }
 
   render() {
@@ -262,7 +280,7 @@ export default class ToggleableLocation extends ValidationElement {
       }
     })
 
-    const countryName = country(this.props.country)
+    const countryName = countryString(this.props.country)
     return (
       <div className="toggleable-location">
         <Branch
@@ -275,10 +293,10 @@ export default class ToggleableLocation extends ValidationElement {
           yesLabel={i18n.m('address.options.us.label')}
           value={branchValue(this.props.country)}
         />
-        <Show when={countryName !== null && countryName === 'United States'}>
+        <Show when={this.addressType() === 'United States'}>
           {domesticFields}
         </Show>
-        <Show when={countryName !== null && countryName !== 'United States'}>
+        <Show when={this.addressType() === 'International'}>
           {internationalFields}
         </Show>
       </div>
@@ -325,16 +343,21 @@ export default class ToggleableLocation extends ValidationElement {
 }
 
 const branchValue = value => {
-  const countryName = country(value)
-
-  if (countryName === null) {
-    // Neutral state
-    return ''
+  let country = value
+  if (typeof country === 'object') {
+    country = countryString(value)
+    if (country === '') {
+      return 'No'
+    } else if (country === null) {
+      return ''
+    }
   }
 
-  switch (countryName) {
+  switch (country) {
     case 'United States':
       return 'Yes'
+    case '':
+      return ''
     default:
       // For all other cases, country is an empty string (user intends to select country) or
       // user has selected a country

--- a/src/validators/location.js
+++ b/src/validators/location.js
@@ -10,12 +10,16 @@ export const isInternational = location => {
 }
 
 export const countryString = country => {
-  if (country && isDefined(country.value)) {
-    if (Array.isArray(country.value)) {
-      return country.value[0]
-    }
+  if (country) {
+    if (isDefined(country.value)) {
+      if (Array.isArray(country.value)) {
+        return country.value[0]
+      }
 
-    return country.value
+      return country.value
+    } else if (country.value === null) {
+      return null
+    }
   }
 
   return country


### PR DESCRIPTION
Fixes #1266 and #1365 

This PR fixes two issues because they are somewhat related.

When a country field is fresh and untouched, it is initialized as:
```
{
  value: null
}
```

When a country field is loaded from the database, it is filled out as a string: "Canada"

When a country field is updated in the input field, it fills out as an object:
```
{
  value: "Cana"
}
```

Because of each of these cases, this is why we created the `countryString` function. I needed to tweak it a little bit so it knows how to handle `null` values.