### PR TITLE
Remove time of day radios from residence reference phone inputs

### DIFF
--- a/api/templates/telephone.xml
+++ b/api/templates/telephone.xml
@@ -22,4 +22,6 @@ Also, here are some additional findings:
 {{- if ne .props.extension ""}}
 <Extension>{{.props.extension}}</Extension>
 {{- end}}
+{{- if ne .props.timeOfDay "NA"}}
 <Time>{{.props.timeOfDay}}</Time>
+{{- end}}

--- a/src/components/Form/Telephone/Telephone.jsx
+++ b/src/components/Form/Telephone/Telephone.jsx
@@ -116,7 +116,7 @@ export default class Telephone extends ValidationElement {
   update(queue) {
     this.props.onUpdate({
       name: this.props.name,
-      timeOfDay: this.props.timeOfDay,
+      timeOfDay: this.props.showTimeOfDay ? this.props.timeOfDay : 'NA',
       type: this.props.type || 'Domestic',
       numberType: this.props.numberType,
       number: this.getFormattedNumber(),
@@ -734,43 +734,45 @@ export default class Telephone extends ValidationElement {
 
         <Show when={phoneType === 'International'}>{this.international()}</Show>
 
-        <div className="timeofday">
-          <RadioGroup
-            selectedValue={this.props.timeOfDay}
-            name="timeofday"
-            disabled={this.props.noNumber}>
-            <Radio
-              native={true}
-              className="time day"
-              label={i18n.t('telephone.timeOfDay.day')}
-              value="Day"
-              ariaLabel={i18n.t('telephone.aria.day')}
-              disabled={this.props.noNumber}
-              onUpdate={this.updateTimeOfDay}
-              onError={this.handleErrorTime}
-            />
-            <Radio
-              native={true}
-              className="time night"
-              label={i18n.t('telephone.timeOfDay.night')}
-              value="Night"
-              ariaLabel={i18n.t('telephone.aria.night')}
-              disabled={this.props.noNumber}
-              onUpdate={this.updateTimeOfDay}
-              onError={this.handleErrorTime}
-            />
-            <Radio
-              native={true}
-              className="time both"
-              label={i18n.t('telephone.timeOfDay.both')}
-              value="Both"
-              ariaLabel={i18n.t('telephone.aria.both')}
-              disabled={this.props.noNumber}
-              onUpdate={this.updateTimeOfDay}
-              onError={this.handleErrorTime}
-            />
-          </RadioGroup>
-        </div>
+        <Show when={this.props.showTimeOfDay}>
+          <div className="timeofday">
+            <RadioGroup
+              selectedValue={this.props.timeOfDay}
+              name="timeofday"
+              disabled={this.props.noNumber}>
+              <Radio
+                native={true}
+                className="time day"
+                label={i18n.t('telephone.timeOfDay.day')}
+                value="Day"
+                ariaLabel={i18n.t('telephone.aria.day')}
+                disabled={this.props.noNumber}
+                onUpdate={this.updateTimeOfDay}
+                onError={this.handleErrorTime}
+              />
+              <Radio
+                native={true}
+                className="time night"
+                label={i18n.t('telephone.timeOfDay.night')}
+                value="Night"
+                ariaLabel={i18n.t('telephone.aria.night')}
+                disabled={this.props.noNumber}
+                onUpdate={this.updateTimeOfDay}
+                onError={this.handleErrorTime}
+              />
+              <Radio
+                native={true}
+                className="time both"
+                label={i18n.t('telephone.timeOfDay.both')}
+                value="Both"
+                ariaLabel={i18n.t('telephone.aria.both')}
+                disabled={this.props.noNumber}
+                onUpdate={this.updateTimeOfDay}
+                onError={this.handleErrorTime}
+              />
+            </RadioGroup>
+          </div>
+        </Show>
 
         <Show when={this.props.showNumberType}>
           <div
@@ -831,6 +833,7 @@ Telephone.defaultProps = {
   extension: '',
   noNumber: false,
   showNumberType: false,
+  showTimeOfDay: true,
   allowNotApplicable: true,
   tab: input => {
     input.focus()

--- a/src/components/Form/Telephone/Telephone.test.jsx
+++ b/src/components/Form/Telephone/Telephone.test.jsx
@@ -312,6 +312,14 @@ describe('The Telephone component', () => {
     expect(component.find('.phonetype').length).toBe(0)
   })
 
+  it('can hide time of day', () => {
+    const props = {
+      showTimeOfDay: false
+    }
+    const component = mount(<Telephone {...props} />)
+    expect(component.find('.time.day input').length).toBe(0)
+  })
+
   it('can disable not applicable on on telephone', () => {
     const props = {
       allowNotApplicable: false

--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -414,36 +414,36 @@ export default class ResidenceItem extends ValidationElement {
                     className="reference-relationship-neighbor"
                     label={i18n.t('reference.label.relationship.neighbor')}
                     value="Neighbor"
-                    onUpdate={this.updateReferenceRelationship}>
-                  </Checkbox>
+                    onUpdate={this.updateReferenceRelationship}
+                  />
                   <Checkbox
                     name="relationship-friend"
                     className="reference-relationship-friend"
                     label={i18n.t('reference.label.relationship.friend')}
                     value="Friend"
-                    onUpdate={this.updateReferenceRelationship}>
-                  </Checkbox>
+                    onUpdate={this.updateReferenceRelationship}
+                  />
                   <Checkbox
                     name="relationship-landlord"
                     className="reference-relationship-landlord"
                     label={i18n.t('reference.label.relationship.landlord')}
                     value="Landlord"
-                    onUpdate={this.updateReferenceRelationship}>
-                  </Checkbox>
+                    onUpdate={this.updateReferenceRelationship}
+                  />
                   <Checkbox
                     name="relationship-business"
                     className="reference-relationship-business"
                     label={i18n.t('reference.label.relationship.business')}
                     value="Business"
-                    onUpdate={this.updateReferenceRelationship}>
-                  </Checkbox>
+                    onUpdate={this.updateReferenceRelationship}
+                  />
                   <Checkbox
                     name="relationship-other"
                     className="reference-relationship-other"
                     label={i18n.t('reference.label.relationship.other')}
                     value="Other"
-                    onUpdate={this.updateReferenceRelationship}>
-                  </Checkbox>
+                    onUpdate={this.updateReferenceRelationship}
+                  />
                 </CheckboxGroup>
                 <Show
                   when={(
@@ -487,6 +487,7 @@ export default class ResidenceItem extends ValidationElement {
                   onUpdate={this.updateReferencePhoneEvening}
                   onError={this.props.onError}
                   required={this.props.required}
+                  showTimeOfDay={false}
                 />
               </Field>
 
@@ -504,6 +505,7 @@ export default class ResidenceItem extends ValidationElement {
                   onUpdate={this.updateReferencePhoneDay}
                   onError={this.props.onError}
                   required={this.props.required}
+                  showTimeOfDay={false}
                 />
               </Field>
 
@@ -521,6 +523,7 @@ export default class ResidenceItem extends ValidationElement {
                   onUpdate={this.updateReferencePhoneMobile}
                   onError={this.props.onError}
                   required={this.props.required}
+                  showTimeOfDay={false}
                 />
               </Field>
 

--- a/src/validators/helpers.test.js
+++ b/src/validators/helpers.test.js
@@ -309,6 +309,17 @@ describe('Helpers for validators', function() {
       {
         phone: null,
         expected: false
+      },
+      {
+        phone: {
+          noNumber: '',
+          number: '7031112222',
+          numberType: 'Home',
+          timeOfDay: '',
+          type: 'Domestic',
+          extension: ''
+        },
+        expected: false
       }
     ]
 


### PR DESCRIPTION
Fixes #1331 

Removes time of day radio buttons from the evening, daytime, and mobile phone inputs found in the reference section of "Where you have lived".

This appears to be an isolated instances of this happening, I could not find any other sections in the form that have multiple phone inputs such as evening, daytime, and mobile.