### PR TITLE
Update .babelrc to understand class arrow functions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-    "presets": ["es2015", "react", "stage-2"]
+    "presets": ["es2015", "react", "stage-2"],
+    "plugins": ["transform-class-properties"]
 }

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,6 +8,7 @@ env:
   es6: true
   node: true
   jest: true
+parser: babel-eslint
 parserOptions:
   ecmaVersion: 9
   sourceType: module

--- a/package.json
+++ b/package.json
@@ -69,7 +69,9 @@
   },
   "devDependencies": {
     "babel-core": "^6.26.3",
+    "babel-eslint": "^10.0.1",
     "babel-loader": "^7.1.4",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-2": "^6.24.1",

--- a/src/components/Section/Package/ValidForm.jsx
+++ b/src/components/Section/Package/ValidForm.jsx
@@ -18,20 +18,12 @@ export default class ValidForm extends ValidationElement {
   constructor(props) {
     super(props)
 
-    this.update = this.update.bind(this)
-    this.updateComments = this.updateComments.bind(this)
-    this.updateGeneral = this.updateGeneral.bind(this)
-    this.updateMedical = this.updateMedical.bind(this)
-    this.updateCredit = this.updateCredit.bind(this)
-    this.accordionItems = this.accordionItems.bind(this)
-    this.submit = this.submit.bind(this)
-
     this.state = {
       accordionItems: this.accordionItems()
     }
   }
 
-  update(queue) {
+  update = (queue) => {
     this.props.onUpdate({
       AdditionalComments: this.props.AdditionalComments,
       General: this.props.General,
@@ -42,31 +34,31 @@ export default class ValidForm extends ValidationElement {
     })
   }
 
-  updateComments(values) {
+  updateComments = (values) => {
     this.update({
       AdditionalComments: values
     })
   }
 
-  updateGeneral(values) {
+  updateGeneral = (values) => {
     this.update({
       General: values
     })
   }
 
-  updateMedical(values) {
+  updateMedical = (values) => {
     this.update({
       Medical: values
     })
   }
 
-  updateCredit(values) {
+  updateCredit = (values) => {
     this.update({
       Credit: values
     })
   }
 
-  submit() {
+  submit = () => {
     if (window.confirm('Are you sure you want to submit this application?')) {
       this.props.onSubmit()
     }
@@ -91,7 +83,7 @@ export default class ValidForm extends ValidationElement {
     }
   }
 
-  accordionItems() {
+  accordionItems = () => {
     const self = this
     return [
       {


### PR DESCRIPTION
`this` is a very important scope issue in Javascript.
This plugin will transform class properties so that we can define class properties using property initializer syntax.

Currently
```
class Component extends React.Component {
  constructor(props) {
    super(props);

    this.someFunction = this.someFunction.bind(this)
  }

  someFunction() {
    {...}
  }

  render() {
    {...}
  }
}
```

After this PR
```
class Component extends React.Component {
  constructor(props) {
    super(props);
  }

  someFunction = () => {
    {...}
  }

  render() {
    {...}
  }
}
```

The arrow functions automatically binds `this`.


Things we need to verify:
1. The code runs (duh) and functionality is not changed.
2. ESLint doesn't complain about the syntax.