### PR TITLE
Don't duplicate value state in Email form component

### DIFF
--- a/src/components/Form/Email/Email.jsx
+++ b/src/components/Form/Email/Email.jsx
@@ -6,11 +6,6 @@ export default class Email extends ValidationElement {
   constructor(props) {
     super(props)
 
-    this.state = {
-      pattern: props.pattern,
-      value: props.value
-    }
-
     this.handleError = this.handleError.bind(this)
   }
 
@@ -18,15 +13,14 @@ export default class Email extends ValidationElement {
    * Handle the change event.
    */
   handleChange(event) {
-    this.setState({ value: event.target.value }, () => {
-      super.handleChange(event)
-      if (this.props.onUpdate) {
-        this.props.onUpdate({
-          name: this.props.name,
-          value: this.state.value
-        })
-      }
-    })
+    const { onUpdate, name} = this.props
+    const { value } = event.target
+
+    super.handleChange(event)
+
+    if (onUpdate) {
+      onUpdate({ name, value })
+    }
   }
 
   handleError(value, arr) {
@@ -42,6 +36,8 @@ export default class Email extends ValidationElement {
   }
 
   render() {
+    const { pattern, value } = this.props
+
     return (
       <Generic
         name={this.props.name}
@@ -52,14 +48,14 @@ export default class Email extends ValidationElement {
         type="text"
         disabled={this.props.disabled}
         maxlength={this.props.maxlength}
-        pattern={this.state.pattern}
+        pattern={pattern}
         readonly={this.props.readonly}
         required={this.props.required}
         autocapitalize={this.props.autocapitalize}
         autocorrect={this.props.autocorrect}
         autocomplete={this.props.autocomplete}
         spellcheck={this.props.spellcheck}
-        value={this.state.value}
+        value={value}
         onChange={this.handleChange}
         onFocus={this.props.Focus}
         onBlur={this.props.Blur}

--- a/src/components/Section/History/Education/EducationItem.jsx
+++ b/src/components/Section/History/Education/EducationItem.jsx
@@ -144,7 +144,8 @@ export default class EducationItem extends ValidationElement {
 
   updateReferenceEmailNotApplicable(values) {
     this.update({
-      ReferenceEmailNotApplicable: values
+      ReferenceEmailNotApplicable: values,
+      ReferenceEmail: values.applicable ? this.props.ReferenceEmail : {}
     })
   }
 

--- a/src/config/locales/en/history.js
+++ b/src/config/locales/en/history.js
@@ -1637,7 +1637,7 @@ export const history = {
       comments:
         'If you need to provide additional comments about this information enter them below',
       type: 'Select the most appropriate option to describe your school',
-      reference: 'List a person who can verify that you attened this school',
+      reference: 'List a person who can verify that you attended this school',
       diploma: 'Provide type of degree(s)/diploma(s) received',
       date: 'Date awarded'
     },


### PR DESCRIPTION
Fixes https://github.com/18F/e-QIP-prototype/issues/1034

Root cause was the Email input `value` persisting in component state. It was not being used in any way that differed from `props.value` so I removed the state altogether.