### PR TITLE
Derived citizenship document validation fix

### DIFF
--- a/src/components/Section/Citizenship/Status/Status.jsx
+++ b/src/components/Section/Citizenship/Status/Status.jsx
@@ -21,46 +21,9 @@ import {
 export default class Status extends SubsectionElement {
   constructor(props) {
     super(props)
-
-    this.update = this.update.bind(this)
-    this.updateCitizenshipStatus = this.updateCitizenshipStatus.bind(this)
-    this.updateAbroadDocumentation = this.updateAbroadDocumentation.bind(this)
-    this.updateExplanation = this.updateExplanation.bind(this)
-    this.updateDocumentNumber = this.updateDocumentNumber.bind(this)
-    this.updateDocumentIssued = this.updateDocumentIssued.bind(this)
-    this.updatePlaceIssued = this.updatePlaceIssued.bind(this)
-    this.updateDocumentName = this.updateDocumentName.bind(this)
-    this.updateCertificateNumber = this.updateCertificateNumber.bind(this)
-    this.updateCertificateIssued = this.updateCertificateIssued.bind(this)
-    this.updateCertificateName = this.updateCertificateName.bind(this)
-    this.updateBornOnMilitaryInstallation = this.updateBornOnMilitaryInstallation.bind(
-      this
-    )
-    this.updateMilitaryBase = this.updateMilitaryBase.bind(this)
-    this.updateEntryDate = this.updateEntryDate.bind(this)
-    this.updateEntryLocation = this.updateEntryLocation.bind(this)
-    this.updatePriorCitizenship = this.updatePriorCitizenship.bind(this)
-    this.updateHasAlienRegistration = this.updateHasAlienRegistration.bind(this)
-    this.updateAlienRegistrationNumber = this.updateAlienRegistrationNumber.bind(
-      this
-    )
-    this.updateAlienRegistrationExpiration = this.updateAlienRegistrationExpiration.bind(
-      this
-    )
-    this.updateCertificateCourtName = this.updateCertificateCourtName.bind(this)
-    this.updateCertificateCourtAddress = this.updateCertificateCourtAddress.bind(
-      this
-    )
-    this.updateBasis = this.updateBasis.bind(this)
-    this.updatePermanentResidentCardNumber = this.updatePermanentResidentCardNumber.bind(
-      this
-    )
-    this.updateResidenceStatus = this.updateResidenceStatus.bind(this)
-    this.updateDocumentType = this.updateDocumentType.bind(this)
-    this.updateDocumentExpiration = this.updateDocumentExpiration.bind(this)
   }
 
-  update(queue) {
+  update = (queue) => {
     this.props.onUpdate({
       CitizenshipStatus: this.props.CitizenshipStatus,
       AbroadDocumentation: this.props.AbroadDocumentation,
@@ -91,151 +54,151 @@ export default class Status extends SubsectionElement {
     })
   }
 
-  updateCitizenshipStatus(values) {
+  updateCitizenshipStatus = (values) => {
     this.update({
       CitizenshipStatus: values
     })
   }
 
-  updateAbroadDocumentation(values) {
+  updateAbroadDocumentation = (values) => {
     this.update({
       AbroadDocumentation: values
     })
   }
 
-  updateExplanation(values) {
+  updateExplanation = (values) => {
     this.update({
       Explanation: values
     })
   }
 
-  updateDocumentNumber(values) {
+  updateDocumentNumber = (values) => {
     this.update({
       DocumentNumber: values
     })
   }
 
-  updateDocumentIssued(values) {
+  updateDocumentIssued = (values) => {
     this.update({
       DocumentIssued: values
     })
   }
 
-  updatePlaceIssued(values) {
+  updatePlaceIssued = (values) => {
     this.update({
       PlaceIssued: values
     })
   }
 
-  updateDocumentName(values) {
+  updateDocumentName = (values) => {
     this.update({
       DocumentName: values
     })
   }
 
-  updateCertificateNumber(values) {
+  updateCertificateNumber = (values) => {
     this.update({
       CertificateNumber: values
     })
   }
 
-  updateCertificateIssued(values) {
+  updateCertificateIssued = (values) => {
     this.update({
       CertificateIssued: values
     })
   }
 
-  updateCertificateName(values) {
+  updateCertificateName = (values) => {
     this.update({
       CertificateName: values
     })
   }
 
-  updateBornOnMilitaryInstallation(values) {
+  updateBornOnMilitaryInstallation = (values) => {
     this.update({
       BornOnMilitaryInstallation: values
     })
   }
 
-  updateMilitaryBase(values) {
+  updateMilitaryBase = (values) => {
     this.update({
       MilitaryBase: values
     })
   }
 
-  updateEntryDate(values) {
+  updateEntryDate = (values) => {
     this.update({
       EntryDate: values
     })
   }
 
-  updateEntryLocation(values) {
+  updateEntryLocation = (values) => {
     this.update({
       EntryLocation: values
     })
   }
 
-  updatePriorCitizenship(values) {
+  updatePriorCitizenship = (values) => {
     this.update({
       PriorCitizenship: values
     })
   }
 
-  updateHasAlienRegistration(values) {
+  updateHasAlienRegistration = (values) => {
     this.update({
       HasAlienRegistration: values
     })
   }
 
-  updateAlienRegistrationNumber(values) {
+  updateAlienRegistrationNumber = (values) => {
     this.update({
       AlienRegistrationNumber: values
     })
   }
 
-  updateAlienRegistrationExpiration(values) {
+  updateAlienRegistrationExpiration = (values) => {
     this.update({
       AlienRegistrationExpiration: values
     })
   }
 
-  updateCertificateCourtName(values) {
+  updateCertificateCourtName = (values) => {
     this.update({
       CertificateCourtName: values
     })
   }
 
-  updateCertificateCourtAddress(values) {
+  updateCertificateCourtAddress = (values) => {
     this.update({
       CertificateCourtAddress: values
     })
   }
 
-  updateBasis(values) {
+  updateBasis = (values) => {
     this.update({
       Basis: values
     })
   }
 
-  updatePermanentResidentCardNumber(values) {
+  updatePermanentResidentCardNumber = (values) => {
     this.update({
       PermanentResidentCardNumber: values
     })
   }
 
-  updateResidenceStatus(values) {
+  updateResidenceStatus = (values) => {
     this.update({
       ResidenceStatus: values
     })
   }
 
-  updateDocumentType(values) {
+  updateDocumentType = (values) => {
     this.update({
       DocumentType: values
     })
   }
 
-  updateDocumentExpiration(values) {
+  updateDocumentExpiration = (values) => {
     this.update({
       DocumentExpiration: values
     })

--- a/src/components/Section/Citizenship/Status/Status.jsx
+++ b/src/components/Section/Citizenship/Status/Status.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { i18n } from 'config'
-import { alphaNumericRegEx } from 'validators/helpers'
+import { alphaNumericRegEx, validGenericTextfield } from 'validators/helpers'
 import schema from 'schema'
 import validate from 'validators'
 import SubsectionElement from 'components/Section/SubsectionElement'
@@ -202,6 +202,24 @@ export default class Status extends SubsectionElement {
     this.update({
       DocumentExpiration: values
     })
+  }
+
+  derivedAlienRegistrationNumberRequired = () => {
+    return this.props.required &&
+      !validGenericTextfield(this.props.PermanentResidentCardNumber) &&
+      !validGenericTextfield(this.props.CertificateNumber)
+  }
+
+  derivedPermanentResidentCardNumberRequired = () => {
+    return this.props.required &&
+      !validGenericTextfield(this.props.AlienRegistrationNumber) &&
+      !validGenericTextfield(this.props.CertificateNumber)
+  }
+
+  derivedCertificateNumberRequired = () => {
+    return this.props.required &&
+      !validGenericTextfield(this.props.AlienRegistrationNumber) &&
+      !validGenericTextfield(this.props.PermanentResidentCardNumber)
   }
 
   render() {
@@ -720,7 +738,7 @@ export default class Status extends SubsectionElement {
                 {...this.props.AlienRegistrationNumber}
                 onUpdate={this.updateAlienRegistrationNumber}
                 onError={this.handleError}
-                required={this.props.required}
+                required={this.derivedAlienRegistrationNumberRequired()}
               />
             </Field>
 
@@ -738,7 +756,7 @@ export default class Status extends SubsectionElement {
                 {...this.props.PermanentResidentCardNumber}
                 onUpdate={this.updatePermanentResidentCardNumber}
                 onError={this.handleError}
-                required={this.props.required}
+                required={this.derivedPermanentResidentCardNumberRequired()}
               />
             </Field>
 
@@ -756,7 +774,7 @@ export default class Status extends SubsectionElement {
                 prefix="alphanumeric"
                 onUpdate={this.updateCertificateNumber}
                 onError={this.handleError}
-                required={this.props.required}
+                required={this.derivedCertificateNumberRequired()}
               />
             </Field>
 

--- a/src/components/Section/Citizenship/Status/Status.jsx
+++ b/src/components/Section/Citizenship/Status/Status.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { i18n } from '../../../../config'
-import { alphaNumericRegEx } from '../../../../validators/helpers'
-import schema from '../../../../schema'
-import validate from '../../../../validators'
-import SubsectionElement from '../../SubsectionElement'
+import { i18n } from 'config'
+import { alphaNumericRegEx } from 'validators/helpers'
+import schema from 'schema'
+import validate from 'validators'
+import SubsectionElement from 'components/Section/SubsectionElement'
 import {
   Branch,
   Show,
@@ -16,7 +16,7 @@ import {
   DateControl,
   Country,
   Location
-} from '../../../Form'
+} from 'components/Form'
 
 export default class Status extends SubsectionElement {
   constructor(props) {

--- a/src/components/Section/Citizenship/Status/Status.test.jsx
+++ b/src/components/Section/Citizenship/Status/Status.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import configureMockStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
-import { mount } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import Status from './Status'
 
 describe('The status component', () => {
@@ -222,5 +222,140 @@ describe('The status component', () => {
       .find('.document-issued .day input')
       .simulate('change', { target: { name: 'day', value: '1' } })
     expect(updates).toBe(12)
+  })
+
+  describe('derivedAlienRegistrationNumberRequired', () => {
+    it('returns false when not required', () => {
+      const expected = {
+        name: 'status',
+        CitizenshipStatus: { value: 'Derived' },
+        required: false
+      }
+      const component = shallow(<Status {...expected} />)
+      const instance = component.instance()
+      expect(instance.derivedAlienRegistrationNumberRequired()).toBe(false)
+    })
+    it('returns true when required and other fields not filled', () => {
+      const expected = {
+        name: 'status',
+        CitizenshipStatus: { value: 'Derived' },
+        required: true
+      }
+      const component = shallow(<Status {...expected} />)
+      const instance = component.instance()
+      expect(instance.derivedAlienRegistrationNumberRequired()).toBe(true)
+    })
+    it('returns false when required and PermanentResidentCardNumber filled in', () => {
+      const expected = {
+        name: 'status',
+        CitizenshipStatus: { value: 'Derived' },
+        PermanentResidentCardNumber: { value: '1234' },
+        required: true
+      }
+      const component = shallow(<Status {...expected} />)
+      const instance = component.instance()
+      expect(instance.derivedAlienRegistrationNumberRequired()).toBe(false)
+    })
+    it('returns false when required and CertificateNumber filled in', () => {
+      const expected = {
+        name: 'status',
+        CitizenshipStatus: { value: 'Derived' },
+        CertificateNumber: { value: '1234' },
+        required: true
+      }
+      const component = shallow(<Status {...expected} />)
+      const instance = component.instance()
+      expect(instance.derivedAlienRegistrationNumberRequired()).toBe(false)
+    })
+  })
+
+  describe('derivedPermanentResidentCardNumberRequired', () => {
+    it('returns false when not required', () => {
+      const expected = {
+        name: 'status',
+        CitizenshipStatus: { value: 'Derived' },
+        required: false
+      }
+      const component = shallow(<Status {...expected} />)
+      const instance = component.instance()
+      expect(instance.derivedPermanentResidentCardNumberRequired()).toBe(false)
+    })
+    it('returns true when required and other fields not filled', () => {
+      const expected = {
+        name: 'status',
+        CitizenshipStatus: { value: 'Derived' },
+        required: true
+      }
+      const component = shallow(<Status {...expected} />)
+      const instance = component.instance()
+      expect(instance.derivedPermanentResidentCardNumberRequired()).toBe(true)
+    })
+    it('returns false when required and PermanentResidentCardNumber filled in', () => {
+      const expected = {
+        name: 'status',
+        CitizenshipStatus: { value: 'Derived' },
+        AlienRegistrationNumber: { value: '1234' },
+        required: true
+      }
+      const component = shallow(<Status {...expected} />)
+      const instance = component.instance()
+      expect(instance.derivedPermanentResidentCardNumberRequired()).toBe(false)
+    })
+    it('returns false when required and CertificateNumber filled in', () => {
+      const expected = {
+        name: 'status',
+        CitizenshipStatus: { value: 'Derived' },
+        CertificateNumber: { value: '1234' },
+        required: true
+      }
+      const component = shallow(<Status {...expected} />)
+      const instance = component.instance()
+      expect(instance.derivedPermanentResidentCardNumberRequired()).toBe(false)
+    })
+  })
+
+  describe('derivedCertificateNumberRequired', () => {
+    it('returns false when not required', () => {
+      const expected = {
+        name: 'status',
+        CitizenshipStatus: { value: 'Derived' },
+        required: false
+      }
+      const component = shallow(<Status {...expected} />)
+      const instance = component.instance()
+      expect(instance.derivedCertificateNumberRequired()).toBe(false)
+    })
+    it('returns true when required and other fields not filled', () => {
+      const expected = {
+        name: 'status',
+        CitizenshipStatus: { value: 'Derived' },
+        required: true
+      }
+      const component = shallow(<Status {...expected} />)
+      const instance = component.instance()
+      expect(instance.derivedCertificateNumberRequired()).toBe(true)
+    })
+    it('returns false when required and PermanentResidentCardNumber filled in', () => {
+      const expected = {
+        name: 'status',
+        CitizenshipStatus: { value: 'Derived' },
+        AlienRegistrationNumber: { value: '1234' },
+        required: true
+      }
+      const component = shallow(<Status {...expected} />)
+      const instance = component.instance()
+      expect(instance.derivedCertificateNumberRequired()).toBe(false)
+    })
+    it('returns false when required and CertificateNumber filled in', () => {
+      const expected = {
+        name: 'status',
+        CitizenshipStatus: { value: 'Derived' },
+        PermanentResidentCardNumber: { value: '1234' },
+        required: true
+      }
+      const component = shallow(<Status {...expected} />)
+      const instance = component.instance()
+      expect(instance.derivedCertificateNumberRequired()).toBe(false)
+    })
   })
 })

--- a/src/validators/citizenship.js
+++ b/src/validators/citizenship.js
@@ -89,9 +89,9 @@ export default class CitizenshipValidator {
     }
 
     return (
-      validGenericTextfield(this.alienRegistrationNumber) &&
-      validGenericTextfield(this.permanentResidentCardNumber) &&
-      validGenericTextfield(this.certificateNumber) &&
+      (validGenericTextfield(this.alienRegistrationNumber) ||
+      validGenericTextfield(this.permanentResidentCardNumber) ||
+      validGenericTextfield(this.certificateNumber)) &&
       new NameValidator(this.certificateName).isValid() &&
       validDateField(this.certificateIssued) &&
       this.validBasis()

--- a/src/validators/citizenship.test.js
+++ b/src/validators/citizenship.test.js
@@ -396,6 +396,39 @@ describe('citizenship component validation', function() {
         data: {
           CitizenshipStatus: { value: 'Derived' },
           AlienRegistrationNumber: {
+            value: ''
+          },
+          PermanentResidentCardNumber: {
+            value: ''
+          },
+          CertificateNumber: {
+            value: ''
+          },
+          CertificateName: {
+            first: 'Foo',
+            firstInitialOnly: false,
+            middle: 'J',
+            middleInitialOnly: true,
+            noMiddleName: false,
+            last: 'Bar',
+            suffix: 'Jr'
+          },
+          CertificateIssued: {
+            day: '1',
+            month: '1',
+            year: '2016'
+          },
+          Basis: { value: 'Other' },
+          Explanation: {
+            value: 'Explanation'
+          }
+        },
+        expected: false
+      },
+      {
+        data: {
+          CitizenshipStatus: { value: 'Derived' },
+          AlienRegistrationNumber: {
             value: 'number'
           },
           PermanentResidentCardNumber: {
@@ -403,6 +436,105 @@ describe('citizenship component validation', function() {
           },
           CertificateNumber: {
             value: 'certificate number'
+          },
+          CertificateName: {
+            first: 'Foo',
+            firstInitialOnly: false,
+            middle: 'J',
+            middleInitialOnly: true,
+            noMiddleName: false,
+            last: 'Bar',
+            suffix: 'Jr'
+          },
+          CertificateIssued: {
+            day: '1',
+            month: '1',
+            year: '2016'
+          },
+          Basis: { value: 'Other' },
+          Explanation: {
+            value: 'Explanation'
+          }
+        },
+        expected: true
+      },
+      {
+        data: {
+          CitizenshipStatus: { value: 'Derived' },
+          AlienRegistrationNumber: {
+            value: 'number'
+          },
+          PermanentResidentCardNumber: {
+            value: ''
+          },
+          CertificateNumber: {
+            value: ''
+          },
+          CertificateName: {
+            first: 'Foo',
+            firstInitialOnly: false,
+            middle: 'J',
+            middleInitialOnly: true,
+            noMiddleName: false,
+            last: 'Bar',
+            suffix: 'Jr'
+          },
+          CertificateIssued: {
+            day: '1',
+            month: '1',
+            year: '2016'
+          },
+          Basis: { value: 'Other' },
+          Explanation: {
+            value: 'Explanation'
+          }
+        },
+        expected: true
+      },
+      {
+        data: {
+          CitizenshipStatus: { value: 'Derived' },
+          AlienRegistrationNumber: {
+            value: ''
+          },
+          PermanentResidentCardNumber: {
+            value: 'number'
+          },
+          CertificateNumber: {
+            value: ''
+          },
+          CertificateName: {
+            first: 'Foo',
+            firstInitialOnly: false,
+            middle: 'J',
+            middleInitialOnly: true,
+            noMiddleName: false,
+            last: 'Bar',
+            suffix: 'Jr'
+          },
+          CertificateIssued: {
+            day: '1',
+            month: '1',
+            year: '2016'
+          },
+          Basis: { value: 'Other' },
+          Explanation: {
+            value: 'Explanation'
+          }
+        },
+        expected: true
+      },
+      {
+        data: {
+          CitizenshipStatus: { value: 'Derived' },
+          AlienRegistrationNumber: {
+            value: 'number'
+          },
+          PermanentResidentCardNumber: {
+            value: ''
+          },
+          CertificateNumber: {
+            value: ''
           },
           CertificateName: {
             first: 'Foo',


### PR DESCRIPTION
## Description

Fixes #1434 by updating the validation rules to allow one or more of the numbers (Alien Registration, Permanent Resident, or Certificate of Citizenship) to be required for Derived Citizenship. At least one is required, and all can be filled in with no issue as well.

Validation issue was affecting the Section Review, Final Review, the green check marks next to the _Citizenship_ section, and the green dot next to the _Citizenship status_ subsection.

## Checklist for Reveiwer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)