### PR TITLE
Use binary buildpack since api is already built

### DIFF
--- a/conf/manifests/api-dev.yml
+++ b/conf/manifests/api-dev.yml
@@ -5,7 +5,7 @@ applications:
   instances: 2
   domain: fr.cloud.gov
   host: eqip-prototype-api-dev
-  buildpack: https://github.com/cloudfoundry/go-buildpack
+  buildpack: https://github.com/cloudfoundry/binary-buildpack
   path: ../../api
   command: ./api
   services:

--- a/conf/manifests/api-staging.yml
+++ b/conf/manifests/api-staging.yml
@@ -5,7 +5,7 @@ applications:
   instances: 2
   domain: fr.cloud.gov
   host: eqip-prototype-api-staging
-  buildpack: https://github.com/cloudfoundry/go-buildpack
+  buildpack: https://github.com/cloudfoundry/binary-buildpack
   path: ../../api
   command: ./api
   services:

--- a/conf/manifests/api.yml
+++ b/conf/manifests/api.yml
@@ -5,7 +5,7 @@ applications:
   instances: 2
   domain: fr.cloud.gov
   host: eqip-prototype-api
-  buildpack: https://github.com/cloudfoundry/go-buildpack
+  buildpack: https://github.com/cloudfoundry/binary-buildpack
   path: ../../api
   command: ./api
   services:


### PR DESCRIPTION
After PR #1289 was merged, deploys to cloud.gov started failing -- the Go
buildpack would not compile the project, due to some yet-to-be-determined
path issue. Best guess is some weird interaction between buildpack, the
package name, the import of a sub-directory in application.go, and a name
collision between pre-built binary (`./api`) and package path (`/api/eqip`).
We can punt on this issue for now, because...

...the Go buildpack is completely unnecessary. Not that it is the preferred
cloud.gov way, but everything is already compiled and staged in the setup
and build Makefile targets. So use the binary buildpack instead, which
elminates a redundant backend compile step.

At some point, it may be worthwhile to change these scripts to push Docker
images directly, as the partner agency is not using Cloud Foundry/cloud.gov.