### PR TITLE
Fix minor print issues

### DIFF
--- a/src/components/Form/Currency/Currency.scss
+++ b/src/components/Form/Currency/Currency.scss
@@ -12,7 +12,8 @@
     display: inline-block;
   }
 
-  input[type='text'] {
+  input[type='text'],
+  .print-only {
     padding-left: 3rem;
   }
 }

--- a/src/components/Form/Telephone/Telephone.jsx
+++ b/src/components/Form/Telephone/Telephone.jsx
@@ -691,7 +691,7 @@ export default class Telephone extends ValidationElement {
         <Show when={this.props.label}>
           <span>{this.props.label}</span>
         </Show>
-        <div className="type">
+        <div className="type screen-only">
           Switch to:
           <Show when={phoneType !== 'Domestic'}>
             <span className="type">

--- a/src/sass/print.scss
+++ b/src/sass/print.scss
@@ -50,7 +50,7 @@
 
 @media only print {
   .screen-only {
-    display: none
+    display: none;
   }
 
   .print-only {

--- a/src/sass/print.scss
+++ b/src/sass/print.scss
@@ -49,6 +49,10 @@
 }
 
 @media only print {
+  .screen-only {
+    display: none
+  }
+
   .print-only {
     display: unset;
     visibility: visible;


### PR DESCRIPTION
Fixes #1387 

This PR:
- Fixes the "$" overlapping the currency amount in the print layout.
- Hides the switch phone number type control

Future Action Item
- We might want to consider a different print rendering for fields that have multiple countries selected. See image in the GitHub issue.