### PR TITLE
Add correct fields for citizenship document place of issuance

### DIFF
--- a/src/components/Section/Citizenship/Status/Status.jsx
+++ b/src/components/Section/Citizenship/Status/Status.jsx
@@ -245,9 +245,8 @@ export default class Status extends SubsectionElement {
               scrollIntoView={this.props.scrollIntoView}>
               <Location
                 name="PlaceIssued"
-                label={'Was this issued in the United States?'}
                 {...this.props.PlaceIssued}
-                layout={Location.CITY_STATE_COUNTRY}
+                layout={Location.US_CITY_STATE_ZIP_INTERNATIONAL_CITY}
                 className="place-issued"
                 onUpdate={value => { this.updateField('PlaceIssued', value) }}
                 onError={this.handleError}

--- a/src/components/Section/Citizenship/Status/Status.jsx
+++ b/src/components/Section/Citizenship/Status/Status.jsx
@@ -246,7 +246,7 @@ export default class Status extends SubsectionElement {
               <Location
                 name="PlaceIssued"
                 {...this.props.PlaceIssued}
-                layout={Location.US_CITY_STATE_ZIP_INTERNATIONAL_CITY}
+                layout={Location.BIRTHPLACE_WITHOUT_COUNTY}
                 className="place-issued"
                 onUpdate={value => { this.updateField('PlaceIssued', value) }}
                 onError={this.handleError}

--- a/src/components/Section/Citizenship/Status/Status.test.jsx
+++ b/src/components/Section/Citizenship/Status/Status.test.jsx
@@ -66,8 +66,8 @@ describe('The status component', () => {
       .find('.document-issued .day input')
       .simulate('change', { target: { name: 'day', value: '1' } })
     component
-      .find('.place-issued .city input')
-      .simulate('change', { target: { name: 'city', value: 'City name' } })
+      .find('.place-issued .no input')
+      .simulate('change')
     component
       .find('.document-name .first input')
       .simulate('change', { target: { name: 'first', value: 'The name' } })


### PR DESCRIPTION
## Description
Fixes #1446 
The component had the wrong `prop`. It was displaying the incorrect fields. I have updated it to include the correct fields.

## Checklist for Reveiwer

- [x] Review code changes
- [x] Review changes for Database effects
- [x] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
