### PR TITLE
Section Render Refactor - History section

### DIFF
--- a/src/components/Section/History/Education/Education.jsx
+++ b/src/components/Section/History/Education/Education.jsx
@@ -1,12 +1,26 @@
 import React from 'react'
-import { i18n } from '../../../../config'
-import schema from '../../../../schema'
-import validate, { EducationItemValidator } from '../../../../validators'
-import SubsectionElement from '../../SubsectionElement'
-import { Accordion } from '../../../Form'
-import { openState } from '../../../Form/Accordion/Accordion'
+import { i18n } from '@config'
+
+import schema from '@schema'
+import validate, { EducationItemValidator } from '@validators'
+
+import Subsection from '@components/Section/shared/Subsection'
+import connectHistorySection from '../HistoryConnector'
+
+import { Accordion } from '@components/Form'
+import { openState } from '@components/Form/Accordion/Accordion'
+
 import { EducationCustomSummary } from '../summaries'
 import EducationItem from './EducationItem'
+
+import { HISTORY, HISTORY_EDUCATION } from '@config/formSections/history'
+
+const sectionConfig = {
+  section: HISTORY.name,
+  store: HISTORY.store,
+  subsection: HISTORY_EDUCATION.name,
+  storeKey: HISTORY_EDUCATION.storeKey,
+}
 
 const byline = (item, index, initial, translation, required, validator) => {
   switch (true) {
@@ -26,18 +40,27 @@ const byline = (item, index, initial, translation, required, validator) => {
   }
 }
 
-export default class Education extends SubsectionElement {
+export class Education extends Subsection {
   constructor(props) {
     super(props)
+
+    const { section, subsection, store, storeKey } = sectionConfig
+
+    this.section = section
+    this.subsection = subsection
+    this.store = store
+    this.storeKey = storeKey
 
     this.customEducationByline = this.customEducationByline.bind(this)
   }
 
   customEducationByline(item, index, initial) {
+    const overrideInitial = this.props.overrideInitial ? false : initial
+
     return byline(
       item,
       index,
-      this.props.overrideInitial(initial),
+      overrideInitial,
       'history.education.collection.school.summary.incomplete',
       this.props.required,
       item => {
@@ -50,7 +73,7 @@ export default class Education extends SubsectionElement {
     return (
       <div
         className="section-content education"
-        {...super.dataAttributes(this.props)}>
+        {...super.dataAttributes()}>
         <Accordion
           scrollToTop={this.props.scrollToTop}
           defaultState={this.props.defaultState}
@@ -87,6 +110,7 @@ export default class Education extends SubsectionElement {
 
 Education.defaultProps = {
   List: Accordion.defaultList,
+  scrollIntoView: false,
   scrollToTop: '',
   defaultState: true,
   realtime: false,
@@ -107,3 +131,5 @@ Education.defaultProps = {
     return validate(schema('history.education', data))
   }
 }
+
+export default connectHistorySection(Education, sectionConfig)

--- a/src/components/Section/History/Education/Education.jsx
+++ b/src/components/Section/History/Education/Education.jsx
@@ -1,19 +1,18 @@
 import React from 'react'
-import { i18n } from '@config'
+import { i18n } from 'config'
+import { HISTORY, HISTORY_EDUCATION } from 'config/formSections/history'
 
-import schema from '@schema'
-import validate, { EducationItemValidator } from '@validators'
+import schema from 'schema'
+import validate, { EducationItemValidator } from 'validators'
 
-import Subsection from '@components/Section/shared/Subsection'
+import Subsection from 'components/Section/shared/Subsection'
+import { Accordion } from 'components/Form'
+import { openState } from 'components/Form/Accordion/Accordion'
+
 import connectHistorySection from '../HistoryConnector'
-
-import { Accordion } from '@components/Form'
-import { openState } from '@components/Form/Accordion/Accordion'
 
 import { EducationCustomSummary } from '../summaries'
 import EducationItem from './EducationItem'
-
-import { HISTORY, HISTORY_EDUCATION } from '@config/formSections/history'
 
 const sectionConfig = {
   section: HISTORY.name,
@@ -25,18 +24,20 @@ const sectionConfig = {
 const byline = (item, index, initial, translation, required, validator) => {
   switch (true) {
     // If item is required and not currently opened and is not valid, show message
-  case required && !item.open && !validator(item.Item):
-  case !item.open && !initial && item.Item && !validator(item.Item):
-    return (<div className={`byline ${openState(item, initial)} fade in`.trim()}>
-            <div className="usa-alert usa-alert-error" role="alert">
-              <div className="usa-alert-body">
-                <h5 className="usa-alert-heading">{i18n.m(translation)}</h5>
-              </div>
+    case required && !item.open && !validator(item.Item):
+    case !item.open && !initial && item.Item && !validator(item.Item):
+      return (
+        <div className={`byline ${openState(item, initial)} fade in`.trim()}>
+          <div className="usa-alert usa-alert-error" role="alert">
+            <div className="usa-alert-body">
+              <h5 className="usa-alert-heading">{i18n.m(translation)}</h5>
             </div>
-            </div>
-           )
-  default:
-    return null
+          </div>
+        </div>
+      )
+
+    default:
+      return null
   }
 }
 
@@ -44,17 +45,17 @@ export class Education extends Subsection {
   constructor(props) {
     super(props)
 
-    const { section, subsection, store, storeKey } = sectionConfig
+    const {
+      section, subsection, store, storeKey,
+    } = sectionConfig
 
     this.section = section
     this.subsection = subsection
     this.store = store
     this.storeKey = storeKey
-
-    this.customEducationByline = this.customEducationByline.bind(this)
   }
 
-  customEducationByline(item, index, initial) {
+  customEducationByline = (item, index, initial) => {
     const overrideInitial = this.props.overrideInitial ? false : initial
 
     return byline(
@@ -63,9 +64,7 @@ export class Education extends Subsection {
       overrideInitial,
       'history.education.collection.school.summary.incomplete',
       this.props.required,
-      item => {
-        return new EducationItemValidator(item).isValid()
-      }
+      i => new EducationItemValidator(i).isValid(),
     )
   }
 
@@ -73,7 +72,8 @@ export class Education extends Subsection {
     return (
       <div
         className="section-content education"
-        {...super.dataAttributes()}>
+        {...super.dataAttributes()}
+      >
         <Accordion
           scrollToTop={this.props.scrollToTop}
           defaultState={this.props.defaultState}
@@ -86,14 +86,15 @@ export class Education extends Subsection {
           byline={this.customEducationByline}
           customSummary={EducationCustomSummary}
           description={i18n.t(
-            'history.education.collection.school.summary.title'
+            'history.education.collection.school.summary.title',
           )}
           appendTitle={i18n.t(
-            'history.education.collection.school.appendTitle'
+            'history.education.collection.school.appendTitle',
           )}
           appendLabel={i18n.t('history.education.collection.school.append')}
           required={this.props.required}
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <EducationItem
             bind
             name="Item"
@@ -116,20 +117,14 @@ Education.defaultProps = {
   realtime: false,
   sort: null,
   totalYears: 10,
-  overrideInitial: initial => {
-    return initial
-  },
+  overrideInitial: initial => initial,
   caption: null,
   onUpdate: () => {},
-  onError: (value, arr) => {
-    return arr
-  },
+  onError: (value, arr) => arr,
   section: 'history',
   subsection: 'education',
   dispatch: () => {},
-  validator: data => {
-    return validate(schema('history.education', data))
-  }
+  validator: data => validate(schema('history.education', data)),
 }
 
 export default connectHistorySection(Education, sectionConfig)

--- a/src/components/Section/History/Education/Education.jsx
+++ b/src/components/Section/History/Education/Education.jsx
@@ -117,7 +117,7 @@ Education.defaultProps = {
   realtime: false,
   sort: null,
   totalYears: 10,
-  overrideInitial: initial => initial,
+  overrideInitial: false,
   caption: null,
   onUpdate: () => {},
   onError: (value, arr) => arr,

--- a/src/components/Section/History/Education/Education.test.jsx
+++ b/src/components/Section/History/Education/Education.test.jsx
@@ -10,18 +10,20 @@ describe('The Education component', () => {
 
   beforeEach(() => {
     const store = mockStore()
-    createComponent = (expected = {}) =>
+    createComponent = (expected = {}) => (
       mount(
         <Provider store={store}>
           <Education {...expected} />
         </Provider>
       )
+    )
   })
 
   it('no error on empty', () => {
     const expected = {
-      name: 'education'
+      name: 'education',
     }
+
     const component = createComponent(expected)
     expect(component.find('.education').length).toEqual(1)
   })
@@ -32,10 +34,10 @@ describe('The Education component', () => {
       List: {
         items: [
           {
-            Item: {}
-          }
-        ]
-      }
+            Item: {},
+          },
+        ],
+      },
     }
     const component = createComponent(expected)
     expect(component.find('.education').length).toEqual(2)

--- a/src/components/Section/History/Education/Education.test.jsx
+++ b/src/components/Section/History/Education/Education.test.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import configureMockStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
-import Education from './Education'
+import { Education } from './Education'
 
 describe('The Education component', () => {
   const mockStore = configureMockStore()

--- a/src/components/Section/History/Education/EducationSummaryProgress.jsx
+++ b/src/components/Section/History/Education/EducationSummaryProgress.jsx
@@ -1,0 +1,84 @@
+import React from 'react'
+
+import { i18n } from '@config'
+
+import SummaryCounter from '@components/Section/History/SummaryCounter'
+import SummaryProgress from '@components/Section/History/SummaryProgress'
+import { totalYears } from '@components/Section/History/History'
+
+import { Svg } from '@components/Form'
+import { EducationItemValidator } from '@validators'
+
+const excludeGaps = (items) => {
+  return items.filter(
+    item => !item.type || (item.type && item.type !== 'Gap')
+  )
+}
+
+const schoolRangesList = (items) => {
+  const dates = []
+
+  for (const i of items) {
+    if (!i.Item || !i.Item.Dates || !i.Item.Dates.to || !i.Item.Dates.from) {
+      continue
+    }
+
+    if (new EducationItemValidator(i.Item).isValid()) {
+      dates.push(i.Item.Dates)
+    }
+  }
+
+  return dates
+}
+
+const diplomasRangesList = (items) => {
+  const dates = []
+
+  for (const i of items) {
+    if (!i.Item) { continue }
+
+    if (!new EducationItemValidator(i.Item).isValid()) {
+      continue
+    }
+
+    if (i.Item.Diplomas.items) {
+      for (const d of i.Item.Diplomas.items) {
+        if (!d.Item || !d.Item.Date) {
+          continue
+        }
+
+        dates.push(d.Item.Date)
+      }
+    }
+  }
+
+  return dates
+}
+
+const EducationSummaryProgress = (props) => {
+  const { Education, Birthdate } = props
+
+  let schoolDates = []
+  if (Education && Education.List && Education.List.items) {
+    schoolDates = Education.List.items
+  }
+
+  return (
+    <SummaryCounter
+      className="education"
+      title={i18n.t('history.education.summary.title')}
+      schools={schoolRangesList.bind(this, schoolDates)}
+      diplomas={diplomasRangesList.bind(this, schoolDates)}
+      schoolsLabel={i18n.t('history.education.summary.schools')}
+      diplomasLabel={i18n.t('history.education.summary.diplomas')}
+      total={totalYears(Birthdate)}>
+        <div className="summary-icon">
+          <Svg
+            src="/img/school-cap.svg"
+            alt={i18n.t('history.education.summary.svgAlt')} />
+        </div>
+      </SummaryCounter>
+  )
+}
+
+export default EducationSummaryProgress

--- a/src/components/Section/History/Education/EducationSummaryProgress.jsx
+++ b/src/components/Section/History/Education/EducationSummaryProgress.jsx
@@ -1,27 +1,26 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
-import { i18n } from '@config'
+import { i18n } from 'config'
 
-import SummaryCounter from '@components/Section/History/SummaryCounter'
-import SummaryProgress from '@components/Section/History/SummaryProgress'
+import SummaryCounter from 'components/Section/History/SummaryCounter'
+import { totalYears } from 'components/Section/History/helpers'
+import { Svg } from 'components/Form'
 
-import { totalYears } from '@components/Section/History/helpers'
-
-import { Svg } from '@components/Form'
-import { EducationItemValidator } from '@validators'
+import { EducationItemValidator } from 'validators'
 
 const schoolRangesList = (items) => {
   const dates = []
 
-  for (const i of items) {
+  items.forEach((i) => {
     if (!i.Item || !i.Item.Dates || !i.Item.Dates.to || !i.Item.Dates.from) {
-      continue
+      return
     }
 
     if (new EducationItemValidator(i.Item).isValid()) {
       dates.push(i.Item.Dates)
     }
-  }
+  })
 
   return dates
 }
@@ -29,23 +28,21 @@ const schoolRangesList = (items) => {
 const diplomasRangesList = (items) => {
   const dates = []
 
-  for (const i of items) {
-    if (!i.Item) { continue }
+  items.forEach((i) => {
+    if (!i.Item) { return }
 
     if (!new EducationItemValidator(i.Item).isValid()) {
-      continue
+      return
     }
 
     if (i.Item.Diplomas.items) {
-      for (const d of i.Item.Diplomas.items) {
-        if (!d.Item || !d.Item.Date) {
-          continue
-        }
+      i.Item.Diplomas.items.forEach((d) => {
+        if (!d.Item || !d.Item.Date) { return }
 
         dates.push(d.Item.Date)
-      }
+      })
     }
-  }
+  })
 
   return dates
 }
@@ -58,22 +55,38 @@ const EducationSummaryProgress = (props) => {
     schoolDates = Education.List.items
   }
 
+  const getSchoolDates = () => schoolRangesList(schoolDates)
+  const getDiplomaDates = () => diplomasRangesList(schoolDates)
+
   return (
     <SummaryCounter
       className="education"
       title={i18n.t('history.education.summary.title')}
-      schools={schoolRangesList.bind(this, schoolDates)}
-      diplomas={diplomasRangesList.bind(this, schoolDates)}
+      schools={getSchoolDates}
+      diplomas={getDiplomaDates}
       schoolsLabel={i18n.t('history.education.summary.schools')}
       diplomasLabel={i18n.t('history.education.summary.diplomas')}
-      total={totalYears(Birthdate)}>
-        <div className="summary-icon">
-          <Svg
-            src="/img/school-cap.svg"
-            alt={i18n.t('history.education.summary.svgAlt')} />
-        </div>
-      </SummaryCounter>
+      total={totalYears(Birthdate)}
+    >
+      <div className="summary-icon">
+        <Svg
+          src="/img/school-cap.svg"
+          alt={i18n.t('history.education.summary.svgAlt')}
+        />
+      </div>
+    </SummaryCounter>
   )
+}
+
+/* eslint react/forbid-prop-types: 0 */
+EducationSummaryProgress.propTypes = {
+  Education: PropTypes.object,
+  Birthdate: PropTypes.any,
+}
+
+EducationSummaryProgress.defaultProps = {
+  Education: null,
+  Birthdate: null,
 }
 
 export default EducationSummaryProgress

--- a/src/components/Section/History/Education/EducationSummaryProgress.jsx
+++ b/src/components/Section/History/Education/EducationSummaryProgress.jsx
@@ -4,16 +4,11 @@ import { i18n } from '@config'
 
 import SummaryCounter from '@components/Section/History/SummaryCounter'
 import SummaryProgress from '@components/Section/History/SummaryProgress'
-import { totalYears } from '@components/Section/History/History'
+
+import { totalYears } from '@components/Section/History/helpers'
 
 import { Svg } from '@components/Form'
 import { EducationItemValidator } from '@validators'
-
-const excludeGaps = (items) => {
-  return items.filter(
-    item => !item.type || (item.type && item.type !== 'Gap')
-  )
-}
 
 const schoolRangesList = (items) => {
   const dates = []

--- a/src/components/Section/History/Education/EducationWrapper.jsx
+++ b/src/components/Section/History/Education/EducationWrapper.jsx
@@ -15,6 +15,7 @@ import { HistoryEducationValidator } from '@validators'
 
 const sectionConfig = {
   section: HISTORY.name,
+  store: HISTORY.store,
   subsection: HISTORY_EDUCATION.name,
 }
 

--- a/src/components/Section/History/Education/EducationWrapper.jsx
+++ b/src/components/Section/History/Education/EducationWrapper.jsx
@@ -7,9 +7,6 @@ import { Field, Show, Branch } from '@components/Form'
 import Education from './Education'
 import EducationSummaryProgress from './EducationSummaryProgress'
 
-import { today, daysAgo, gaps } from '@components/Section/History/dateranges'
-import { totalYears } from '@components/Section/History/History'
-
 import connectHistorySection from '../HistoryConnector'
 import { HISTORY, HISTORY_EDUCATION } from '@config/formSections/history'
 
@@ -20,8 +17,6 @@ const sectionConfig = {
   section: HISTORY.name,
   subsection: HISTORY_EDUCATION.name,
 }
-
-// TODO totalYears has to change based on formType
 
 class EducationWrapper extends React.Component {
   updateBranchAttendance = (values) => {

--- a/src/components/Section/History/Education/EducationWrapper.jsx
+++ b/src/components/Section/History/Education/EducationWrapper.jsx
@@ -1,17 +1,17 @@
 import React from 'react'
 
-import { i18n } from '@config'
+import { i18n } from 'config'
+import { HISTORY, HISTORY_EDUCATION } from 'config/formSections/history'
 
-import { Field, Show, Branch } from '@components/Form'
+import { Field, Show, Branch } from 'components/Form'
 
-import Education from './Education'
+import { reportCompletion } from 'actions/ApplicationActions'
+import { HistoryEducationValidator } from 'validators'
+
+import ConnectedEducation from './Education'
 import EducationSummaryProgress from './EducationSummaryProgress'
 
 import connectHistorySection from '../HistoryConnector'
-import { HISTORY, HISTORY_EDUCATION } from '@config/formSections/history'
-
-import { reportCompletion } from '@actions/ApplicationActions'
-import { HistoryEducationValidator } from '@validators'
 
 const sectionConfig = {
   section: HISTORY.name,
@@ -21,47 +21,50 @@ const sectionConfig = {
 
 class EducationWrapper extends React.Component {
   updateBranchAttendance = (values) => {
-    const education = this.props.Education || {}
+    const { Education, onUpdate, dispatch } = this.props
+    const education = Education || {}
     education.HasAttended = values
     education.HasDegree10 = values.value === 'No' ? education.HasDegree10 : {}
     education.List = values.value === 'Yes' ? education.List : { items: [], branch: {} }
 
-    this.props.onUpdate('Education', education)
-    this.props.dispatch(
+    onUpdate('Education', education)
+    dispatch(
       reportCompletion(
         'history',
         'education',
-        new HistoryEducationValidator(education, education).isValid()
-      )
+        new HistoryEducationValidator(education, education).isValid(),
+      ),
     )
   }
 
   updateBranchDegree10 = (values) => {
-    const education = this.props.Education || {}
+    const { Education, onUpdate, dispatch } = this.props
+    const education = Education || {}
     education.HasDegree10 = values
     education.List = values.value === 'Yes' ? education.List : { items: [], branch: {} }
-    
-    this.props.onUpdate('Education', education)
-    this.props.dispatch(
+
+    onUpdate('Education', education)
+    dispatch(
       reportCompletion(
         'history',
         'education',
-        new HistoryEducationValidator(education, education).isValid()
-      )
+        new HistoryEducationValidator(education, education).isValid(),
+      ),
     )
   }
 
   handleUpdate = (values) => {
-    const education = this.props.Education || {}
+    const { Education, onUpdate } = this.props
+    const education = Education || {}
     education.List = values
-    this.props.onUpdate('Education', education)
+    onUpdate('Education', education)
   }
 
-  render () {
-    const { Birthdate, inReview } = this.props
+  render() {
+    const { Education, Birthdate, inReview } = this.props
 
-    const hasAttendedSchool = this.props.Education.HasAttended.value === 'Yes'
-    const hasDegree = this.props.Education.HasDegree10.value === 'Yes'
+    const hasAttendedSchool = Education.HasAttended.value === 'Yes'
+    const hasDegree = Education.HasDegree10.value === 'Yes'
 
     const reviewProps = inReview ? {
       realtime: true,
@@ -69,7 +72,7 @@ class EducationWrapper extends React.Component {
       scrollIntoView: false,
       required: true,
     } : {
-      scrollToTop: 'scrollToHistory'
+      scrollToTop: 'scrollToHistory',
     }
 
     return (
@@ -83,29 +86,32 @@ class EducationWrapper extends React.Component {
         <Field
           title={i18n.t('history.education.title')}
           titleSize={inReview ? 'h4' : 'h3'}
-          optional={true}
-          className="no-margin-bottom">
+          optional
+          className="no-margin-bottom"
+        >
           {i18n.m('history.education.info')}
         </Field>
 
         <Branch
           name="branch_school"
-          {...this.props.Education.HasAttended}
+          {...Education.HasAttended}
           help="history.education.help.attendance"
           label={i18n.t('history.education.label.attendance')}
           labelSize={inReview ? 'h3' : 'h4'}
-          warning={true}
-          onUpdate={this.updateBranchAttendance} />
+          warning
+          onUpdate={this.updateBranchAttendance}
+        />
 
-        <Show when={this.props.Education.HasAttended.value === 'No'}>
+        <Show when={Education.HasAttended.value === 'No'}>
           <Branch
             name="branch_degree10"
-            {...this.props.Education.HasDegree10}
+            {...Education.HasDegree10}
             help="history.education.help.degree10"
             label={i18n.t('history.education.label.degree10')}
             labelSize={inReview ? 'h3' : 'h4'}
-            warning={true}
-            onUpdate={this.updateBranchDegree10} />
+            warning
+            onUpdate={this.updateBranchDegree10}
+          />
         </Show>
 
         <Show when={hasAttendedSchool || hasDegree}>
@@ -114,13 +120,15 @@ class EducationWrapper extends React.Component {
 
             {!inReview && (
               <EducationSummaryProgress
-                Education={this.props.Education}
-                Birthdate={Birthdate} />
+                Education={Education}
+                Birthdate={Birthdate}
+              />
             )}
 
-            <Education
+            <ConnectedEducation
               onUpdate={this.handleUpdate}
-              {...reviewProps} />
+              {...reviewProps}
+            />
           </div>
         </Show>
       </div>

--- a/src/components/Section/History/Education/EducationWrapper.jsx
+++ b/src/components/Section/History/Education/EducationWrapper.jsx
@@ -1,0 +1,145 @@
+import React from 'react'
+
+import { i18n } from '@config'
+
+import { Field, Show, Branch } from '@components/Form'
+
+import Education from './Education'
+import EducationSummaryProgress from './EducationSummaryProgress'
+
+import { today, daysAgo, gaps } from '@components/Section/History/dateranges'
+import { totalYears } from '@components/Section/History/History'
+
+import connectHistorySection from '../HistoryConnector'
+import { HISTORY, HISTORY_EDUCATION } from '@config/formSections/history'
+
+import { reportCompletion } from '@actions/ApplicationActions'
+import { HistoryEducationValidator } from '@validators'
+
+const sectionConfig = {
+  section: HISTORY.name,
+  subsection: HISTORY_EDUCATION.name,
+}
+
+// TODO totalYears has to change based on formType
+
+class EducationWrapper extends React.Component {
+  updateBranchAttendance = (values) => {
+    const education = this.props.Education || {}
+    education.HasAttended = values
+    education.HasDegree10 = values.value === 'No' ? education.HasDegree10 : {}
+    education.List = values.value === 'Yes' ? education.List : { items: [], branch: {} }
+
+    this.props.onUpdate('Education', education)
+    this.props.dispatch(
+      reportCompletion(
+        'history',
+        'education',
+        new HistoryEducationValidator(education, education).isValid()
+      )
+    )
+  }
+
+  updateBranchDegree10 = (values) => {
+    const education = this.props.Education || {}
+    education.HasDegree10 = values
+    education.List = values.value === 'Yes' ? education.List : { items: [], branch: {} }
+    
+    this.props.onUpdate('Education', education)
+    this.props.dispatch(
+      reportCompletion(
+        'history',
+        'education',
+        new HistoryEducationValidator(education, education).isValid()
+      )
+    )
+  }
+
+  handleUpdate = (values) => {
+    const education = this.props.Education || {}
+    education.List = values
+    this.props.onUpdate('Education', education)
+  }
+
+  render () {
+    const { Birthdate, inReview } = this.props
+
+    const hasAttendedSchool = this.props.Education.HasAttended.value === 'Yes'
+    const hasDegree = this.props.Education.HasDegree10.value === 'Yes'
+
+    const reviewProps = inReview ? {
+      realtime: true,
+      overrideInitial: true,
+      scrollIntoView: false,
+      required: true,
+    } : {
+      scrollToTop: 'scrollToHistory'
+    }
+
+    return (
+      <div>
+        {!inReview && (
+          <h1 className="section-header">
+            {i18n.t('history.education.summary.title')}
+          </h1>
+        )}
+
+        <Field
+          title={i18n.t('history.education.title')}
+          titleSize={inReview ? 'h4' : 'h3'}
+          optional={true}
+          className="no-margin-bottom">
+          {i18n.m('history.education.info')}
+        </Field>
+
+        <Branch
+          name="branch_school"
+          {...this.props.Education.HasAttended}
+          help="history.education.help.attendance"
+          label={i18n.t('history.education.label.attendance')}
+          labelSize={inReview ? 'h3' : 'h4'}
+          warning={true}
+          onUpdate={this.updateBranchAttendance} />
+
+        <Show when={this.props.Education.HasAttended.value === 'No'}>
+          <Branch
+            name="branch_degree10"
+            {...this.props.Education.HasDegree10}
+            help="history.education.help.degree10"
+            label={i18n.t('history.education.label.degree10')}
+            labelSize={inReview ? 'h3' : 'h4'}
+            warning={true}
+            onUpdate={this.updateBranchDegree10} />
+        </Show>
+
+        <Show when={hasAttendedSchool || hasDegree}>
+          <div>
+            <span id="scrollToHistory" />
+
+            {!inReview && (
+              <EducationSummaryProgress
+                Education={this.props.Education}
+                Birthdate={Birthdate} />
+            )}
+
+            <Education
+              onUpdate={this.handleUpdate}
+              {...reviewProps} />
+          </div>
+        </Show>
+      </div>
+    )
+  }
+}
+
+EducationWrapper.defaultProps = {
+  Education: {
+    HasAttended: '',
+    HasDegree10: '',
+    List: { items: [] },
+  },
+  Birthdate: {},
+  inReview: false,
+}
+
+export default connectHistorySection(EducationWrapper, sectionConfig)

--- a/src/components/Section/History/Employment/Employment.jsx
+++ b/src/components/Section/History/Employment/Employment.jsx
@@ -239,9 +239,7 @@ Employment.defaultProps = {
   overrideInitial: false,
   caption: null,
   onUpdate: () => {},
-  onError: (value, arr) => {
-    return arr
-  },
+  onError: (value, arr) => arr,
   section: 'history',
   subsection: 'employment',
   addressBooks: {},

--- a/src/components/Section/History/Employment/Employment.jsx
+++ b/src/components/Section/History/Employment/Employment.jsx
@@ -1,15 +1,30 @@
 import React from 'react'
 import { i18n } from 'config'
+
 import schema from 'schema'
 import validate, { EmploymentValidator } from 'validators'
-import SubsectionElement from 'components/Section/SubsectionElement'
+
+import Subsection from 'components/Section/shared/Subsection'
 import { Accordion, Branch } from 'components/Form'
 import { openState } from 'components/Form/Accordion/Accordion'
 import { newGuid } from 'components/Form/ValidationElement'
-import { today, daysAgo, extractDate, validDate } from 'components/Section/History/dateranges'
+import {
+  today, daysAgo, extractDate, validDate,
+} from 'components/Section/History/dateranges'
 import { InjectGaps, EmploymentCustomSummary } from 'components/Section/History/summaries'
 import EmploymentItem from 'components/Section/History/Employment/EmploymentItem'
 import { Gap } from 'components/Section/History/Gap'
+
+import { HISTORY, HISTORY_EMPLOYMENT } from 'config/formSections/history'
+
+import connectHistorySection from '../HistoryConnector'
+
+const sectionConfig = {
+  section: HISTORY.name,
+  store: HISTORY.store,
+  subsection: HISTORY_EMPLOYMENT.name,
+  storeKey: HISTORY_EMPLOYMENT.storeKey,
+}
 
 const byline = (item, index, initial, translation, required, validator) => {
   // If item is required and not currently opened and is not valid, show message
@@ -30,29 +45,43 @@ const byline = (item, index, initial, translation, required, validator) => {
   }
 }
 
-export default class Employment extends SubsectionElement {
+export class Employment extends Subsection {
+  constructor(props) {
+    super(props)
+
+    const {
+      section, subsection, store, storeKey,
+    } = sectionConfig
+
+    this.section = section
+    this.subsection = subsection
+    this.store = store
+    this.storeKey = storeKey
+
+    this.employment = null
+  }
+
   customEmploymentByline = (item, index, initial) => {
+    const overrideInitial = this.props.overrideInitial ? false : initial
+
     return byline(
       item,
       index,
-      this.props.overrideInitial(initial),
+      overrideInitial,
       'history.employment.default.collection.summary.incomplete',
       this.props.required,
-      item => {
-        return new EmploymentValidator(item).isValid()
-      }
+      i => new EmploymentValidator(i).isValid(),
     )
   }
 
-  sortEmploymentItems = (employmentItems) => {
-    return employmentItems.sort((a, b) => {
-      if (a.type === 'Gap') {
-        return 1
-      } else if (b.type === 'Gap') {
-        return -1
-      } else if (
-        a.Item && a.Item.Dates && validDate(a.Item.Dates.to) &&
-        b.Item && b.Item.Dates && validDate(b.Item.Dates.to)
+  sortEmploymentItems = employmentItems => (
+    employmentItems.sort((a, b) => {
+      if (a.type === 'Gap') { return 1 }
+      if (b.type === 'Gap') { return -1 }
+
+      if (
+        a.Item && a.Item.Dates && validDate(a.Item.Dates.to)
+        && b.Item && b.Item.Dates && validDate(b.Item.Dates.to)
       ) {
         const aDateObj = a.Item.Dates.to
         const bDateObj = b.Item.Dates.to
@@ -61,29 +90,30 @@ export default class Employment extends SubsectionElement {
 
         return bDate.getTime() - aDate.getTime()
       }
+
       return 0
     })
-  }
+  )
 
   update = (queue) => {
     const updatedValues = {
       List: this.props.List,
       EmploymentRecord: this.props.EmploymentRecord,
-      ...queue
+      ...queue,
     }
 
     if (queue.List) {
       updatedValues.List = {
         ...queue.List,
-        items: this.sortEmploymentItems(queue.List.items)
+        items: this.sortEmploymentItems(queue.List.items),
       }
     }
 
-    this.props.onUpdate(updatedValues)
+    this.props.onUpdate('Employment', updatedValues)
   }
 
-  fillGap = (dates) => {
-    let items = [...this.props.List.items]
+  fillGap = () => {
+    const items = [...this.props.List.items]
     items.push({
       uuid: newGuid(),
       open: true,
@@ -92,18 +122,18 @@ export default class Employment extends SubsectionElement {
         Dates: {
           name: 'Dates',
           receiveProps: true,
-          present: false
-        }
-      }
+          present: false,
+        },
+      },
     })
 
     this.update({
       List: {
-        items: InjectGaps(items, daysAgo(365 * this.props.totalYears)).sort(
-          this.sort
-        ).filter(item => !item.type || (item.type && item.type !== 'Gap')),
-        branch: {}
-      }
+        items: InjectGaps(items, daysAgo(365 * this.props.totalYears))
+          .sort(this.sort)
+          .filter(item => !item.type || (item.type && item.type !== 'Gap')),
+        branch: {},
+      },
     })
   }
 
@@ -117,7 +147,7 @@ export default class Employment extends SubsectionElement {
           btnText={i18n.t('history.employment.gap.btnText')}
           first={index === 0}
           dates={dates}
-          onClick={this.fillGap.bind(this, dates)}
+          onClick={() => { this.fillGap(dates) }}
         />
       )
     }
@@ -125,20 +155,19 @@ export default class Employment extends SubsectionElement {
     return callback()
   }
 
-  inject = (items) => {
-    return InjectGaps(items, daysAgo(today, 365 * this.props.totalYears))
-  }
+  inject = items => InjectGaps(items, daysAgo(today, 365 * this.props.totalYears))
 
   render() {
     return (
       <div
         className="section-content employment"
-        {...super.dataAttributes(this.props)}>
+        {...super.dataAttributes()}
+      >
         <Accordion
           scrollToTop={this.props.scrollToTop}
           defaultState={this.props.defaultState}
           {...this.props.List}
-          ref="employment"
+          ref={(el) => { this.employment = el }}
           sort={this.props.sort}
           inject={this.inject}
           realtime={this.props.realtime}
@@ -151,15 +180,16 @@ export default class Employment extends SubsectionElement {
           customSummary={EmploymentCustomSummary}
           customDetails={this.customEmploymentDetails}
           description={i18n.t(
-            'history.employment.default.collection.summary.title'
+            'history.employment.default.collection.summary.title',
           )}
           appendTitle={i18n.t(
-            'history.employment.default.collection.appendTitle'
+            'history.employment.default.collection.appendTitle',
           )}
           appendLabel={i18n.t('history.employment.default.collection.append')}
           appendClass="no-margin-bottom"
           required={this.props.required}
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <EmploymentItem
             bind
             name="Item"
@@ -177,17 +207,18 @@ export default class Employment extends SubsectionElement {
           {...this.props.EmploymentRecord}
           onUpdate={(values) => {
             if (values.value === 'Yes') {
-              this.refs.employment.add()
+              this.employment.add()
               return
             }
 
             this.update({
-              EmploymentRecord: values
+              EmploymentRecord: values,
             })
           }}
           onError={this.handleError}
           required={this.props.required}
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           {i18n.m('history.employment.default.employmentRecord.list')}
           {i18n.m('history.employment.default.employmentRecord.para')}
         </Branch>
@@ -199,14 +230,13 @@ export default class Employment extends SubsectionElement {
 Employment.defaultProps = {
   List: Accordion.defaultList,
   EmploymentRecord: {},
+  scrollIntoView: false,
   scrollToTop: '',
   defaultState: true,
   realtime: false,
   sort: null,
   totalYears: 10,
-  overrideInitial: initial => {
-    return initial
-  },
+  overrideInitial: false,
   caption: null,
   onUpdate: () => {},
   onError: (value, arr) => {
@@ -216,7 +246,7 @@ Employment.defaultProps = {
   subsection: 'employment',
   addressBooks: {},
   dispatch: () => {},
-  validator: data => {
-    return validate(schema('history.employment', data))
-  }
+  validator: data => validate(schema('history.employment', data)),
 }
+
+export default connectHistorySection(Employment, sectionConfig)

--- a/src/components/Section/History/Employment/Employment.test.jsx
+++ b/src/components/Section/History/Employment/Employment.test.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { shallow, mount } from 'enzyme'
 import configureMockStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
-import Employment from './Employment'
+import { Employment } from './Employment'
 
 describe('The employment section', () => {
   const mockStore = configureMockStore()
@@ -128,6 +128,7 @@ describe('The employment section', () => {
         <Employment {...props} />
       </Provider>
     )
+  
     const sortedEmploymentItems = component
       .dive()
       .instance()

--- a/src/components/Section/History/Employment/Employment.test.jsx
+++ b/src/components/Section/History/Employment/Employment.test.jsx
@@ -10,12 +10,13 @@ describe('The employment section', () => {
 
   beforeEach(() => {
     const store = mockStore()
-    createComponent = (expected = {}) =>
+    createComponent = (expected = {}) => (
       mount(
         <Provider store={store}>
           <Employment {...expected} />
         </Provider>
       )
+    )
   })
 
   it('can trigger updates', () => {
@@ -30,15 +31,15 @@ describe('The employment section', () => {
                 from: {
                   day: '1',
                   month: '1',
-                  year: '2013'
+                  year: '2013',
                 },
                 to: {
                   day: '12',
                   month: '31',
-                  year: '2013'
-                }
-              }
-            }
+                  year: '2013',
+                },
+              },
+            },
           },
           {
             Item: {
@@ -46,26 +47,25 @@ describe('The employment section', () => {
                 from: {
                   day: '1',
                   month: '1',
-                  year: '2014'
+                  year: '2014',
                 },
                 to: {
                   day: '1',
                   month: '1',
-                  year: '2018'
-                }
-              }
-            }
-          }
-        ]
+                  year: '2018',
+                },
+              },
+            },
+          },
+        ],
       },
-      onUpdate: jest.fn()
+      onUpdate: jest.fn(),
     }
-    const component = createComponent(expected)
+    createComponent(expected)
     expect(expected.onUpdate.mock.calls.length).toBe(1)
   })
 
   it('sorts employment items with most recent being first', () => {
-    const mockStore = configureMockStore()
     const store = mockStore()
     const props = {
       List: {
@@ -77,15 +77,15 @@ describe('The employment section', () => {
                 from: {
                   day: '10',
                   month: '10',
-                  year: '2005'
+                  year: '2005',
                 },
                 to: {
                   day: '1',
                   month: '1',
-                  year: '2007'
-                }
-              }
-            }
+                  year: '2007',
+                },
+              },
+            },
           },
           {
             Item: {
@@ -93,15 +93,15 @@ describe('The employment section', () => {
                 from: {
                   day: '10',
                   month: '10',
-                  year: '2000'
+                  year: '2000',
                 },
                 to: {
                   day: '1',
                   month: '1',
-                  year: '2004'
-                }
-              }
-            }
+                  year: '2004',
+                },
+              },
+            },
           },
           {
             Item: {
@@ -109,18 +109,18 @@ describe('The employment section', () => {
                 from: {
                   day: '10',
                   month: '10',
-                  year: '2014'
+                  year: '2014',
                 },
                 to: {
                   day: '1',
                   month: '1',
-                  year: '2018'
-                }
-              }
-            }
-          }
-        ]
-      }
+                  year: '2018',
+                },
+              },
+            },
+          },
+        ],
+      },
     }
 
     const component = shallow(
@@ -128,7 +128,7 @@ describe('The employment section', () => {
         <Employment {...props} />
       </Provider>
     )
-  
+
     const sortedEmploymentItems = component
       .dive()
       .instance()

--- a/src/components/Section/History/Employment/EmploymentSummaryProgress.jsx
+++ b/src/components/Section/History/Employment/EmploymentSummaryProgress.jsx
@@ -3,16 +3,10 @@ import React from 'react'
 import { i18n } from '@config'
 
 import SummaryProgress from '@components/Section/History/SummaryProgress'
-import { totalYears } from '@components/Section/History/History'
+import { totalYears, excludeGaps } from '@components/Section/History/helpers'
 
 import { Svg } from '@components/Form'
 import { EmploymentValidator } from '@validators'
-
-const excludeGaps = (items) => {
-  return items.filter(
-    item => !item.type || (item.type && item.type !== 'Gap')
-  )
-}
 
 const dateRangeList = (items) => {
   const dates = []

--- a/src/components/Section/History/Employment/EmploymentSummaryProgress.jsx
+++ b/src/components/Section/History/Employment/EmploymentSummaryProgress.jsx
@@ -1,23 +1,24 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
-import { i18n } from '@config'
+import { i18n } from 'config'
 
-import SummaryProgress from '@components/Section/History/SummaryProgress'
-import { totalYears, excludeGaps } from '@components/Section/History/helpers'
+import SummaryProgress from 'components/Section/History/SummaryProgress'
+import { totalYears } from 'components/Section/History/helpers'
 
-import { Svg } from '@components/Form'
-import { EmploymentValidator } from '@validators'
+import { Svg } from 'components/Form'
+import { EmploymentValidator } from 'validators'
 
 const dateRangeList = (items) => {
   const dates = []
 
-  for (const i of excludeGaps(items)) {
-    if (!i.Item) { continue }
+  items.forEach((i) => {
+    if (!i.Item) { return }
 
     if (new EmploymentValidator(i.Item).isValid()) {
       dates.push(i.Item.Dates)
     }
-  }
+  })
 
   return dates
 }
@@ -30,20 +31,35 @@ const EmploymentSummaryProgress = (props) => {
     employmentDates = Employment.List.items
   }
 
+  const getEmploymentDates = () => dateRangeList(employmentDates)
+
   return (
     <SummaryProgress
       className="residence"
-      List={dateRangeList.bind(this, employmentDates)}
+      List={getEmploymentDates}
       title={i18n.t('history.employment.summary.title')}
       unit={i18n.t('history.employment.summary.unit')}
-      total={totalYears(Birthdate)}>
-        <div className="summary-icon">
-          <Svg
-            src="/img/employer-briefcase.svg"
-            alt={i18n.t('history.employment.summary.svgAlt')} />
-        </div>
-      </SummaryProgress>
+      total={totalYears(Birthdate)}
+    >
+      <div className="summary-icon">
+        <Svg
+          src="/img/employer-briefcase.svg"
+          alt={i18n.t('history.employment.summary.svgAlt')}
+        />
+      </div>
+    </SummaryProgress>
   )
+}
+
+/* eslint react/forbid-prop-types: 0 */
+EmploymentSummaryProgress.propTypes = {
+  Employment: PropTypes.object,
+  Birthdate: PropTypes.any,
+}
+
+EmploymentSummaryProgress.defaultProps = {
+  Employment: undefined,
+  Birthdate: undefined,
 }
 
 export default EmploymentSummaryProgress

--- a/src/components/Section/History/Employment/EmploymentSummaryProgress.jsx
+++ b/src/components/Section/History/Employment/EmploymentSummaryProgress.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+import { i18n } from '@config'
+
+import SummaryProgress from '@components/Section/History/SummaryProgress'
+import { totalYears } from '@components/Section/History/History'
+
+import { Svg } from '@components/Form'
+import { EmploymentValidator } from '@validators'
+
+const excludeGaps = (items) => {
+  return items.filter(
+    item => !item.type || (item.type && item.type !== 'Gap')
+  )
+}
+
+const dateRangeList = (items) => {
+  const dates = []
+
+  for (const i of excludeGaps(items)) {
+    if (!i.Item) { continue }
+
+    if (new EmploymentValidator(i.Item).isValid()) {
+      dates.push(i.Item.Dates)
+    }
+  }
+
+  return dates
+}
+
+const EmploymentSummaryProgress = (props) => {
+  const { Employment, Birthdate } = props
+
+  let employmentDates = []
+  if (Employment && Employment.List && Employment.List.items) {
+    employmentDates = Employment.List.items
+  }
+
+  return (
+    <SummaryProgress
+      className="residence"
+      List={dateRangeList.bind(this, employmentDates)}
+      title={i18n.t('history.employment.summary.title')}
+      unit={i18n.t('history.employment.summary.unit')}
+      total={totalYears(Birthdate)}>
+        <div className="summary-icon">
+          <Svg
+            src="/img/employer-briefcase.svg"
+            alt={i18n.t('history.employment.summary.svgAlt')} />
+        </div>
+      </SummaryProgress>
+  )
+}
+
+export default EmploymentSummaryProgress

--- a/src/components/Section/History/Employment/EmploymentWrapper.jsx
+++ b/src/components/Section/History/Employment/EmploymentWrapper.jsx
@@ -7,8 +7,7 @@ import { Field, Show } from '@components/Form'
 import Employment from './Employment'
 import EmploymentSummaryProgress from './EmploymentSummaryProgress'
 
-import { today, daysAgo, gaps } from '@components/Section/History/dateranges'
-import { totalYears } from '@components/Section/History/History'
+import { sectionHasGaps } from '@components/Section/History/helpers'
 
 import connectHistorySection from '../HistoryConnector'
 import { HISTORY, HISTORY_EMPLOYMENT } from '@config/formSections/history'
@@ -16,24 +15,6 @@ import { HISTORY, HISTORY_EMPLOYMENT } from '@config/formSections/history'
 const sectionConfig = {
   section: HISTORY.name,
   subsection: HISTORY_EMPLOYMENT.name,
-}
-
-// TODO totalYears has to change based on formType
-
-// TODO - move this to a helper file
-const sectionHasGaps = (items = []) => {
-  if (!items || !items.length) return true
-
-  const ranges = items
-    .filter(i => i.Item && i.Item.Dates)
-    .map(i => i.Item.Dates)
-
-  if (!ranges.length) return true
-
-  const start = daysAgo(today, 365 * totalYears())
-  const holes = gaps(ranges, start).length
-
-  return holes > 0
 }
 
 class EmploymentWrapper extends React.Component {

--- a/src/components/Section/History/Employment/EmploymentWrapper.jsx
+++ b/src/components/Section/History/Employment/EmploymentWrapper.jsx
@@ -1,78 +1,86 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
-import { i18n } from '@config'
+import { i18n } from 'config'
+import { HISTORY, HISTORY_EMPLOYMENT } from 'config/formSections/history'
 
-import { Field, Show } from '@components/Form'
+import { Field, Show } from 'components/Form'
+import { sectionHasGaps } from 'components/Section/History/helpers'
 
-import Employment from './Employment'
+import ConnectedEmployment from './Employment'
 import EmploymentSummaryProgress from './EmploymentSummaryProgress'
 
-import { sectionHasGaps } from '@components/Section/History/helpers'
-
 import connectHistorySection from '../HistoryConnector'
-import { HISTORY, HISTORY_EMPLOYMENT } from '@config/formSections/history'
 
 const sectionConfig = {
   section: HISTORY.name,
   subsection: HISTORY_EMPLOYMENT.name,
 }
 
-class EmploymentWrapper extends React.Component {
-  render () {
-    const { Birthdate } = this.props
+const EmploymentWrapper = (props) => {
+  const { Employment, Birthdate } = props
 
-    let employmentItems = []
-    if (this.props.Employment && this.props.Employment.List && this.props.Employment.List.items) {
-      employmentItems = this.props.Employment.List.items
-    }
-    
-    const employmentHasGaps = sectionHasGaps(employmentItems)
-
-    return (
-      <div>
-        <h1 className="section-header">
-          {i18n.t('history.employment.summary.title')}
-        </h1>
-
-        <Field
-          title={i18n.t('history.employment.heading.employment')}
-          titleSize="h3"
-          optional={true}
-          className="no-margin-bottom">
-          {i18n.m('history.employment.para.employment')}
-          {i18n.m('history.employment.para.employment2')}
-        </Field>
-
-        <span id="scrollToHistory" />
-
-        <EmploymentSummaryProgress
-          Employment={this.props.Employment}
-          Birthdate={Birthdate} />
-          
-        <Employment
-          scrollToTop="scrollToHistory" />
-        
-        <Show when={employmentHasGaps}>
-          <div className="not-complete">
-            <hr className="section-divider" />
-            
-            <Field
-              title={i18n.t('history.employment.heading.exiting')}
-              titleSize="h4"
-              optional={true}
-              className="no-margin-bottom">
-              {i18n.m('history.employment.para.exiting')}
-            </Field>
-          </div>
-        </Show>
-      </div>
-    )
+  let employmentItems = []
+  if (Employment && Employment.List && Employment.List.items) {
+    employmentItems = Employment.List.items
   }
+
+  const employmentHasGaps = sectionHasGaps(employmentItems)
+
+  return (
+    <div>
+      <h1 className="section-header">
+        {i18n.t('history.employment.summary.title')}
+      </h1>
+
+      <Field
+        title={i18n.t('history.employment.heading.employment')}
+        titleSize="h3"
+        optional
+        className="no-margin-bottom"
+      >
+        {i18n.m('history.employment.para.employment')}
+        {i18n.m('history.employment.para.employment2')}
+      </Field>
+
+      <span id="scrollToHistory" />
+
+      <EmploymentSummaryProgress
+        Employment={Employment}
+        Birthdate={Birthdate}
+      />
+
+      <ConnectedEmployment
+        scrollToTop="scrollToHistory"
+      />
+
+      <Show when={employmentHasGaps}>
+        <div className="not-complete">
+          <hr className="section-divider" />
+
+          <Field
+            title={i18n.t('history.employment.heading.exiting')}
+            titleSize="h4"
+            optional
+            className="no-margin-bottom"
+          >
+            {i18n.m('history.employment.para.exiting')}
+          </Field>
+        </div>
+      </Show>
+    </div>
+  )
+}
+
+/* eslint react/forbid-prop-types: 0 */
+EmploymentWrapper.propTypes = {
+  Employment: PropTypes.object,
+  Birthdate: PropTypes.any,
 }
 
 EmploymentWrapper.defaultProps = {
-  Employment: {},
-  Birthdate: {},
+  Employment: undefined,
+  Birthdate: undefined,
 }
 
 export default connectHistorySection(EmploymentWrapper, sectionConfig)

--- a/src/components/Section/History/Employment/EmploymentWrapper.jsx
+++ b/src/components/Section/History/Employment/EmploymentWrapper.jsx
@@ -1,0 +1,97 @@
+import React from 'react'
+
+import { i18n } from '@config'
+
+import { Field, Show } from '@components/Form'
+
+import Employment from './Employment'
+import EmploymentSummaryProgress from './EmploymentSummaryProgress'
+
+import { today, daysAgo, gaps } from '@components/Section/History/dateranges'
+import { totalYears } from '@components/Section/History/History'
+
+import connectHistorySection from '../HistoryConnector'
+import { HISTORY, HISTORY_EMPLOYMENT } from '@config/formSections/history'
+
+const sectionConfig = {
+  section: HISTORY.name,
+  subsection: HISTORY_EMPLOYMENT.name,
+}
+
+// TODO totalYears has to change based on formType
+
+// TODO - move this to a helper file
+const sectionHasGaps = (items = []) => {
+  if (!items || !items.length) return true
+
+  const ranges = items
+    .filter(i => i.Item && i.Item.Dates)
+    .map(i => i.Item.Dates)
+
+  if (!ranges.length) return true
+
+  const start = daysAgo(today, 365 * totalYears())
+  const holes = gaps(ranges, start).length
+
+  return holes > 0
+}
+
+class EmploymentWrapper extends React.Component {
+  render () {
+    const { Birthdate } = this.props
+
+    let employmentItems = []
+    if (this.props.Employment && this.props.Employment.List && this.props.Employment.List.items) {
+      employmentItems = this.props.Employment.List.items
+    }
+    
+    const employmentHasGaps = sectionHasGaps(employmentItems)
+
+    return (
+      <div>
+        <h1 className="section-header">
+          {i18n.t('history.employment.summary.title')}
+        </h1>
+
+        <Field
+          title={i18n.t('history.employment.heading.employment')}
+          titleSize="h3"
+          optional={true}
+          className="no-margin-bottom">
+          {i18n.m('history.employment.para.employment')}
+          {i18n.m('history.employment.para.employment2')}
+        </Field>
+
+        <span id="scrollToHistory" />
+
+        <EmploymentSummaryProgress
+          Employment={this.props.Employment}
+          Birthdate={Birthdate} />
+          
+        <Employment
+          scrollToTop="scrollToHistory" />
+        
+        <Show when={employmentHasGaps}>
+          <div className="not-complete">
+            <hr className="section-divider" />
+            
+            <Field
+              title={i18n.t('history.employment.heading.exiting')}
+              titleSize="h4"
+              optional={true}
+              className="no-margin-bottom">
+              {i18n.m('history.employment.para.exiting')}
+            </Field>
+          </div>
+        </Show>
+      </div>
+    )
+  }
+}
+
+EmploymentWrapper.defaultProps = {
+  Employment: {},
+  Birthdate: {},
+}
+
+export default connectHistorySection(EmploymentWrapper, sectionConfig)

--- a/src/components/Section/History/Federal/Federal.jsx
+++ b/src/components/Section/History/Federal/Federal.jsx
@@ -1,18 +1,40 @@
 import React from 'react'
-import { i18n } from '../../../../config'
-import schema from '../../../../schema'
+import { i18n } from '@config'
+
+import schema from '@schema'
+
 import validate, {
   FederalServiceValidator,
   FederalServiceItemValidator
-} from '../../../../validators'
-import SubsectionElement from '../../SubsectionElement'
-import { Branch, Show, Accordion } from '../../../Form'
-import { Summary, DateSummary } from '../../../Summary'
+} from '@validators'
+
+import Subsection from '@components/Section/shared/Subsection'
+import connectHistorySection from '../HistoryConnector'
+
+import { Branch, Show, Accordion } from '@components/Form'
+import { Summary, DateSummary } from '@components/Summary'
+
 import FederalItem from './FederalItem'
 
-export default class Federal extends SubsectionElement {
+import { HISTORY, HISTORY_FEDERAL } from '@config/formSections/history'
+
+const sectionConfig = {
+  section: HISTORY.name,
+  store: HISTORY.store,
+  subsection: HISTORY_FEDERAL.name,
+  storeKey: HISTORY_FEDERAL.storeKey,
+}
+
+export class Federal extends Subsection {
   constructor(props) {
     super(props)
+
+    const { section, subsection, store, storeKey } = sectionConfig
+
+    this.section = section
+    this.subsection = subsection
+    this.store = store
+    this.storeKey = storeKey
 
     this.update = this.update.bind(this)
     this.updateBranch = this.updateBranch.bind(this)
@@ -20,7 +42,7 @@ export default class Federal extends SubsectionElement {
   }
 
   update(queue) {
-    this.props.onUpdate({
+    this.props.onUpdate('Federal', {
       HasFederalService: this.props.HasFederalService,
       List: this.props.List,
       ...queue
@@ -61,7 +83,7 @@ export default class Federal extends SubsectionElement {
     return (
       <div
         className="section-content federal"
-        {...super.dataAttributes(this.props)}>
+        {...super.dataAttributes()}>
         <Branch
           name="has_federalservice"
           label={i18n.t('history.federal.heading.branch')}
@@ -117,3 +139,5 @@ Federal.defaultProps = {
   },
   defaultState: true
 }
+
+export default connectHistorySection(Federal, sectionConfig)

--- a/src/components/Section/History/Federal/Federal.jsx
+++ b/src/components/Section/History/Federal/Federal.jsx
@@ -1,22 +1,18 @@
 import React from 'react'
-import { i18n } from '@config'
+import { i18n } from 'config'
+import { HISTORY, HISTORY_FEDERAL } from 'config/formSections/history'
 
-import schema from '@schema'
+import schema from 'schema'
 
-import validate, {
-  FederalServiceValidator,
-  FederalServiceItemValidator
-} from '@validators'
+import validate, { FederalServiceItemValidator } from 'validators'
 
-import Subsection from '@components/Section/shared/Subsection'
+import Subsection from 'components/Section/shared/Subsection'
+import { Branch, Show, Accordion } from 'components/Form'
+import { Summary, DateSummary } from 'components/Summary'
+
 import connectHistorySection from '../HistoryConnector'
 
-import { Branch, Show, Accordion } from '@components/Form'
-import { Summary, DateSummary } from '@components/Summary'
-
 import FederalItem from './FederalItem'
-
-import { HISTORY, HISTORY_FEDERAL } from '@config/formSections/history'
 
 const sectionConfig = {
   section: HISTORY.name,
@@ -29,53 +25,50 @@ export class Federal extends Subsection {
   constructor(props) {
     super(props)
 
-    const { section, subsection, store, storeKey } = sectionConfig
+    const {
+      section, subsection, store, storeKey,
+    } = sectionConfig
 
     this.section = section
     this.subsection = subsection
     this.store = store
     this.storeKey = storeKey
-
-    this.update = this.update.bind(this)
-    this.updateBranch = this.updateBranch.bind(this)
-    this.updateList = this.updateList.bind(this)
   }
 
-  update(queue) {
+  update = (queue) => {
     this.props.onUpdate('Federal', {
       HasFederalService: this.props.HasFederalService,
       List: this.props.List,
-      ...queue
+      ...queue,
     })
   }
 
-  updateBranch(values) {
+  updateBranch = (values) => {
     this.update({
       HasFederalService: values,
-      List: values.value === 'Yes' ? this.props.List : []
+      List: values.value === 'Yes' ? this.props.List : [],
     })
   }
 
-  updateList(values) {
+  updateList = (values) => {
     this.update({
-      List: values
+      List: values,
     })
   }
 
   /**
    * Assists in rendering the summary section.
    */
-  summary(item, index) {
-    item = (item && item.Item) || {}
+  summary = (item = {}, index) => {
     const agency = item && item.Name && item.Name.value ? item.Name.value : ''
     const dates = DateSummary(item.Dates)
 
     return Summary({
       type: i18n.t('history.federal.collection.summary.item'),
-      index: index,
+      index,
       left: agency,
       right: dates,
-      placeholder: i18n.t('history.federal.collection.summary.unknown')
+      placeholder: i18n.t('history.federal.collection.summary.unknown'),
     })
   }
 
@@ -83,14 +76,15 @@ export class Federal extends Subsection {
     return (
       <div
         className="section-content federal"
-        {...super.dataAttributes()}>
+        {...super.dataAttributes()}
+      >
         <Branch
           name="has_federalservice"
           label={i18n.t('history.federal.heading.branch')}
           labelSize="h4"
           help="history.federal.help.branch"
           {...this.props.HasFederalService}
-          warning={true}
+          warning
           onUpdate={this.updateBranch}
           onError={this.handleError}
           required={this.props.required}
@@ -108,10 +102,11 @@ export class Federal extends Subsection {
             appendLabel={i18n.t('history.federal.collection.append')}
             required={this.props.required}
             validator={FederalServiceItemValidator}
-            scrollIntoView={this.props.scrollIntoView}>
+            scrollIntoView={this.props.scrollIntoView}
+          >
             <FederalItem
               name="Item"
-              bind={true}
+              bind
               required={this.props.required}
               scrollIntoView={this.props.scrollIntoView}
               onError={this.props.onError}
@@ -126,18 +121,14 @@ export class Federal extends Subsection {
 Federal.defaultProps = {
   HasFederalService: {},
   List: Accordion.defaultList,
-  onUpdate: queue => {},
-  onError: (value, arr) => {
-    return arr
-  },
+  onUpdate: () => {},
+  onError: (value, arr) => arr,
   section: 'history',
   subsection: 'federal',
   addressBooks: {},
   dispatch: () => {},
-  validator: data => {
-    return validate(schema('history.federal', data))
-  },
-  defaultState: true
+  validator: data => validate(schema('history.federal', data)),
+  defaultState: true,
 }
 
 export default connectHistorySection(Federal, sectionConfig)

--- a/src/components/Section/History/Federal/Federal.jsx
+++ b/src/components/Section/History/Federal/Federal.jsx
@@ -59,9 +59,10 @@ export class Federal extends Subsection {
   /**
    * Assists in rendering the summary section.
    */
-  summary = (item = {}, index) => {
-    const agency = item && item.Name && item.Name.value ? item.Name.value : ''
-    const dates = DateSummary(item.Dates)
+  summary = (item, index) => {
+    const summaryItem = (item && item.Item) || {}
+    const agency = summaryItem && summaryItem.Name && summaryItem.Name.value ? summaryItem.Name.value : ''
+    const dates = DateSummary(summaryItem.Dates)
 
     return Summary({
       type: i18n.t('history.federal.collection.summary.item'),

--- a/src/components/Section/History/Federal/FederalWrapper.jsx
+++ b/src/components/Section/History/Federal/FederalWrapper.jsx
@@ -1,21 +1,17 @@
 import React from 'react'
 
-import { i18n } from '@config'
+import { i18n } from 'config'
 
-import Federal from './Federal'
+import ConnectedFederal from './Federal'
 
-class FederalWrapper extends React.Component {
-  render () {
-    return (
-      <div>
-        <h1 className="section-header">
-          {i18n.t('history.destination.federal')}
-        </h1>
+const FederalWrapper = () => (
+  <div>
+    <h1 className="section-header">
+      {i18n.t('history.destination.federal')}
+    </h1>
 
-        <Federal />
-      </div>
-    )
-  }
-}
+    <ConnectedFederal />
+  </div>
+)
 
 export default FederalWrapper

--- a/src/components/Section/History/Federal/FederalWrapper.jsx
+++ b/src/components/Section/History/Federal/FederalWrapper.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import { i18n } from '@config'
+
+import Federal from './Federal'
+
+class FederalWrapper extends React.Component {
+  render () {
+    return (
+      <div>
+        <h1 className="section-header">
+          {i18n.t('history.destination.federal')}
+        </h1>
+
+        <Federal />
+      </div>
+    )
+  }
+}
+
+export default FederalWrapper

--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -17,24 +17,19 @@ import EmploymentWrapper from 'components/Section/History/Employment/EmploymentW
 import Employment from 'components/Section/History/Employment'
 import EducationWrapper from 'components/Section/History/Education/EducationWrapper'
 import Education from 'components/Section/History/Education'
-
+import FederalWrapper from 'components/Section/History/Federal/FederalWrapper'
+import Federal from 'components/Section/History/Federal'
 import Review from 'components/Section/History/Review'
 
-import { SectionViews, SectionView } from 'components/Section/SectionView'
-import SectionElement from 'components/Section/SectionElement'
-import { Field, Svg, Show, Branch } from 'components/Form'
-
-import Federal from 'components/Section/History/Federal'
+import { Show, Branch } from 'components/Form'
 
 import {
   utc,
   today,
   daysAgo,
   daysBetween,
-  gaps,
   extractDate
 } from 'components/Section/History/dateranges'
-import { InjectGaps } from 'components/Section/History/summaries'
 
 /**
  * Default sorting of history objects. This assumes that all objects contain a `Dates` property
@@ -87,7 +82,7 @@ export const totalYears = birthdate => {
   return total
 }
 
-class History extends SectionElement {
+class History extends React.Component {
   render() {
     const subsection = this.props.subsection || 'intro'
 
@@ -118,6 +113,7 @@ class History extends SectionElement {
             <Route path="/form/history/residence" component={ResidenceWrapper} />
             <Route path="/form/history/employment" component={EmploymentWrapper} />
             <Route path="/form/history/education" component={EducationWrapper} />
+            <Route path="/form/history/federal" component={FederalWrapper} />
             <Route path="/form/history/review" component={Review} />
 
             <SectionNavigation
@@ -126,205 +122,24 @@ class History extends SectionElement {
               formType={formType} />
           </div>
         </div>
-
-        {/*
-        <SectionViews
-          current={this.props.subsection}
-          dispatch={this.props.dispatch}
-          update={this.props.update}>
-          <SectionView
-            name="review"
-            title={i18n.t('review.title')}
-            para={i18n.m('review.para')}
-            showTop={true}
-            back="history/federal"
-            backLabel={i18n.t('history.destination.federal')}
-            next="relationships/intro"
-            nextLabel={i18n.t('relationships.destination.intro')}>
-            {this.residenceSummaryProgress()}
-            {this.employmentSummaryProgress()}
-            <Show
-              when={
-                (this.props.Education.HasAttended || {}).value === 'Yes' ||
-                (this.props.Education.HasDegree10 || {}).value === 'Yes'
-              }>
-              {this.educationSummaryProgress()}
-            </Show>
-
-            <hr className="section-divider" />
-            <h1 className="section-header">{i18n.t('history.residence.collection.caption')}</h1>
-            <Residence
-              {...this.props.Residence}
-              section="history"
-              subsection="residence"
-              sort={sort}
-              totalYears={totalYears(this.props.Birthdate)}
-              overrideInitial={this.overrideInitial}
-              onUpdate={this.updateResidence}
-              onError={this.handleError}
-              addressBooks={this.props.AddressBooks}
-              dispatch={this.props.dispatch}
-              scrollIntoView={false}
-              realtime
-              required
-            />
-
-            <hr className="section-divider" />
-            <h1 className="section-header">{i18n.t('history.employment.default.collection.caption')}</h1>
-            <Employment
-              {...this.props.Employment}
-              section="history"
-              subsection="employment"
-              sort={sort}
-              totalYears={totalYears(this.props.Birthdate)}
-              overrideInitial={this.overrideInitial}
-              onUpdate={this.updateEmployment}
-              onError={this.handleError}
-              addressBooks={this.props.AddressBooks}
-              dispatch={this.props.dispatch}
-              scrollIntoView={false}
-              realtime
-              required
-            />
-
-            <hr className="section-divider" />
-            <h1 className="section-header">{i18n.t('history.education.collection.caption')}</h1>
-            <Field
-              title={i18n.t('history.education.title')}
-              titleSize="h4"
-              optional={true}
-              className="no-margin-bottom">
-              {i18n.m('history.education.info')}
-            </Field>
-
-            <Branch
-              name="branch_school"
-              {...this.props.Education.HasAttended}
-              help="history.education.help.attendance"
-              label={i18n.t('history.education.label.attendance')}
-              labelSize="h3"
-              warning={true}
-              onUpdate={this.updateBranchAttendance}
-            />
-            <Show when={this.props.Education.HasAttended.value === 'No'}>
-              <Branch
-                name="branch_degree10"
-                {...this.props.Education.HasDegree10}
-                help="history.education.help.degree10"
-                label={i18n.t('history.education.label.degree10')}
-                labelSize="h3"
-                warning={true}
-                onUpdate={this.updateBranchDegree10}
-              />
-            </Show>
-            <Show
-              when={
-                this.props.Education.HasAttended.value === 'Yes' ||
-                this.props.Education.HasDegree10.value === 'Yes'
-              }>
-              <div>
-                <span id="scrollToHistory" />
-                <Education
-                  {...this.props.Education}
-                  section="history"
-                  subsection="education"
-                  realtime={true}
-                  sort={sort}
-                  totalYears={totalYears(this.props.Birthdate)}
-                  overrideInitial={this.overrideInitial}
-                  onUpdate={this.updateEducation}
-                  onError={this.handleError}
-                  dispatch={this.props.dispatch}
-                  addressBooks={this.props.AddressBooks}
-                  scrollIntoView={false}
-                  required={true}
-                />
-              </div>
-            </Show>
-
-            <hr className="section-divider" />
-            <h1 className="section-header">{i18n.t('history.destination.federal')}</h1>
-            <Federal
-              name="federal"
-              {...this.props.Federal}
-              section="history"
-              subsection="federal"
-              addressBooks={this.props.AddressBooks}
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Federal')}
-              onError={this.handleError}
-              scrollIntoView={false}
-              required={true}
-            />
-          </SectionView>
-
-          <SectionView
-            name="federal"
-            back="history/education"
-            backLabel={i18n.t('history.destination.education')}
-            next="history/review"
-            nextLabel={i18n.t('history.destination.review')}>
-            <h1 className="section-header">{i18n.t('history.destination.federal')}</h1>
-            <Federal
-              name="federal"
-              {...this.props.Federal}
-              addressBooks={this.props.AddressBooks}
-              dispatch={this.props.dispatch}
-              onUpdate={this.handleUpdate.bind(this, 'Federal')}
-              onError={this.handleError}
-            />
-          </SectionView>
-            </SectionViews>*/}
       </div>
     )
   }
 }
 
-const processDate = date => {
-  if (!date) {
-    return null
-  }
-
-  let d = null
-  const { month, day, year } = date.Date
-  if (month && day && year) {
-    d = utc(new Date(year, month - 1, day))
-  }
-  return d
-}
-
 function mapStateToProps(state) {
   const { section } = state
-  const app = state.application || {}
-  const identification = app.Identification || {}
-  const history = app.History || {}
-  const errors = app.Errors || {}
-  const completed = app.Completed || {}
-  const addressBooks = app.AddressBooks || {}
 
   return {
     ...section,
-    History: history,
-    Residence: history.Residence || { List: { items: [] } },
-    Employment: history.Employment || { items: [] },
-    Education: history.Education || {
-      HasAttended: '',
-      HasDegree10: '',
-      List: { items: [] }
-    },
-    Federal: history.Federal || {},
-    Errors: errors.history || [],
-    Completed: completed.history || [],
-    Birthdate: processDate(identification.ApplicantBirthDate),
-    AddressBooks: addressBooks
   }
 }
 
 History.defaultProps = {
   subsection: 'intro',
-  section: 'history',
-  store: 'History'
 }
+
+export default connect(mapStateToProps)(History)
 
 export class HistorySections extends React.Component {
   render() {
@@ -377,11 +192,7 @@ export class HistorySections extends React.Component {
 
         <hr className="section-divider" />
         <Federal
-          name="federal"
-          {...this.props.Federal}
           defaultState={false}
-          addressBooks={this.props.AddressBooks}
-          dispatch={this.props.dispatch}
           onError={this.props.onError}
           scrollIntoView={false}
           required={true}
@@ -390,5 +201,3 @@ export class HistorySections extends React.Component {
     )
   }
 }
-
-export default connect(mapStateToProps)(History)

--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -96,8 +96,10 @@ export class HistorySections extends React.Component {
       <div className="history">
         <Residence
           defaultState={false}
+          realtime={true}
           overrideInitial={true}
           onError={this.props.onError}
+          scrollIntoView={false}
           required={true} />
 
         <Employment
@@ -105,8 +107,8 @@ export class HistorySections extends React.Component {
           realtime={true}
           overrideInitial={true}
           onError={this.props.onError}
-          required={true}
-        />
+          scrollIntoView={false}
+          required={true} />
 
         <Branch
           name="branch_school"
@@ -132,6 +134,7 @@ export class HistorySections extends React.Component {
             realtime={true}
             overrideInitial={true}
             onError={this.props.onError}
+            scrollIntoView={false}
             required={true}
           />
         </Show>

--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -5,8 +5,6 @@ import classnames from 'classnames'
 
 import { reportCompletion } from 'actions/ApplicationActions'
 import {
-  ResidenceValidator,
-  EmploymentValidator,
   HistoryEducationValidator,
   EducationItemValidator
 } from 'validators'
@@ -19,6 +17,10 @@ import * as sections from 'constants/sections'
 
 import Intro from 'components/Section/History/Intro'
 import ResidenceWrapper from 'components/Section/History/Residence/ResidenceWrapper'
+import Residence from 'components/Section/History/Residence'
+import EmploymentWrapper from 'components/Section/History/Employment/EmploymentWrapper'
+import Employment from 'components/Section/History/Employment'
+
 import Review from 'components/Section/History/Review'
 
 import { SectionViews, SectionView } from 'components/Section/SectionView'
@@ -36,8 +38,6 @@ import {
   extractDate
 } from 'components/Section/History/dateranges'
 import { InjectGaps } from 'components/Section/History/summaries'
-import Residence from 'components/Section/History/Residence'
-import Employment from 'components/Section/History/Employment'
 import Education from 'components/Section/History/Education'
 
 /**
@@ -95,12 +95,8 @@ class History extends SectionElement {
   constructor(props) {
     super(props)
 
-    this.residenceRangeList = this.residenceRangeList.bind(this)
-    this.employmentRangesList = this.employmentRangesList.bind(this)
     this.schoolRangesList = this.schoolRangesList.bind(this)
     this.diplomaRangesList = this.diplomaRangesList.bind(this)
-    this.updateResidence = this.updateResidence.bind(this)
-    this.updateEmployment = this.updateEmployment.bind(this)
     this.updateEducation = this.updateEducation.bind(this)
     this.updateBranchAttendance = this.updateBranchAttendance.bind(this)
     this.updateBranchDegree10 = this.updateBranchDegree10.bind(this)
@@ -111,16 +107,6 @@ class History extends SectionElement {
     return items.filter(
       item => !item.type || (item.type && item.type !== 'Gap')
     )
-  }
-
-  updateResidence(values) {
-    this.handleUpdate('Residence', {
-      List: values
-    })
-  }
-
-  updateEmployment(employment) {
-    this.handleUpdate('Employment', employment)
   }
 
   updateEducation(values) {
@@ -158,58 +144,6 @@ class History extends SectionElement {
         new HistoryEducationValidator(education, education).isValid()
       )
     )
-  }
-
-  /**
-   * Extracts dates used for summary progress and gap analysis for residence
-   */
-  residenceRangeList() {
-    let dates = []
-    if (
-      !this.props.Residence ||
-      !this.props.Residence.List ||
-      !this.props.Residence.List.items
-    ) {
-      return dates
-    }
-
-    for (const i of this.excludeGaps(this.props.Residence.List.items)) {
-      if (!i.Item) {
-        continue
-      }
-
-      if (new ResidenceValidator(i.Item).isValid()) {
-        dates.push(i.Item.Dates)
-      }
-    }
-
-    return dates
-  }
-
-  /**
-   * Extracts dates used for summary progress and gap analysis for employment
-   */
-  employmentRangesList() {
-    let dates = []
-    if (
-      !this.props.Employment ||
-      !this.props.Employment.List ||
-      !this.props.Employment.List.items
-    ) {
-      return dates
-    }
-
-    for (const i of this.excludeGaps(this.props.Employment.List.items)) {
-      if (!i.Item) {
-        continue
-      }
-
-      if (new EmploymentValidator(i.Item).isValid()) {
-        dates.push(i.Item.Dates)
-      }
-    }
-
-    return dates
   }
 
   schoolRangesList() {
@@ -258,42 +192,6 @@ class History extends SectionElement {
     }
 
     return dates
-  }
-
-  residenceSummaryProgress() {
-    return (
-      <SummaryProgress
-        className="residence"
-        List={this.residenceRangeList}
-        title={i18n.t('history.residence.summary.title')}
-        unit={i18n.t('history.residence.summary.unit')}
-        total={totalYears(this.props.Birthdate)}>
-        <div className="summary-icon">
-          <Svg
-            src="/img/residence-house.svg"
-            alt={i18n.t('history.residence.summary.svgAlt')}
-          />
-        </div>
-      </SummaryProgress>
-    )
-  }
-
-  employmentSummaryProgress() {
-    return (
-      <SummaryProgress
-        className="residence"
-        List={this.employmentRangesList}
-        title={i18n.t('history.employment.summary.title')}
-        unit={i18n.t('history.employment.summary.unit')}
-        total={totalYears(this.props.Birthdate)}>
-        <div className="summary-icon">
-          <Svg
-            src="/img/employer-briefcase.svg"
-            alt={i18n.t('history.employment.summary.svgAlt')}
-          />
-        </div>
-      </SummaryProgress>
-    )
   }
 
   educationSummaryProgress() {
@@ -391,6 +289,7 @@ class History extends SectionElement {
 
             <Route path="/form/history/intro" component={Intro} />
             <Route path="/form/history/residence" component={ResidenceWrapper} />
+            <Route path="/form/history/employment" component={EmploymentWrapper} />
             <Route path="/form/history/review" component={Review} />
 
             <SectionNavigation
@@ -529,98 +428,6 @@ class History extends SectionElement {
               scrollIntoView={false}
               required={true}
             />
-          </SectionView>
-
-          <SectionView
-            name="residence"
-            back="history/intro"
-            backLabel={i18n.t('history.destination.intro')}
-            next="history/employment"
-            nextLabel={i18n.t('history.destination.employment')}>
-            <h1 className="section-header">{i18n.t('history.residence.title')}</h1>
-            <Field
-              title={i18n.t('history.residence.info')}
-              titleSize="h3"
-              optional={true}
-              className="no-margin-bottom">
-              {i18n.m('history.residence.info2')}
-              {i18n.m('history.residence.info3a')}
-              {i18n.m('history.residence.info3b')}
-              {i18n.m('history.residence.info3c')}
-              {i18n.m('history.residence.info3d')}
-            </Field>
-
-            <span id="scrollToHistory" />
-            {this.residenceSummaryProgress()}
-            <Residence
-              {...this.props.Residence}
-              scrollToTop="scrollToHistory"
-              realtime={true}
-              sort={sort}
-              totalYears={totalYears(this.props.Birthdate)}
-              overrideInitial={this.overrideInitial}
-              onUpdate={this.updateResidence}
-              onError={this.handleError}
-              addressBooks={this.props.AddressBooks}
-              dispatch={this.props.dispatch}
-            />
-
-            <Show when={this.hasGaps(['Residence'])}>
-              <div className="not-complete">
-                <hr className="section-divider" />
-                <Field
-                  title={i18n.t('history.residence.heading.exiting')}
-                  titleSize="h4"
-                  optional={true}
-                  className="no-margin-bottom">
-                  {i18n.m('history.residence.para.exiting')}
-                </Field>
-              </div>
-            </Show>
-          </SectionView>
-
-          <SectionView
-            name="employment"
-            back="history/residence"
-            backLabel={i18n.t('history.destination.residence')}
-            next="history/education"
-            nextLabel={i18n.t('history.destination.education')}>
-            <h1 className="section-header">{i18n.t('history.employment.summary.title')}</h1>
-            <Field
-              title={i18n.t('history.employment.heading.employment')}
-              titleSize="h3"
-              optional={true}
-              className="no-margin-bottom">
-              {i18n.m('history.employment.para.employment')}
-              {i18n.m('history.employment.para.employment2')}
-            </Field>
-
-            <span id="scrollToHistory" />
-            {this.employmentSummaryProgress()}
-            <Employment
-              {...this.props.Employment}
-              scrollToTop="scrollToHistory"
-              sort={sort}
-              totalYears={totalYears(this.props.Birthdate)}
-              overrideInitial={this.overrideInitial}
-              onUpdate={this.updateEmployment}
-              onError={this.handleError}
-              addressBooks={this.props.AddressBooks}
-              dispatch={this.props.dispatch}
-            />
-
-            <Show when={this.hasGaps(['Employment'])}>
-              <div className="not-complete">
-                <hr className="section-divider" />
-                <Field
-                  title={i18n.t('history.employment.heading.exiting')}
-                  titleSize="h4"
-                  optional={true}
-                  className="no-margin-bottom">
-                  {i18n.m('history.employment.para.exiting')}
-                </Field>
-              </div>
-            </Show>
           </SectionView>
 
           <SectionView
@@ -763,16 +570,9 @@ export class HistorySections extends React.Component {
           required={true} />
 
         <Employment
-          {...this.props.Employment}
           defaultState={false}
           realtime={true}
-          sort={sort}
-          totalYears={totalYears(this.props.Birthdate)}
-          overrideInitial={noOverride}
-          onError={this.props.onError}
-          addressBooks={this.props.AddressBooks}
-          dispatch={this.props.dispatch}
-          scrollIntoView={false}
+          overrideInitial={true}
           required={true}
         />
 

--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Route } from 'react-router'
 import { connect } from 'react-redux'
 import classnames from 'classnames'
@@ -16,7 +17,7 @@ import Residence from 'components/Section/History/Residence'
 import EmploymentWrapper from 'components/Section/History/Employment/EmploymentWrapper'
 import Employment from 'components/Section/History/Employment'
 import EducationWrapper from 'components/Section/History/Education/EducationWrapper'
-import Education from 'components/Section/History/Education'
+import ConnectedEducation from 'components/Section/History/Education'
 import FederalWrapper from 'components/Section/History/Federal/FederalWrapper'
 import Federal from 'components/Section/History/Federal'
 import Review from 'components/Section/History/Review'
@@ -28,49 +29,48 @@ import { Show, Branch } from 'components/Form'
  * - totalYears needs to change based on form type
  */
 
-class History extends React.Component {
-  render() {
-    const subsection = this.props.subsection || 'intro'
+const History = (props) => {
+  const { subsection } = props
 
-    const subsectionClasses = classnames(
-      'view',
-      `view-${subsection}`
-    )
+  const subsectionClasses = classnames(
+    'view',
+    `view-${subsection}`
+  )
 
-    const isReview = subsection === 'review'
-    const title = isReview && i18n.t('review.title')
-    const para = isReview && i18n.m('review.para')
+  const isReview = subsection === 'review'
+  const title = isReview && i18n.t('review.title')
+  const para = isReview && i18n.m('review.para')
 
-    /** TODO - this should come from Redux store */
-    const formType = 'SF86'
-    
-    return (
-      <div className="history">
-        <div className="section-view">
-          {title && <h1 className="title">{title}</h1>}
-          {para}
+  /** TODO - this should come from Redux store */
+  const formType = 'SF86'
 
-          <div className={subsectionClasses}>
-            {isReview && (
-              <div className="top-btns"><ErrorList /></div>
-            )}
+  return (
+    <div className="history">
+      <div className="section-view">
+        {title && <h1 className="title">{title}</h1>}
+        {para}
 
-            <Route path="/form/history/intro" component={Intro} />
-            <Route path="/form/history/residence" component={ResidenceWrapper} />
-            <Route path="/form/history/employment" component={EmploymentWrapper} />
-            <Route path="/form/history/education" component={EducationWrapper} />
-            <Route path="/form/history/federal" component={FederalWrapper} />
-            <Route path="/form/history/review" component={Review} />
+        <div className={subsectionClasses}>
+          {isReview && (
+            <div className="top-btns"><ErrorList /></div>
+          )}
 
-            <SectionNavigation
-              section={sections.HISTORY}
-              subsection={subsection}
-              formType={formType} />
-          </div>
+          <Route path="/form/history/intro" component={Intro} />
+          <Route path="/form/history/residence" component={ResidenceWrapper} />
+          <Route path="/form/history/employment" component={EmploymentWrapper} />
+          <Route path="/form/history/education" component={EducationWrapper} />
+          <Route path="/form/history/federal" component={FederalWrapper} />
+          <Route path="/form/history/review" component={Review} />
+
+          <SectionNavigation
+            section={sections.HISTORY}
+            subsection={subsection}
+            formType={formType}
+          />
         </div>
       </div>
-    )
-  }
+    </div>
+  )
 }
 
 function mapStateToProps(state) {
@@ -81,72 +81,76 @@ function mapStateToProps(state) {
   }
 }
 
+History.propTypes = {
+  subsection: PropTypes.string,
+}
+
 History.defaultProps = {
   subsection: 'intro',
 }
 
 export default connect(mapStateToProps)(History)
 
-export class HistorySections extends React.Component {
-  render() {
-    const noOverride = () => {
-      return false
-    }
-    return (
-      <div className="history">
-        <Residence
-          defaultState={false}
-          realtime={true}
-          overrideInitial={true}
-          onError={this.props.onError}
-          scrollIntoView={false}
-          required={true} />
+export const HistorySections = (props) => {
+  const { onError, Education } = props
 
-        <Employment
-          defaultState={false}
-          realtime={true}
-          overrideInitial={true}
-          onError={this.props.onError}
-          scrollIntoView={false}
-          required={true} />
+  return (
+    <div className="history">
+      <Residence
+        defaultState={false}
+        realtime
+        overrideInitial
+        onError={onError}
+        scrollIntoView={false}
+        required
+      />
 
+      <Employment
+        defaultState={false}
+        realtime
+        overrideInitial
+        onError={onError}
+        scrollIntoView={false}
+        required
+      />
+
+      <Branch
+        name="branch_school"
+        {...Education.HasAttended}
+        label={i18n.t('history.education.label.attendance')}
+        labelSize="h3"
+      />
+      <Show when={Education.HasAttended.value === 'No'}>
         <Branch
-          name="branch_school"
-          {...this.props.Education.HasAttended}
-          label={i18n.t('history.education.label.attendance')}
+          name="branch_degree10"
+          {...Education.HasDegree10}
+          label={i18n.t('history.education.label.degree10')}
           labelSize="h3"
         />
-        <Show when={this.props.Education.HasAttended.value === 'No'}>
-          <Branch
-            name="branch_degree10"
-            {...this.props.Education.HasDegree10}
-            label={i18n.t('history.education.label.degree10')}
-            labelSize="h3"
-          />
-        </Show>
-        <Show
-          when={
-            this.props.Education.HasAttended.value === 'Yes' ||
-            this.props.Education.HasDegree10.value === 'Yes'
-          }>
-          <Education
-            defaultState={false}
-            realtime={true}
-            overrideInitial={true}
-            onError={this.props.onError}
-            scrollIntoView={false}
-            required={true}
-          />
-        </Show>
-
-        <hr className="section-divider" />
-        <Federal
+      </Show>
+      <Show
+        when={
+          Education.HasAttended.value === 'Yes'
+          || Education.HasDegree10.value === 'Yes'
+        }
+      >
+        <ConnectedEducation
           defaultState={false}
-          onError={this.props.onError}
+          realtime
+          overrideInitial
+          onError={onError}
           scrollIntoView={false}
-          required={true}
+          required
         />
-      </div>
-    )
-  }
+      </Show>
+
+      <hr className="section-divider" />
+      <Federal
+        defaultState={false}
+        onError={onError}
+        scrollIntoView={false}
+        required
+      />
+    </div>
+  )
 }

--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -23,64 +23,10 @@ import Review from 'components/Section/History/Review'
 
 import { Show, Branch } from 'components/Form'
 
-import {
-  utc,
-  today,
-  daysAgo,
-  daysBetween,
-  extractDate
-} from 'components/Section/History/dateranges'
-
 /**
- * Default sorting of history objects. This assumes that all objects contain a `Dates` property
- * with date range values.
+ * TODO
+ * - totalYears needs to change based on form type
  */
-export const sort = (a, b) => {
-  // Helper to find the date value or default it to 0
-  const getOptionalDate = obj => {
-    return (((obj || {}).Item || {}).Dates || {}).to
-  }
-
-  const first = extractDate(getOptionalDate(a)) || 0
-  const second = extractDate(getOptionalDate(b)) || 0
-
-  if (a.type === 'Gap') {
-    return 1
-  } else if (b.type === 'Gap') {
-    return -1
-  } else if (first < second) {
-    return 1
-  } else if (first > second) {
-    return -1
-  }
-
-  return 0
-}
-
-/**
- * Figure the total amount of years to collect for the timeline
- */
-export const totalYears = birthdate => {
-  let total = 10
-  if (!birthdate) {
-    return total
-  }
-
-  const eighteen = daysAgo(birthdate, 365 * -18)
-  total = Math.ceil(daysBetween(eighteen, today) / 365)
-
-  // A maximum of 10 years is required
-  if (total > 10) {
-    total = 10
-  }
-
-  // A minimum of two years is required
-  if (total < 2) {
-    total = 2
-  }
-
-  return total
-}
 
 class History extends React.Component {
   render() {

--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -758,7 +758,7 @@ export class HistorySections extends React.Component {
       <div className="history">
         <Residence
           defaultState={false}
-          overrideInitial={noOverride}
+          overrideInitial={true}
           onError={this.props.onError}
           required={true} />
 

--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -1,5 +1,8 @@
 import React from 'react'
+import { Route } from 'react-router'
 import { connect } from 'react-redux'
+import classnames from 'classnames'
+
 import { reportCompletion } from 'actions/ApplicationActions'
 import {
   ResidenceValidator,
@@ -8,6 +11,16 @@ import {
   EducationItemValidator
 } from 'validators'
 import { i18n } from 'config'
+
+import { ErrorList } from 'components/ErrorList'
+import SectionNavigation from 'components/Section/shared/SectionNavigation'
+
+import * as sections from 'constants/sections'
+
+import Intro from 'components/Section/History/Intro'
+import ResidenceWrapper from 'components/Section/History/Residence/ResidenceWrapper'
+import Review from 'components/Section/History/Review'
+
 import { SectionViews, SectionView } from 'components/Section/SectionView'
 import SectionElement from 'components/Section/SectionElement'
 import { Field, Svg, Show, Branch } from 'components/Form'
@@ -351,26 +364,47 @@ class History extends SectionElement {
   }
 
   render() {
+    const subsection = this.props.subsection || 'intro'
+
+    const subsectionClasses = classnames(
+      'view',
+      `view-${subsection}`
+    )
+
+    const isReview = subsection === 'review'
+    const title = isReview && i18n.t('review.title')
+    const para = isReview && i18n.m('review.para')
+
+    /** TODO - this should come from Redux store */
+    const formType = 'SF86'
+    
     return (
       <div className="history">
+        <div className="section-view">
+          {title && <h1 className="title">{title}</h1>}
+          {para}
+
+          <div className={subsectionClasses}>
+            {isReview && (
+              <div className="top-btns"><ErrorList /></div>
+            )}
+
+            <Route path="/form/history/intro" component={Intro} />
+            <Route path="/form/history/residence" component={ResidenceWrapper} />
+            <Route path="/form/history/review" component={Review} />
+
+            <SectionNavigation
+              section={sections.HISTORY}
+              subsection={subsection}
+              formType={formType} />
+          </div>
+        </div>
+
+        {/*
         <SectionViews
           current={this.props.subsection}
           dispatch={this.props.dispatch}
           update={this.props.update}>
-          <SectionView
-            name="intro"
-            back="identification/review"
-            backLabel={i18n.t('identification.destination.review')}
-            next="history/residence"
-            nextLabel={i18n.t('history.destination.residence')}>
-            <h1 className="section-header">{i18n.t('history.intro.title')}</h1>
-            <Field
-              optional={true}
-              className="no-margin-bottom">
-              {i18n.m('history.intro.body')}
-            </Field>
-          </SectionView>
-
           <SectionView
             name="review"
             title={i18n.t('review.title')}
@@ -663,7 +697,7 @@ class History extends SectionElement {
               onError={this.handleError}
             />
           </SectionView>
-        </SectionViews>
+            </SectionViews>*/}
       </div>
     )
   }
@@ -683,6 +717,7 @@ const processDate = date => {
 }
 
 function mapStateToProps(state) {
+  const { section } = state
   const app = state.application || {}
   const identification = app.Identification || {}
   const history = app.History || {}
@@ -691,6 +726,7 @@ function mapStateToProps(state) {
   const addressBooks = app.AddressBooks || {}
 
   return {
+    ...section,
     History: history,
     Residence: history.Residence || { List: { items: [] } },
     Employment: history.Employment || { items: [] },
@@ -708,6 +744,7 @@ function mapStateToProps(state) {
 }
 
 History.defaultProps = {
+  subsection: 'intro',
   section: 'history',
   store: 'History'
 }
@@ -720,18 +757,10 @@ export class HistorySections extends React.Component {
     return (
       <div className="history">
         <Residence
-          {...this.props.Residence}
           defaultState={false}
-          realtime={true}
-          sort={sort}
-          totalYears={totalYears(this.props.Birthdate)}
           overrideInitial={noOverride}
           onError={this.props.onError}
-          addressBooks={this.props.AddressBooks}
-          dispatch={this.props.dispatch}
-          scrollIntoView={false}
-          required={true}
-        />
+          required={true} />
 
         <Employment
           {...this.props.Employment}

--- a/src/components/Section/History/History.test.jsx
+++ b/src/components/Section/History/History.test.jsx
@@ -5,10 +5,6 @@ import { Provider } from 'react-redux'
 import History from 'components/Section/History/History'
 import { mount } from 'enzyme'
 
-const applicationState = {
-  History: {}
-}
-
 describe('The History section', () => {
   const mockStore = configureMockStore()
 
@@ -31,11 +27,11 @@ describe('The History section', () => {
       'residence',
       'employment',
       'education',
-      'federal'
+      'federal',
     ]
     const store = mockStore({})
 
-    sections.forEach(section => {
+    sections.forEach((section) => {
       const component = mount(
         <MemoryRouter initialEntries={[`/form/history/${section}`]}>
           <Provider store={store}>

--- a/src/components/Section/History/History.test.jsx
+++ b/src/components/Section/History/History.test.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
+import { MemoryRouter } from 'react-router'
 import configureMockStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
-import History, { totalYears } from 'components/Section/History/History'
-import Employment from 'components/Section/History/Employment'
+import History from 'components/Section/History/History'
 import { mount } from 'enzyme'
 
 const applicationState = {
@@ -15,9 +15,11 @@ describe('The History section', () => {
   it('can review all subsections', () => {
     const store = mockStore({})
     const component = mount(
-      <Provider store={store}>
-        <History subsection="review" />
-      </Provider>
+      <MemoryRouter initialEntries={['/form/history/review']}>
+        <Provider store={store}>
+          <History subsection="review" />
+        </Provider>
+      </MemoryRouter>
     )
     expect(component.find('div').length).toBeGreaterThan(0)
   })
@@ -35,61 +37,13 @@ describe('The History section', () => {
 
     sections.forEach(section => {
       const component = mount(
-        <Provider store={store}>
-          <History subsection={section} />
-        </Provider>
+        <MemoryRouter initialEntries={[`/form/history/${section}`]}>
+          <Provider store={store}>
+            <History subsection={section} />
+          </Provider>
+        </MemoryRouter>
       )
       expect(component.find('div').length).toBeGreaterThan(0)
     })
-  })
-
-  it('sets totalYears to proper value if applicant has less than 10 years of history', () => {
-    const store = mockStore({
-      application: {
-        Identification: {
-          ApplicantBirthDate: {
-            Date: {
-              month: `${new Date().getMonth() + 1}`,
-              day: `${new Date().getDate()}`,
-              year: `${new Date().getFullYear() - 18}`,
-              estimated: false
-            }
-          }
-        }
-      }
-    })
-
-    const component = mount(
-      <Provider store={store}>
-        <History subsection="employment" />
-      </Provider>
-    )
-
-    expect(component.find(Employment).props().totalYears).toEqual(2)
-  })
-
-  it('sets totalYears to proper value if applicant has more than 10 years of history', () => {
-    const store = mockStore({
-      application: {
-        Identification: {
-          ApplicantBirthDate: {
-            Date: {
-              month: `${new Date().getMonth() + 1}`,
-              day: `${new Date().getDate()}`,
-              year: `${new Date().getFullYear() - 30}`,
-              estimated: false
-            }
-          }
-        }
-      }
-    })
-
-    const component = mount(
-      <Provider store={store}>
-        <History subsection="employment" />
-      </Provider>
-    )
-
-    expect(component.find(Employment).props().totalYears).toEqual(10)
   })
 })

--- a/src/components/Section/History/HistoryConnector.jsx
+++ b/src/components/Section/History/HistoryConnector.jsx
@@ -7,7 +7,7 @@ import {
   reportErrors,
 } from '@actions/ApplicationActions'
 
-import { totalYears, sort } from '@components/Section/History/History'
+import { totalYears, sort } from '@components/Section/History/helpers'
 import { utc } from '@components/Section/History/dateranges'
 
 const connectHistorySection = (Component, { section, subsection, store, storeKey }) => {
@@ -100,6 +100,12 @@ const connectHistorySection = (Component, { section, subsection, store, storeKey
             ...emptyList,
           },
           Birthdate: processDate(identification.ApplicantBirthDate),
+          addressBooks,
+        }
+
+      case 'Federal':
+        return {
+          ...history.Federal || {},
           addressBooks,
         }
 

--- a/src/components/Section/History/HistoryConnector.jsx
+++ b/src/components/Section/History/HistoryConnector.jsx
@@ -5,32 +5,36 @@ import { connect } from 'react-redux'
 import {
   updateApplication,
   reportErrors,
-} from '@actions/ApplicationActions'
+} from 'actions/ApplicationActions'
 
-import { totalYears, sort } from '@components/Section/History/helpers'
-import { utc } from '@components/Section/History/dateranges'
+import { totalYears, sort } from 'components/Section/History/helpers'
+import { utc } from 'components/Section/History/dateranges'
 
-const connectHistorySection = (Component, { section, subsection, store, storeKey }) => {
+const connectHistorySection = (Component, {
+  section, subsection, store, storeKey,
+}) => {
   class ConnectedHistorySection extends React.Component {
     constructor(props) {
       super(props)
-  
+
       this.section = section
       this.subsection = subsection
       this.store = store
     }
 
     handleError = (value, arr) => {
+      const { dispatch } = this.props
       const action = reportErrors(this.section, this.subsection, arr)
-      this.props.dispatch(action)
+      dispatch(action)
       return arr
     }
-  
+
     handleUpdate = (field, values) => {
-      this.props.dispatch(updateApplication(this.store, field, values))
+      const { dispatch } = this.props
+      dispatch(updateApplication(this.store, field, values))
     }
 
-    render () {
+    render() {
       const { Birthdate } = this.props
 
       const totalYearsProp = totalYears(Birthdate)
@@ -41,23 +45,28 @@ const connectHistorySection = (Component, { section, subsection, store, storeKey
           onError={this.handleError}
           totalYears={totalYearsProp}
           sort={sort}
-          {...this.props} />
+          {...this.props}
+        />
       )
     }
   }
 
+  /* eslint react/forbid-prop-types: 0 */
   ConnectedHistorySection.propTypes = {
     Birthdate: PropTypes.any,
-    update: PropTypes.func,
-    validator: PropTypes.func,
     dispatch: PropTypes.func, // Passed in via connect (below)
   }
 
-  const processDate = date => {
+  ConnectedHistorySection.defaultProps = {
+    Birthdate: null,
+    dispatch: () => {},
+  }
+
+  const processDate = (date) => {
     if (!date) {
       return null
     }
-  
+
     let d = null
     const { month, day, year } = date.Date
     if (month && day && year) {

--- a/src/components/Section/History/HistoryConnector.jsx
+++ b/src/components/Section/History/HistoryConnector.jsx
@@ -1,0 +1,117 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+
+import {
+  updateApplication,
+  reportErrors,
+} from '@actions/ApplicationActions'
+
+import { totalYears, sort } from '@components/Section/History/History'
+import { utc } from '@components/Section/History/dateranges'
+
+const connectHistorySection = (Component, { section, subsection, store, storeKey }) => {
+  class ConnectedHistorySection extends React.Component {
+    constructor(props) {
+      super(props)
+  
+      this.section = section
+      this.subsection = subsection
+      this.store = store
+    }
+
+    handleError = (value, arr) => {
+      const action = reportErrors(this.section, this.subsection, arr)
+      this.props.dispatch(action)
+      return arr
+    }
+  
+    handleUpdate = (field, values) => {
+      this.props.dispatch(updateApplication(this.store, field, values))
+    }
+
+    overrideInitial = (initial) => {
+      return this.props.inReview ? false : initial
+    }
+
+    render () {
+      const { Birthdate } = this.props
+
+      const totalYearsProp = totalYears(Birthdate)
+
+      return (
+        <Component
+          onUpdate={this.handleUpdate}
+          onError={this.handleError}
+          overrideInitial={this.overrideInitial}
+          totalYears={totalYearsProp}
+          sort={sort}
+          {...this.props} />
+      )
+    }
+  }
+
+  ConnectedHistorySection.propTypes = {
+    Birthdate: PropTypes.any,
+    inReview: PropTypes.bool,
+    update: PropTypes.func,
+    validator: PropTypes.func,
+    dispatch: PropTypes.func, // Passed in via connect (below)
+  }
+
+  const processDate = date => {
+    if (!date) {
+      return null
+    }
+  
+    let d = null
+    const { month, day, year } = date.Date
+    if (month && day && year) {
+      d = utc(new Date(year, month - 1, day))
+    }
+    return d
+  }
+
+  const mapStateToProps = (state) => {
+    const app = state.application || {}
+    const identification = app.Identification || {}
+    const history = app.History || {}
+    const errors = app.Errors || {}
+    const completed = app.Completed || {}
+    const addressBooks = app.AddressBooks || {}
+
+    const emptyItems = { items: [] }
+    const emptyList = { List: emptyItems }
+
+    switch (storeKey) {
+      case 'Residence':
+        return {
+          ...history.Residence || emptyList,
+          Birthdate: processDate(identification.ApplicantBirthDate),
+          addressBooks,
+        }
+
+      default:
+        return {
+          History: history,
+          Residence: history.Residence || emptyList,
+          Employment: history.Employment || emptyItems,
+          Education: history.Education || {
+            HasAttended: '',
+            HasDegree10: '',
+            ...emptyList,
+          },
+          Federal: history.Federal || {},
+
+          Errors: errors.history || [],
+          Completed: completed.history || [],
+          Birthdate: processDate(identification.ApplicantBirthDate),
+          AddressBooks: addressBooks,
+        }
+    }
+  }
+
+  return connect(mapStateToProps)(ConnectedHistorySection)
+}
+
+export default connectHistorySection

--- a/src/components/Section/History/HistoryConnector.jsx
+++ b/src/components/Section/History/HistoryConnector.jsx
@@ -30,10 +30,6 @@ const connectHistorySection = (Component, { section, subsection, store, storeKey
       this.props.dispatch(updateApplication(this.store, field, values))
     }
 
-    overrideInitial = (initial) => {
-      return this.props.inReview ? false : initial
-    }
-
     render () {
       const { Birthdate } = this.props
 
@@ -43,7 +39,6 @@ const connectHistorySection = (Component, { section, subsection, store, storeKey
         <Component
           onUpdate={this.handleUpdate}
           onError={this.handleError}
-          overrideInitial={this.overrideInitial}
           totalYears={totalYearsProp}
           sort={sort}
           {...this.props} />
@@ -87,6 +82,13 @@ const connectHistorySection = (Component, { section, subsection, store, storeKey
       case 'Residence':
         return {
           ...history.Residence || emptyList,
+          Birthdate: processDate(identification.ApplicantBirthDate),
+          addressBooks,
+        }
+
+      case 'Employment':
+        return {
+          ...history.Employment || emptyItems,
           Birthdate: processDate(identification.ApplicantBirthDate),
           addressBooks,
         }

--- a/src/components/Section/History/HistoryConnector.jsx
+++ b/src/components/Section/History/HistoryConnector.jsx
@@ -48,7 +48,6 @@ const connectHistorySection = (Component, { section, subsection, store, storeKey
 
   ConnectedHistorySection.propTypes = {
     Birthdate: PropTypes.any,
-    inReview: PropTypes.bool,
     update: PropTypes.func,
     validator: PropTypes.func,
     dispatch: PropTypes.func, // Passed in via connect (below)
@@ -89,6 +88,17 @@ const connectHistorySection = (Component, { section, subsection, store, storeKey
       case 'Employment':
         return {
           ...history.Employment || emptyItems,
+          Birthdate: processDate(identification.ApplicantBirthDate),
+          addressBooks,
+        }
+
+      case 'Education':
+        return {
+          ...history.Education || {
+            HasAttended: '',
+            HasDegree10: '',
+            ...emptyList,
+          },
           Birthdate: processDate(identification.ApplicantBirthDate),
           addressBooks,
         }

--- a/src/components/Section/History/HistoryConnector.test.jsx
+++ b/src/components/Section/History/HistoryConnector.test.jsx
@@ -1,0 +1,109 @@
+import React from 'react'
+
+import configureMockStore from 'redux-mock-store'
+import { Provider } from 'react-redux'
+
+import { mount } from 'enzyme'
+
+import connectHistorySection from './HistoryConnector'
+
+describe('The HistoryConnector HOC', () => {
+  const mockStore = configureMockStore()
+
+  const TestComponent = () => (
+    <div>Testing!</div>
+  )
+
+  const testConfig = {
+    section: '',
+    subsection: '',
+    store: '',
+    storeKey: '',
+  }
+
+  const Wrapper = connectHistorySection(TestComponent, testConfig)
+
+  describe('default behavior', () => {
+    const store = mockStore({})
+    const component = mount(
+      <Provider store={store}>
+        <Wrapper />
+      </Provider>
+    )
+
+    it('wraps and renders a given component', () => {
+      expect(component.exists()).toBe(true)
+      expect(component.find(TestComponent).length).toEqual(1)
+    })
+  
+    it('passes an onUpdate handler to the wrapped component', () => {
+      expect(component.find(TestComponent).prop('onUpdate')).toBeTruthy()
+    })
+
+    it('passes an onError handler to the wrapped component', () => {
+      expect(component.find(TestComponent).prop('onError')).toBeTruthy()
+    })
+
+    it('passes a totalYears prop to the wrapped component', () => {
+      expect(component.find(TestComponent).prop('totalYears')).toBeTruthy()
+    })
+
+    it('passes a sort prop to the wrapped component', () => {
+      expect(component.find(TestComponent).prop('sort')).toBeTruthy()
+    })
+  })
+
+  describe('if an applicant has less than 10 years of history', () => {
+    const store = mockStore({
+      application: {
+        Identification: {
+          ApplicantBirthDate: {
+            Date: {
+              month: `${new Date().getMonth() + 1}`,
+              day: `${new Date().getDate()}`,
+              year: `${new Date().getFullYear() - 18}`,
+              estimated: false
+            }
+          }
+        }
+      }
+    })
+
+    const component = mount(
+      <Provider store={store}>
+        <Wrapper />
+      </Provider>
+    )
+
+    it('sets totalYears to be the proper value', () => {
+      expect(component.find(TestComponent).prop('totalYears')).toEqual(2)
+    })
+  })
+
+  describe('if an applicant has more than 10 years of history', () => {
+    const store = mockStore({
+      application: {
+        Identification: {
+          ApplicantBirthDate: {
+            Date: {
+              month: `${new Date().getMonth() + 1}`,
+              day: `${new Date().getDate()}`,
+              year: `${new Date().getFullYear() - 30}`,
+              estimated: false
+            }
+          }
+        }
+      }
+    })
+
+    const component = mount(
+      <Provider store={store}>
+        <Wrapper />
+      </Provider>
+    )
+
+    it('sets totalYears to be the proper value', () => {
+      expect(component.find(TestComponent).prop('totalYears')).toEqual(10)
+    })
+  })
+})

--- a/src/components/Section/History/HistoryConnector.test.jsx
+++ b/src/components/Section/History/HistoryConnector.test.jsx
@@ -35,7 +35,7 @@ describe('The HistoryConnector HOC', () => {
       expect(component.exists()).toBe(true)
       expect(component.find(TestComponent).length).toEqual(1)
     })
-  
+
     it('passes an onUpdate handler to the wrapped component', () => {
       expect(component.find(TestComponent).prop('onUpdate')).toBeTruthy()
     })
@@ -62,11 +62,11 @@ describe('The HistoryConnector HOC', () => {
               month: `${new Date().getMonth() + 1}`,
               day: `${new Date().getDate()}`,
               year: `${new Date().getFullYear() - 18}`,
-              estimated: false
-            }
-          }
-        }
-      }
+              estimated: false,
+            },
+          },
+        },
+      },
     })
 
     const component = mount(
@@ -89,11 +89,11 @@ describe('The HistoryConnector HOC', () => {
               month: `${new Date().getMonth() + 1}`,
               day: `${new Date().getDate()}`,
               year: `${new Date().getFullYear() - 30}`,
-              estimated: false
-            }
-          }
-        }
-      }
+              estimated: false,
+            },
+          },
+        },
+      },
     })
 
     const component = mount(

--- a/src/components/Section/History/Intro.jsx
+++ b/src/components/Section/History/Intro.jsx
@@ -5,11 +5,11 @@ import { Field } from '@components/Form'
 const Intro = () => {
   return (
     <div>
-      <h1 className="section-header">{i18n.t('identification.intro.title')}</h1>
+      <h1 className="section-header">{i18n.t('history.intro.title')}</h1>
       <Field
         optional={true}
         className="no-margin-bottom">
-        {i18n.m('identification.intro.body')}
+        {i18n.m('history.intro.body')}
       </Field>
     </div>
   )

--- a/src/components/Section/History/Intro.jsx
+++ b/src/components/Section/History/Intro.jsx
@@ -1,18 +1,17 @@
 import React from 'react'
-import { i18n } from '@config'
-import { Field } from '@components/Form'
+import { i18n } from 'config'
+import { Field } from 'components/Form'
 
-const Intro = () => {
-  return (
-    <div>
-      <h1 className="section-header">{i18n.t('history.intro.title')}</h1>
-      <Field
-        optional={true}
-        className="no-margin-bottom">
-        {i18n.m('history.intro.body')}
-      </Field>
-    </div>
-  )
-}
+const Intro = () => (
+  <div>
+    <h1 className="section-header">{i18n.t('history.intro.title')}</h1>
+    <Field
+      optional
+      className="no-margin-bottom"
+    >
+      {i18n.m('history.intro.body')}
+    </Field>
+  </div>
+)
 
 export default Intro

--- a/src/components/Section/History/Residence/Residence.jsx
+++ b/src/components/Section/History/Residence/Residence.jsx
@@ -1,10 +1,14 @@
 import React from 'react'
-import { i18n } from '../../../../config'
+import { i18n } from '@config'
+
 import {
   HistoryResidenceValidator,
   ResidenceValidator
-} from '../../../../validators'
-import SubsectionElement from '../../SubsectionElement'
+} from '@validators'
+
+import Subsection from '@components/Section/shared/Subsection'
+import connectHistorySection from '../HistoryConnector'
+
 import { Accordion } from '../../../Form'
 import { newGuid } from '../../../Form/ValidationElement'
 import { openState } from '../../../Form/Accordion/Accordion'
@@ -12,6 +16,15 @@ import { today, daysAgo } from '../dateranges'
 import { InjectGaps, ResidenceCustomSummary } from '../summaries'
 import ResidenceItem from './ResidenceItem'
 import { Gap } from '../Gap'
+
+import { HISTORY, HISTORY_RESIDENCE } from '@config/formSections/history'
+
+const sectionConfig = {
+  section: HISTORY.name,
+  store: HISTORY.store,
+  subsection: HISTORY_RESIDENCE.name,
+  storeKey: HISTORY_RESIDENCE.storeKey,
+}
 
 const byline = (item, index, initial, translation, required, validator) => {
   switch (true) {
@@ -30,14 +43,25 @@ const byline = (item, index, initial, translation, required, validator) => {
   }
 }
 
-export default class Residence extends SubsectionElement {
+export class Residence extends Subsection {
   constructor(props) {
     super(props)
+
+    const { section, subsection, store, storeKey } = sectionConfig
+
+    this.section = section
+    this.subsection = subsection
+    this.store = store
+    this.storeKey = storeKey
 
     this.customResidenceByline = this.customResidenceByline.bind(this)
     this.customResidenceDetails = this.customResidenceDetails.bind(this)
     this.fillGap = this.fillGap.bind(this)
     this.inject = this.inject.bind(this)
+  }
+
+  handleUpdate = (values) => {
+    this.props.onUpdate('Residence', { List: values })
   }
 
   customResidenceByline(item, index, initial) {
@@ -86,7 +110,7 @@ export default class Residence extends SubsectionElement {
       }
     })
 
-    this.props.onUpdate({
+    this.handleUpdate({
       items: InjectGaps(items, daysAgo(365 * this.props.totalYears)).sort(
         this.sort
       ).filter(item => !item.type || (item.type && item.type !== 'Gap')),
@@ -102,7 +126,7 @@ export default class Residence extends SubsectionElement {
     return (
       <div
         className="section-content residence"
-        {...super.dataAttributes(this.props)}>
+        {...super.dataAttributes()}>
         <Accordion
           scrollToTop={this.props.scrollToTop}
           defaultState={this.props.defaultState}
@@ -110,7 +134,7 @@ export default class Residence extends SubsectionElement {
           sort={this.props.sort}
           inject={this.inject}
           realtime={this.props.realtime}
-          onUpdate={this.props.onUpdate}
+          onUpdate={this.handleUpdate}
           onError={this.handleError}
           caption={this.props.caption}
           byline={this.customResidenceByline}
@@ -137,9 +161,11 @@ export default class Residence extends SubsectionElement {
 
 Residence.defaultProps = {
   List: Accordion.defaultList,
+  scrollIntoView: false,
   scrollToTop: '',
   defaultState: true,
-  realtime: false,
+  realtime: true,
+  required: false,
   sort: null,
   totalYears: 10,
   overrideInitial: initial => {
@@ -150,11 +176,11 @@ Residence.defaultProps = {
   onError: (value, arr) => {
     return arr
   },
-  section: 'history',
-  subsection: 'residence',
   addressBooks: {},
   dispatch: () => {},
   validator: data => {
     return new HistoryResidenceValidator(data).isValid()
   }
 }
+
+export default connectHistorySection(Residence, sectionConfig)

--- a/src/components/Section/History/Residence/Residence.jsx
+++ b/src/components/Section/History/Residence/Residence.jsx
@@ -164,10 +164,9 @@ export class Residence extends Subsection {
 
 Residence.defaultProps = {
   List: Accordion.defaultList,
-  scrollIntoView: false,
   scrollToTop: '',
   defaultState: true,
-  realtime: true,
+  realtime: false,
   required: false,
   sort: null,
   totalYears: 10,

--- a/src/components/Section/History/Residence/Residence.jsx
+++ b/src/components/Section/History/Residence/Residence.jsx
@@ -65,10 +65,12 @@ export class Residence extends Subsection {
   }
 
   customResidenceByline(item, index, initial) {
+    const overrideInitial = this.props.overrideInitial ? false : initial
+
     return byline(
       item,
       index,
-      this.props.overrideInitial(initial),
+      overrideInitial,
       'history.residence.collection.summary.incomplete',
       this.props.required,
       item => {
@@ -168,9 +170,7 @@ Residence.defaultProps = {
   required: false,
   sort: null,
   totalYears: 10,
-  overrideInitial: initial => {
-    return initial
-  },
+  overrideInitial: false,
   caption: null,
   onUpdate: () => {},
   onError: (value, arr) => {

--- a/src/components/Section/History/Residence/Residence.jsx
+++ b/src/components/Section/History/Residence/Residence.jsx
@@ -9,10 +9,11 @@ import {
 import Subsection from '@components/Section/shared/Subsection'
 import connectHistorySection from '../HistoryConnector'
 
-import { Accordion } from '../../../Form'
-import { newGuid } from '../../../Form/ValidationElement'
-import { openState } from '../../../Form/Accordion/Accordion'
-import { today, daysAgo } from '../dateranges'
+import { Accordion } from '@components/Form'
+import { newGuid } from '@components/Form/ValidationElement'
+import { openState } from '@components/Form/Accordion/Accordion'
+import { today, daysAgo } from '@components/Section/History/dateranges'
+
 import { InjectGaps, ResidenceCustomSummary } from '../summaries'
 import ResidenceItem from './ResidenceItem'
 import { Gap } from '../Gap'

--- a/src/components/Section/History/Residence/Residence.jsx
+++ b/src/components/Section/History/Residence/Residence.jsx
@@ -1,24 +1,24 @@
 import React from 'react'
-import { i18n } from '@config'
+import { i18n } from 'config'
+import { HISTORY, HISTORY_RESIDENCE } from 'config/formSections/history'
 
 import {
   HistoryResidenceValidator,
-  ResidenceValidator
-} from '@validators'
+  ResidenceValidator,
+} from 'validators'
 
-import Subsection from '@components/Section/shared/Subsection'
+import Subsection from 'components/Section/shared/Subsection'
+
+import { Accordion } from 'components/Form'
+import { newGuid } from 'components/Form/ValidationElement'
+import { openState } from 'components/Form/Accordion/Accordion'
+import { today, daysAgo } from 'components/Section/History/dateranges'
+
 import connectHistorySection from '../HistoryConnector'
-
-import { Accordion } from '@components/Form'
-import { newGuid } from '@components/Form/ValidationElement'
-import { openState } from '@components/Form/Accordion/Accordion'
-import { today, daysAgo } from '@components/Section/History/dateranges'
 
 import { InjectGaps, ResidenceCustomSummary } from '../summaries'
 import ResidenceItem from './ResidenceItem'
 import { Gap } from '../Gap'
-
-import { HISTORY, HISTORY_RESIDENCE } from '@config/formSections/history'
 
 const sectionConfig = {
   section: HISTORY.name,
@@ -32,13 +32,16 @@ const byline = (item, index, initial, translation, required, validator) => {
     // If item is required and not currently opened and is not valid, show message
     case required && !item.open && !validator(item.Item):
     case !item.open && !initial && item.Item && !validator(item.Item):
-      return (<div className={`byline ${openState(item, initial)} fade in`.trim()}>
-        <div className="usa-alert usa-alert-error" role="alert">
-          <div className="usa-alert-body">
-            <h5 className="usa-alert-heading">{i18n.m(translation)}</h5>
+      return (
+        <div className={`byline ${openState(item, initial)} fade in`.trim()}>
+          <div className="usa-alert usa-alert-error" role="alert">
+            <div className="usa-alert-body">
+              <h5 className="usa-alert-heading">{i18n.m(translation)}</h5>
+            </div>
           </div>
         </div>
-      </div>)
+      )
+
     default:
       return null
   }
@@ -48,24 +51,21 @@ export class Residence extends Subsection {
   constructor(props) {
     super(props)
 
-    const { section, subsection, store, storeKey } = sectionConfig
+    const {
+      section, subsection, store, storeKey,
+    } = sectionConfig
 
     this.section = section
     this.subsection = subsection
     this.store = store
     this.storeKey = storeKey
-
-    this.customResidenceByline = this.customResidenceByline.bind(this)
-    this.customResidenceDetails = this.customResidenceDetails.bind(this)
-    this.fillGap = this.fillGap.bind(this)
-    this.inject = this.inject.bind(this)
   }
 
   handleUpdate = (values) => {
     this.props.onUpdate('Residence', { List: values })
   }
 
-  customResidenceByline(item, index, initial) {
+  customResidenceByline = (item, index, initial) => {
     const overrideInitial = this.props.overrideInitial ? false : initial
 
     return byline(
@@ -74,13 +74,11 @@ export class Residence extends Subsection {
       overrideInitial,
       'history.residence.collection.summary.incomplete',
       this.props.required,
-      item => {
-        return new ResidenceValidator(item, null).isValid()
-      }
+      i => new ResidenceValidator(i, null).isValid(),
     )
   }
 
-  customResidenceDetails(item, index, initial, callback) {
+  customResidenceDetails = (item, index, initial, callback) => {
     if (item.type === 'Gap') {
       const dates = (item.Item || {}).Dates || {}
       return (
@@ -90,7 +88,7 @@ export class Residence extends Subsection {
           btnText={i18n.t('history.residence.gap.btnText')}
           first={index === 0}
           dates={dates}
-          onClick={this.fillGap.bind(this, dates)}
+          onClick={() => this.fillGap(dates)}
         />
       )
     }
@@ -98,8 +96,9 @@ export class Residence extends Subsection {
     return callback()
   }
 
-  fillGap(dates) {
-    let items = [...this.props.List.items]
+  fillGap = () => {
+    const items = [...this.props.List.items]
+
     items.push({
       uuid: newGuid(),
       open: true,
@@ -108,28 +107,27 @@ export class Residence extends Subsection {
         Dates: {
           name: 'Dates',
           present: false,
-          receiveProps: true
-        }
-      }
+          receiveProps: true,
+        },
+      },
     })
 
     this.handleUpdate({
-      items: InjectGaps(items, daysAgo(365 * this.props.totalYears)).sort(
-        this.sort
-      ).filter(item => !item.type || (item.type && item.type !== 'Gap')),
-      branch: {}
+      items: InjectGaps(items, daysAgo(365 * this.props.totalYears))
+        .sort(this.sort)
+        .filter(item => !item.type || (item.type && item.type !== 'Gap')),
+      branch: {},
     })
   }
 
-  inject(items) {
-    return InjectGaps(items, daysAgo(today, 365 * this.props.totalYears))
-  }
+  inject = items => InjectGaps(items, daysAgo(today, 365 * this.props.totalYears))
 
   render() {
     return (
       <div
         className="section-content residence"
-        {...super.dataAttributes()}>
+        {...super.dataAttributes()}
+      >
         <Accordion
           scrollToTop={this.props.scrollToTop}
           defaultState={this.props.defaultState}
@@ -147,7 +145,8 @@ export class Residence extends Subsection {
           appendTitle={i18n.t('history.residence.collection.appendTitle')}
           appendLabel={i18n.t('history.residence.collection.append')}
           required={this.props.required}
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <ResidenceItem
             bind
             name="Item"
@@ -173,14 +172,10 @@ Residence.defaultProps = {
   overrideInitial: false,
   caption: null,
   onUpdate: () => {},
-  onError: (value, arr) => {
-    return arr
-  },
+  onError: (value, arr) => arr,
   addressBooks: {},
   dispatch: () => {},
-  validator: data => {
-    return new HistoryResidenceValidator(data).isValid()
-  }
+  validator: data => new HistoryResidenceValidator(data).isValid(),
 }
 
 export default connectHistorySection(Residence, sectionConfig)

--- a/src/components/Section/History/Residence/Residence.test.jsx
+++ b/src/components/Section/History/Residence/Residence.test.jsx
@@ -15,19 +15,19 @@ describe('The residence section', () => {
                 from: {
                   day: '1',
                   month: '1',
-                  year: '2014'
+                  year: '2014',
                 },
                 to: {
                   day: '1',
                   month: '1',
-                  year: '2018'
-                }
-              }
-            }
-          }
-        ]
+                  year: '2018',
+                },
+              },
+            },
+          },
+        ],
       },
-      onUpdate
+      onUpdate,
     }
     const component = shallow(<Residence {...expected} />)
     expect(component).toBeDefined()

--- a/src/components/Section/History/Residence/Residence.test.jsx
+++ b/src/components/Section/History/Residence/Residence.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import Residence from './Residence'
+import { Residence } from './Residence'
 
 describe('The residence section', () => {
   it('can trigger updates', () => {

--- a/src/components/Section/History/Residence/ResidenceSummaryProgress.jsx
+++ b/src/components/Section/History/Residence/ResidenceSummaryProgress.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+import { i18n } from '@config'
+
+import SummaryProgress from '@components/Section/History/SummaryProgress'
+import { totalYears } from '@components/Section/History/History'
+
+import { Svg } from '@components/Form'
+import { ResidenceValidator } from '@validators'
+
+const excludeGaps = (items) => {
+  return items.filter(
+    item => !item.type || (item.type && item.type !== 'Gap')
+  )
+}
+
+const dateRangeList = (items) => {
+  const dates = []
+
+  for (const i of excludeGaps(items)) {
+    if (!i.Item) { continue }
+
+    if (new ResidenceValidator(i.Item).isValid()) {
+      dates.push(i.Item.Dates)
+    }
+  }
+
+  return dates
+}
+
+const ResidenceSummaryProgress = (props) => {
+  const { Residence, Birthdate } = props
+
+  let residenceDates = []
+  if (Residence && Residence.List && Residence.List.items) {
+    residenceDates = Residence.List.items
+  }
+
+  return (
+    <SummaryProgress
+      className="residence"
+      List={dateRangeList.bind(this, residenceDates)}
+      title={i18n.t('history.residence.summary.title')}
+      unit={i18n.t('history.residence.summary.unit')}
+      total={totalYears(Birthdate)}>
+        <div className="summary-icon">
+          <Svg
+            src="/img/residence-house.svg"
+            alt={i18n.t('history.residence.summary.svgAlt')} />
+        </div>
+      </SummaryProgress>
+  )
+}
+
+export default ResidenceSummaryProgress

--- a/src/components/Section/History/Residence/ResidenceSummaryProgress.jsx
+++ b/src/components/Section/History/Residence/ResidenceSummaryProgress.jsx
@@ -3,16 +3,10 @@ import React from 'react'
 import { i18n } from '@config'
 
 import SummaryProgress from '@components/Section/History/SummaryProgress'
-import { totalYears } from '@components/Section/History/History'
+import { totalYears, excludeGaps } from '@components/Section/History/helpers'
 
 import { Svg } from '@components/Form'
 import { ResidenceValidator } from '@validators'
-
-const excludeGaps = (items) => {
-  return items.filter(
-    item => !item.type || (item.type && item.type !== 'Gap')
-  )
-}
 
 const dateRangeList = (items) => {
   const dates = []

--- a/src/components/Section/History/Residence/ResidenceSummaryProgress.jsx
+++ b/src/components/Section/History/Residence/ResidenceSummaryProgress.jsx
@@ -1,23 +1,24 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
-import { i18n } from '@config'
+import { i18n } from 'config'
 
-import SummaryProgress from '@components/Section/History/SummaryProgress'
-import { totalYears, excludeGaps } from '@components/Section/History/helpers'
+import SummaryProgress from 'components/Section/History/SummaryProgress'
+import { totalYears } from 'components/Section/History/helpers'
 
-import { Svg } from '@components/Form'
-import { ResidenceValidator } from '@validators'
+import { Svg } from 'components/Form'
+import { ResidenceValidator } from 'validators'
 
 const dateRangeList = (items) => {
   const dates = []
 
-  for (const i of excludeGaps(items)) {
-    if (!i.Item) { continue }
+  items.forEach((i) => {
+    if (!i.Item) { return }
 
     if (new ResidenceValidator(i.Item).isValid()) {
       dates.push(i.Item.Dates)
     }
-  }
+  })
 
   return dates
 }
@@ -30,20 +31,35 @@ const ResidenceSummaryProgress = (props) => {
     residenceDates = Residence.List.items
   }
 
+  const getResidenceDates = () => dateRangeList(residenceDates)
+
   return (
     <SummaryProgress
       className="residence"
-      List={dateRangeList.bind(this, residenceDates)}
+      List={getResidenceDates}
       title={i18n.t('history.residence.summary.title')}
       unit={i18n.t('history.residence.summary.unit')}
-      total={totalYears(Birthdate)}>
-        <div className="summary-icon">
-          <Svg
-            src="/img/residence-house.svg"
-            alt={i18n.t('history.residence.summary.svgAlt')} />
-        </div>
-      </SummaryProgress>
+      total={totalYears(Birthdate)}
+    >
+      <div className="summary-icon">
+        <Svg
+          src="/img/residence-house.svg"
+          alt={i18n.t('history.residence.summary.svgAlt')}
+        />
+      </div>
+    </SummaryProgress>
   )
+}
+
+/* eslint react/forbid-prop-types: 0 */
+ResidenceSummaryProgress.propTypes = {
+  Residence: PropTypes.object,
+  Birthdate: PropTypes.any,
+}
+
+ResidenceSummaryProgress.defaultProps = {
+  Residence: undefined,
+  Birthdate: undefined,
 }
 
 export default ResidenceSummaryProgress

--- a/src/components/Section/History/Residence/ResidenceWrapper.jsx
+++ b/src/components/Section/History/Residence/ResidenceWrapper.jsx
@@ -53,6 +53,7 @@ class ResidenceWrapper extends React.Component {
           Birthdate={Birthdate} />
 
         <Residence
+          realtime={true}
           scrollToTop="scrollToHistory" />
 
         <Show when={residenceHasGaps}>

--- a/src/components/Section/History/Residence/ResidenceWrapper.jsx
+++ b/src/components/Section/History/Residence/ResidenceWrapper.jsx
@@ -7,8 +7,7 @@ import { Field, Show } from '@components/Form'
 import Residence from './Residence'
 import ResidenceSummaryProgress from './ResidenceSummaryProgress'
 
-import { today, daysAgo, gaps } from '@components/Section/History/dateranges'
-import { totalYears } from '@components/Section/History/History'
+import { sectionHasGaps } from '@components/Section/History/helpers'
 
 import connectHistorySection from '../HistoryConnector'
 import { HISTORY, HISTORY_RESIDENCE } from '@config/formSections/history'
@@ -16,24 +15,6 @@ import { HISTORY, HISTORY_RESIDENCE } from '@config/formSections/history'
 const sectionConfig = {
   section: HISTORY.name,
   subsection: HISTORY_RESIDENCE.name,
-}
-
-// TODO totalYears has to change based on formType
-
-// TODO - move this to a helper file
-const sectionHasGaps = (items = []) => {
-  if (!items || !items.length) return true
-
-  const ranges = items
-    .filter(i => i.Item && i.Item.Dates)
-    .map(i => i.Item.Dates)
-
-  if (!ranges.length) return true
-
-  const start = daysAgo(today, 365 * totalYears())
-  const holes = gaps(ranges, start).length
-
-  return holes > 0
 }
 
 class ResidenceWrapper extends React.Component {

--- a/src/components/Section/History/Residence/ResidenceWrapper.jsx
+++ b/src/components/Section/History/Residence/ResidenceWrapper.jsx
@@ -1,82 +1,90 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
-import { i18n } from '@config'
+import { i18n } from 'config'
+import { HISTORY, HISTORY_RESIDENCE } from 'config/formSections/history'
 
-import { Field, Show } from '@components/Form'
+import { Field, Show } from 'components/Form'
+import { sectionHasGaps } from 'components/Section/History/helpers'
 
-import Residence from './Residence'
+import ConnectedResidence from './Residence'
 import ResidenceSummaryProgress from './ResidenceSummaryProgress'
 
-import { sectionHasGaps } from '@components/Section/History/helpers'
-
 import connectHistorySection from '../HistoryConnector'
-import { HISTORY, HISTORY_RESIDENCE } from '@config/formSections/history'
 
 const sectionConfig = {
   section: HISTORY.name,
   subsection: HISTORY_RESIDENCE.name,
 }
 
-class ResidenceWrapper extends React.Component {
-  render () {
-    const { Birthdate } = this.props
+const ResidenceWrapper = (props) => {
+  const { Residence, Birthdate } = props
 
-    let residenceItems = []
-    if (this.props.Residence && this.props.Residence.List && this.props.Residence.List.items) {
-      residenceItems = this.props.Residence.List.items
-    }
-
-    const residenceHasGaps = sectionHasGaps(residenceItems)
-
-    return (
-      <div>
-        <h1 className="section-header">
-          {i18n.t('history.residence.title')}
-        </h1>
-
-        <Field
-          title={i18n.t('history.residence.info')}
-          titleSize="h3"
-          optional={true}
-          className="no-margin-bottom">
-           {i18n.m('history.residence.info2')}
-           {i18n.m('history.residence.info3a')}
-           {i18n.m('history.residence.info3b')}
-           {i18n.m('history.residence.info3c')}
-           {i18n.m('history.residence.info3d')}
-        </Field>
-
-        <span id="scrollToHistory" />
-
-        <ResidenceSummaryProgress
-          Residence={this.props.Residence}
-          Birthdate={Birthdate} />
-
-        <Residence
-          realtime={true}
-          scrollToTop="scrollToHistory" />
-
-        <Show when={residenceHasGaps}>
-          <div className="not-complete">
-            <hr className="section-divider" />
-
-            <Field
-              title={i18n.t('history.residence.heading.exiting')}
-              titleSize="h4"
-              optional={true}
-              className="no-margin-bottom">
-              {i18n.m('history.residence.para.exiting')}  
-            </Field>
-          </div>
-        </Show>
-      </div>
-    )
+  let residenceItems = []
+  if (Residence && Residence.List && Residence.List.items) {
+    residenceItems = Residence.List.items
   }
+
+  const residenceHasGaps = sectionHasGaps(residenceItems)
+
+  return (
+    <div>
+      <h1 className="section-header">
+        {i18n.t('history.residence.title')}
+      </h1>
+
+      <Field
+        title={i18n.t('history.residence.info')}
+        titleSize="h3"
+        optional
+        className="no-margin-bottom"
+      >
+        {i18n.m('history.residence.info2')}
+        {i18n.m('history.residence.info3a')}
+        {i18n.m('history.residence.info3b')}
+        {i18n.m('history.residence.info3c')}
+        {i18n.m('history.residence.info3d')}
+      </Field>
+
+      <span id="scrollToHistory" />
+
+      <ResidenceSummaryProgress
+        Residence={Residence}
+        Birthdate={Birthdate}
+      />
+
+      <ConnectedResidence
+        realtime
+        scrollToTop="scrollToHistory"
+      />
+
+      <Show when={residenceHasGaps}>
+        <div className="not-complete">
+          <hr className="section-divider" />
+
+          <Field
+            title={i18n.t('history.residence.heading.exiting')}
+            titleSize="h4"
+            optional
+            className="no-margin-bottom"
+          >
+            {i18n.m('history.residence.para.exiting')}
+          </Field>
+        </div>
+      </Show>
+    </div>
+  )
+}
+
+/* eslint react/forbid-prop-types: 0 */
+ResidenceWrapper.propTypes = {
+  Residence: PropTypes.object,
+  Birthdate: PropTypes.any,
 }
 
 ResidenceWrapper.defaultProps = {
-  Residence: {},
-  Birthdate: {},
+  Residence: undefined,
+  Birthdate: undefined,
 }
 
 export default connectHistorySection(ResidenceWrapper, sectionConfig)

--- a/src/components/Section/History/Residence/ResidenceWrapper.jsx
+++ b/src/components/Section/History/Residence/ResidenceWrapper.jsx
@@ -1,0 +1,100 @@
+import React from 'react'
+
+import { i18n } from '@config'
+
+import { Field, Show } from '@components/Form'
+
+import Residence from './Residence'
+import ResidenceSummaryProgress from './ResidenceSummaryProgress'
+
+import { today, daysAgo, gaps } from '@components/Section/History/dateranges'
+import { totalYears } from '@components/Section/History/History'
+
+import connectHistorySection from '../HistoryConnector'
+import { HISTORY, HISTORY_RESIDENCE } from '@config/formSections/history'
+
+const sectionConfig = {
+  section: HISTORY.name,
+  subsection: HISTORY_RESIDENCE.name,
+}
+
+// TODO totalYears has to change based on formType
+
+// TODO - move this to a helper file
+const sectionHasGaps = (items = []) => {
+  if (!items || !items.length) return true
+
+  const ranges = items
+    .filter(i => i.Item && i.Item.Dates)
+    .map(i => i.Item.Dates)
+
+  if (!ranges.length) return true
+
+  const start = daysAgo(today, 365 * totalYears())
+  const holes = gaps(ranges, start).length
+
+  return holes > 0
+}
+
+class ResidenceWrapper extends React.Component {
+  render () {
+    const { Birthdate } = this.props
+
+    let residenceItems = []
+    if (this.props.Residence && this.props.Residence.List && this.props.Residence.List.items) {
+      residenceItems = this.props.Residence.List.items
+    }
+
+    const residenceHasGaps = sectionHasGaps(residenceItems)
+
+    return (
+      <div>
+        <h1 className="section-header">
+          {i18n.t('history.residence.title')}
+        </h1>
+
+        <Field
+          title={i18n.t('history.residence.info')}
+          titleSize="h3"
+          optional={true}
+          className="no-margin-bottom">
+           {i18n.m('history.residence.info2')}
+           {i18n.m('history.residence.info3a')}
+           {i18n.m('history.residence.info3b')}
+           {i18n.m('history.residence.info3c')}
+           {i18n.m('history.residence.info3d')}
+        </Field>
+
+        <span id="scrollToHistory" />
+
+        <ResidenceSummaryProgress
+          Residence={this.props.Residence}
+          Birthdate={Birthdate} />
+
+        <Residence
+          scrollToTop="scrollToHistory" />
+
+        <Show when={residenceHasGaps}>
+          <div className="not-complete">
+            <hr className="section-divider" />
+
+            <Field
+              title={i18n.t('history.residence.heading.exiting')}
+              titleSize="h4"
+              optional={true}
+              className="no-margin-bottom">
+              {i18n.m('history.residence.para.exiting')}  
+            </Field>
+          </div>
+        </Show>
+      </div>
+    )
+  }
+}
+
+ResidenceWrapper.defaultProps = {
+  Residence: {},
+  Birthdate: {},
+}
+
+export default connectHistorySection(ResidenceWrapper, sectionConfig)

--- a/src/components/Section/History/Review.jsx
+++ b/src/components/Section/History/Review.jsx
@@ -6,8 +6,9 @@ import connectHistorySection from './HistoryConnector'
 import { HISTORY, HISTORY_REVIEW } from '@config/formSections/history'
 
 import ResidenceSummaryProgress from './Residence/ResidenceSummaryProgress'
-
+import EmploymentSummaryProgress from './Employment/EmploymentSummaryProgress'
 import Residence from './Residence'
+import Employment from './Employment'
 
 const sectionConfig = {
   section: HISTORY.name,
@@ -33,16 +34,24 @@ const Review = (props) => {
       <ResidenceSummaryProgress
         Residence={props.Residence}
         Birthdate={Birthdate} />
-      {/* TODO employment summary progress */}
+
+      <EmploymentSummaryProgress
+        Employment={props.Employment}
+        Birthdate={Birthdate} />
+
       {/* TODO education summary progress */}
 
-      <hr className="section-divider" />
-      
+      <hr className="section-divider" />      
       <h1 className="section-header">
         {i18n.t('history.residence.collection.caption')}
       </h1>
-
       <Residence {...subsectionProps} />
+
+      <hr className="section-divider" />      
+      <h1 className="section-header">
+        {i18n.t('history.employment.default.collection.caption')}
+      </h1>
+      <Employment {...subsectionProps} realtime={true} />
     </div>
   )
 }

--- a/src/components/Section/History/Review.jsx
+++ b/src/components/Section/History/Review.jsx
@@ -2,13 +2,17 @@ import React from 'react'
 
 import { i18n } from '@config'
 
+import { Show } from '@components/Form'
+
 import connectHistorySection from './HistoryConnector'
 import { HISTORY, HISTORY_REVIEW } from '@config/formSections/history'
 
 import ResidenceSummaryProgress from './Residence/ResidenceSummaryProgress'
 import EmploymentSummaryProgress from './Employment/EmploymentSummaryProgress'
+import EducationSummaryProgress from './Education/EducationSummaryProgress'
 import Residence from './Residence'
 import Employment from './Employment'
+import EducationWrapper from './Education/EducationWrapper'
 
 const sectionConfig = {
   section: HISTORY.name,
@@ -29,6 +33,9 @@ const Review = (props) => {
     <hr className="section-divider" />
   )
 
+  const hasAttendedSchool = props.Education.HasAttended.value === 'Yes'
+  const hasDegree = props.Education.HasDegree10.value === 'Yes'
+
   return (
     <div>
       <ResidenceSummaryProgress
@@ -38,20 +45,30 @@ const Review = (props) => {
       <EmploymentSummaryProgress
         Employment={props.Employment}
         Birthdate={Birthdate} />
+      
+      <Show when={hasAttendedSchool || hasDegree}>
+        <EducationSummaryProgress
+          Education={props.Education}
+          Birthdate={Birthdate} />
+      </Show>
 
-      {/* TODO education summary progress */}
-
-      <hr className="section-divider" />      
+      <hr className="section-divider" />
       <h1 className="section-header">
         {i18n.t('history.residence.collection.caption')}
       </h1>
       <Residence {...subsectionProps} />
 
-      <hr className="section-divider" />      
+      <hr className="section-divider" />
       <h1 className="section-header">
         {i18n.t('history.employment.default.collection.caption')}
       </h1>
       <Employment {...subsectionProps} realtime={true} />
+
+      <hr className="section-divider" />
+      <h1 className="section-header">
+        {i18n.t('history.education.collection.caption')}
+      </h1>
+      <EducationWrapper inReview={true} />
     </div>
   )
 }

--- a/src/components/Section/History/Review.jsx
+++ b/src/components/Section/History/Review.jsx
@@ -1,17 +1,17 @@
 import React from 'react'
 
-import { i18n } from '@config'
+import { i18n } from 'config'
+import { HISTORY, HISTORY_REVIEW } from 'config/formSections/history'
 
-import { Show } from '@components/Form'
+import { Show } from 'components/Form'
 
 import connectHistorySection from './HistoryConnector'
-import { HISTORY, HISTORY_REVIEW } from '@config/formSections/history'
 
 import ResidenceSummaryProgress from './Residence/ResidenceSummaryProgress'
 import EmploymentSummaryProgress from './Employment/EmploymentSummaryProgress'
 import EducationSummaryProgress from './Education/EducationSummaryProgress'
-import Residence from './Residence'
-import Employment from './Employment'
+import ConnectedResidence from './Residence'
+import ConnectedEmployment from './Employment'
 import EducationWrapper from './Education/EducationWrapper'
 import FederalWrapper from './Federal/FederalWrapper'
 
@@ -22,7 +22,9 @@ const sectionConfig = {
 }
 
 const Review = (props) => {
-  const { Birthdate } = props
+  const {
+    Birthdate, Education, Residence, Employment,
+  } = props
 
   const subsectionProps = {
     required: true,
@@ -30,49 +32,48 @@ const Review = (props) => {
     overrideInitial: true,
   }
 
-  const sectionDivider = (
-    <hr className="section-divider" />
-  )
-
-  const hasAttendedSchool = props.Education.HasAttended.value === 'Yes'
-  const hasDegree = props.Education.HasDegree10.value === 'Yes'
+  const hasAttendedSchool = Education.HasAttended.value === 'Yes'
+  const hasDegree = Education.HasDegree10.value === 'Yes'
 
   return (
     <div>
       <ResidenceSummaryProgress
-        Residence={props.Residence}
-        Birthdate={Birthdate} />
+        Residence={Residence}
+        Birthdate={Birthdate}
+      />
 
       <EmploymentSummaryProgress
-        Employment={props.Employment}
-        Birthdate={Birthdate} />
-      
+        Employment={Employment}
+        Birthdate={Birthdate}
+      />
+
       <Show when={hasAttendedSchool || hasDegree}>
         <EducationSummaryProgress
-          Education={props.Education}
-          Birthdate={Birthdate} />
+          Education={Education}
+          Birthdate={Birthdate}
+        />
       </Show>
 
       <hr className="section-divider" />
       <h1 className="section-header">
         {i18n.t('history.residence.collection.caption')}
       </h1>
-      <Residence {...subsectionProps} realtime={true} />
+      <ConnectedResidence {...subsectionProps} realtime />
 
       <hr className="section-divider" />
       <h1 className="section-header">
         {i18n.t('history.employment.default.collection.caption')}
       </h1>
-      <Employment {...subsectionProps} realtime={true} />
+      <ConnectedEmployment {...subsectionProps} realtime />
 
       <hr className="section-divider" />
       <h1 className="section-header">
         {i18n.t('history.education.collection.caption')}
       </h1>
-      <EducationWrapper inReview={true} />
+      <EducationWrapper inReview />
 
       <hr className="section-divider" />
-      <FederalWrapper inReview={true} />
+      <FederalWrapper inReview />
     </div>
   )
 }

--- a/src/components/Section/History/Review.jsx
+++ b/src/components/Section/History/Review.jsx
@@ -13,6 +13,7 @@ import EducationSummaryProgress from './Education/EducationSummaryProgress'
 import Residence from './Residence'
 import Employment from './Employment'
 import EducationWrapper from './Education/EducationWrapper'
+import FederalWrapper from './Federal/FederalWrapper'
 
 const sectionConfig = {
   section: HISTORY.name,
@@ -69,6 +70,9 @@ const Review = (props) => {
         {i18n.t('history.education.collection.caption')}
       </h1>
       <EducationWrapper inReview={true} />
+
+      <hr className="section-divider" />
+      <FederalWrapper inReview={true} />
     </div>
   )
 }

--- a/src/components/Section/History/Review.jsx
+++ b/src/components/Section/History/Review.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+
+import { i18n } from '@config'
+
+import connectHistorySection from './HistoryConnector'
+import { HISTORY, HISTORY_REVIEW } from '@config/formSections/history'
+
+import ResidenceSummaryProgress from './Residence/ResidenceSummaryProgress'
+
+import Residence from './Residence'
+
+const sectionConfig = {
+  section: HISTORY.name,
+  store: HISTORY.store,
+  subsection: HISTORY_REVIEW.name,
+}
+
+const Review = (props) => {
+  const { Birthdate } = props
+
+  const subsectionProps = {
+    required: true,
+    scrollIntoView: false,
+    inReview: true,
+  }
+
+  const sectionDivider = (
+    <hr className="section-divider" />
+  )
+
+  return (
+    <div>
+      <ResidenceSummaryProgress
+        Residence={props.Residence}
+        Birthdate={Birthdate} />
+      {/* TODO employment summary progress */}
+      {/* TODO education summary progress */}
+
+      <hr className="section-divider" />
+      
+      <h1 className="section-header">
+        {i18n.t('history.residence.collection.caption')}
+      </h1>
+
+      <Residence {...subsectionProps} />
+    </div>
+  )
+}
+
+export default connectHistorySection(Review, sectionConfig)

--- a/src/components/Section/History/Review.jsx
+++ b/src/components/Section/History/Review.jsx
@@ -21,7 +21,7 @@ const Review = (props) => {
   const subsectionProps = {
     required: true,
     scrollIntoView: false,
-    inReview: true,
+    overrideInitial: true,
   }
 
   const sectionDivider = (

--- a/src/components/Section/History/Review.jsx
+++ b/src/components/Section/History/Review.jsx
@@ -57,7 +57,7 @@ const Review = (props) => {
       <h1 className="section-header">
         {i18n.t('history.residence.collection.caption')}
       </h1>
-      <Residence {...subsectionProps} />
+      <Residence {...subsectionProps} realtime={true} />
 
       <hr className="section-divider" />
       <h1 className="section-header">

--- a/src/components/Section/History/helpers.js
+++ b/src/components/Section/History/helpers.js
@@ -1,17 +1,39 @@
 import {
-  utc,
   today,
   daysAgo,
   daysBetween,
   extractDate,
   gaps,
-} from '@components/Section/History/dateranges'
+} from 'components/Section/History/dateranges'
 
-export const excludeGaps = (items) => {
-  return items.filter(
-    item => !item.type || (item.type && item.type !== 'Gap')
-  )
+/**
+ * Figure the total amount of years to collect for the timeline
+ */
+export const totalYears = (birthdate) => {
+  let total = 10
+  if (!birthdate) {
+    return total
+  }
+
+  const eighteen = daysAgo(birthdate, 365 * -18)
+  total = Math.ceil(daysBetween(eighteen, today) / 365)
+
+  // A maximum of 10 years is required
+  if (total > 10) {
+    total = 10
+  }
+
+  // A minimum of two years is required
+  if (total < 2) {
+    total = 2
+  }
+
+  return total
 }
+
+export const excludeGaps = items => items.filter(
+  item => !item.type || (item.type && item.type !== 'Gap'),
+)
 
 export const sectionHasGaps = (items = []) => {
   if (!items || !items.length) return true
@@ -34,47 +56,26 @@ export const sectionHasGaps = (items = []) => {
  */
 export const sort = (a, b) => {
   // Helper to find the date value or default it to 0
-  const getOptionalDate = obj => {
-    return (((obj || {}).Item || {}).Dates || {}).to
-  }
+  const getOptionalDate = obj => (((obj || {}).Item || {}).Dates || {}).to
 
   const first = extractDate(getOptionalDate(a)) || 0
   const second = extractDate(getOptionalDate(b)) || 0
 
   if (a.type === 'Gap') {
     return 1
-  } else if (b.type === 'Gap') {
+  }
+
+  if (b.type === 'Gap') {
     return -1
-  } else if (first < second) {
+  }
+
+  if (first < second) {
     return 1
-  } else if (first > second) {
+  }
+
+  if (first > second) {
     return -1
   }
 
   return 0
-}
-
-/**
- * Figure the total amount of years to collect for the timeline
- */
-export const totalYears = birthdate => {
-  let total = 10
-  if (!birthdate) {
-    return total
-  }
-
-  const eighteen = daysAgo(birthdate, 365 * -18)
-  total = Math.ceil(daysBetween(eighteen, today) / 365)
-
-  // A maximum of 10 years is required
-  if (total > 10) {
-    total = 10
-  }
-
-  // A minimum of two years is required
-  if (total < 2) {
-    total = 2
-  }
-
-  return total
 }

--- a/src/components/Section/History/helpers.js
+++ b/src/components/Section/History/helpers.js
@@ -1,0 +1,58 @@
+import {
+  utc,
+  today,
+  daysAgo,
+  daysBetween,
+  extractDate
+} from '@components/Section/History/dateranges'
+
+/**
+ * Default sorting of history objects. This assumes that all objects contain a `Dates` property
+ * with date range values.
+ */
+export const sort = (a, b) => {
+  // Helper to find the date value or default it to 0
+  const getOptionalDate = obj => {
+    return (((obj || {}).Item || {}).Dates || {}).to
+  }
+
+  const first = extractDate(getOptionalDate(a)) || 0
+  const second = extractDate(getOptionalDate(b)) || 0
+
+  if (a.type === 'Gap') {
+    return 1
+  } else if (b.type === 'Gap') {
+    return -1
+  } else if (first < second) {
+    return 1
+  } else if (first > second) {
+    return -1
+  }
+
+  return 0
+}
+
+/**
+ * Figure the total amount of years to collect for the timeline
+ */
+export const totalYears = birthdate => {
+  let total = 10
+  if (!birthdate) {
+    return total
+  }
+
+  const eighteen = daysAgo(birthdate, 365 * -18)
+  total = Math.ceil(daysBetween(eighteen, today) / 365)
+
+  // A maximum of 10 years is required
+  if (total > 10) {
+    total = 10
+  }
+
+  // A minimum of two years is required
+  if (total < 2) {
+    total = 2
+  }
+
+  return total
+}

--- a/src/components/Section/History/helpers.js
+++ b/src/components/Section/History/helpers.js
@@ -3,8 +3,30 @@ import {
   today,
   daysAgo,
   daysBetween,
-  extractDate
+  extractDate,
+  gaps,
 } from '@components/Section/History/dateranges'
+
+export const excludeGaps = (items) => {
+  return items.filter(
+    item => !item.type || (item.type && item.type !== 'Gap')
+  )
+}
+
+export const sectionHasGaps = (items = []) => {
+  if (!items || !items.length) return true
+
+  const ranges = items
+    .filter(i => i.Item && i.Item.Dates)
+    .map(i => i.Item.Dates)
+
+  if (!ranges.length) return true
+
+  const start = daysAgo(today, 365 * totalYears())
+  const holes = gaps(ranges, start).length
+
+  return holes > 0
+}
 
 /**
  * Default sorting of history objects. This assumes that all objects contain a `Dates` property

--- a/src/components/Section/Identification/IdentificationConnector.jsx
+++ b/src/components/Section/Identification/IdentificationConnector.jsx
@@ -5,46 +5,49 @@ import { connect } from 'react-redux'
 import {
   updateApplication,
   reportErrors,
-} from '@actions/ApplicationActions'
+} from 'actions/ApplicationActions'
 
-const connectIdentificationSection = (Component, { section, subsection, store, storeKey }) => {
+const connectIdentificationSection = (Component, {
+  section, subsection, store, storeKey,
+}) => {
   class ConnectedIdentificationSection extends React.Component {
     constructor(props) {
       super(props)
-  
+
       this.section = section
       this.subsection = subsection
       this.store = store
-
-      this.handleError = this.handleError.bind(this)
-      this.handleUpdate = this.handleUpdate.bind(this)
     }
 
-    handleError(value, arr) {
+    handleError = (value, arr) => {
+      const { dispatch } = this.props
       const action = reportErrors(this.section, this.subsection, arr)
-      this.props.dispatch(action)
+      dispatch(action)
       return arr
     }
-  
-    handleUpdate(field, values) {
-      this.props.dispatch(updateApplication(this.store, field, values))
+
+    handleUpdate = (field, values) => {
+      const { dispatch } = this.props
+      dispatch(updateApplication(this.store, field, values))
     }
 
-    render () {
+    render() {
       return (
         <Component
           onUpdate={this.handleUpdate}
           onError={this.handleError}
-          {...this.props} />
+          {...this.props}
+        />
       )
     }
   }
 
   ConnectedIdentificationSection.propTypes = {
-    Comments: PropTypes.object,
-    update: PropTypes.func,
-    validator: PropTypes.func,
     dispatch: PropTypes.func, // Passed in via connect (below)
+  }
+
+  ConnectedIdentificationSection.defaultProps = {
+    dispatch: () => {},
   }
 
   const mapStateToProps = (state) => {
@@ -86,7 +89,7 @@ const connectIdentificationSection = (Component, { section, subsection, store, s
           Contacts: identification.Contacts || {},
           Physical: identification.Physical || {},
           Errors: errors.identification || [],
-          Completed: completed.identification || []
+          Completed: completed.identification || [],
         }
     }
   }

--- a/src/components/Section/Identification/IdentificationConnector.jsx
+++ b/src/components/Section/Identification/IdentificationConnector.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux'
 import {
   updateApplication,
   reportErrors,
-} from '../../../actions/ApplicationActions'
+} from '@actions/ApplicationActions'
 
 const connectIdentificationSection = (Component, { section, subsection, store, storeKey }) => {
   class ConnectedIdentificationSection extends React.Component {

--- a/src/components/Section/Identification/Intro.jsx
+++ b/src/components/Section/Identification/Intro.jsx
@@ -1,18 +1,17 @@
 import React from 'react'
-import { i18n } from '@config'
-import { Field } from '@components/Form'
+import { i18n } from 'config'
+import { Field } from 'components/Form'
 
-const Intro = () => {
-  return (
-    <div>
-      <h1 className="section-header">{i18n.t('identification.intro.title')}</h1>
-      <Field
-        optional={true}
-        className="no-margin-bottom">
-        {i18n.m('identification.intro.body')}
-      </Field>
-    </div>
-  )
-}
+const Intro = () => (
+  <div>
+    <h1 className="section-header">{i18n.t('identification.intro.title')}</h1>
+    <Field
+      optional
+      className="no-margin-bottom"
+    >
+      {i18n.m('identification.intro.body')}
+    </Field>
+  </div>
+)
 
 export default Intro

--- a/src/components/Section/Package/Verify.jsx
+++ b/src/components/Section/Package/Verify.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { i18n } from '../../../config'
 import { SSN } from './helpers'
 import { Field } from '../../Form'
-import { sort } from '../History/History'
+import { sort } from '../History/helpers'
 import {
   NameSummary,
   DateSummary,

--- a/src/components/Section/Relationships/People/People.jsx
+++ b/src/components/Section/Relationships/People/People.jsx
@@ -14,7 +14,7 @@ import { Summary, DateSummary, NameSummary } from '../../../Summary'
 import { extractDate, today, daysAgo } from '../../History/dateranges'
 import { InjectGaps } from '../../History/summaries'
 import { Gap } from '../../History/Gap'
-import { sort } from '../../History/History'
+import { sort } from '../../History/helpers'
 
 export default class People extends SubsectionElement {
   constructor(props) {

--- a/src/components/Section/Section.jsx
+++ b/src/components/Section/Section.jsx
@@ -74,6 +74,7 @@ class Section extends React.Component {
       <Switch>
         {/* REFACTORED - These sections are rendered via <Route>s */}
         <Route path="/form/identification" component={Identification} />
+        <Route path="/form/history" component={History} />
 
         {/* TBD */}
         <Route path="/form/:section/:subsection" render={() => (
@@ -82,7 +83,6 @@ class Section extends React.Component {
 
         {/* Sections to refactor */}
         {/*
-          <Route path="/form/history" component={History} />
           <Route path="/form/relationships" component={Relationships} />
           <Route path="/form/citizenship" component={Citizenship} />
           <Route path="/form/military" component={Military} />

--- a/src/components/Section/Section.test.jsx
+++ b/src/components/Section/Section.test.jsx
@@ -2,35 +2,34 @@ import React from 'react'
 import configureMockStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
-import Section from './Section'
 import { mount } from 'enzyme'
+
+import Section from './Section'
 import { testSnapshot } from '../test-helpers'
 import navigation from '../../config/navigation'
 
 // give a fake GUID so the field IDs don't differ between snapshots
 // https://github.com/facebook/jest/issues/936#issuecomment-404246102
-jest.mock('../Form/ValidationElement/helpers', () =>
+jest.mock('../Form/ValidationElement/helpers', () => (
   Object.assign(require.requireActual('../Form/ValidationElement/helpers'), {
-    newGuid: jest.fn().mockReturnValue('MOCK-GUID')
+    newGuid: jest.fn().mockReturnValue('MOCK-GUID'),
   })
-)
+))
 
-const shouldSkip = (section, subsection) => {
-  return (
-    section.exclude ||
-    // these need special handling, which we will come back to
-    (section.url === 'foreign' && subsection.url === 'activities') ||
-    (section.url === 'substance' && subsection.url === 'drugs') ||
-    (section.url === 'substance' && subsection.url === 'alcohol') ||
-    (section.url === 'psychological' && subsection.url === 'review')
-  )
-}
+const shouldSkip = (section, subsection) => (
+  // these need special handling, which we will come back to
+  section.exclude
+    || (section.url === 'foreign' && subsection.url === 'activities')
+    || (section.url === 'substance' && subsection.url === 'drugs')
+    || (section.url === 'substance' && subsection.url === 'alcohol')
+    || (section.url === 'psychological' && subsection.url === 'review')
+)
 
 describe('The section component', () => {
   const mockStore = configureMockStore({
     authentication: {
-      formType: 'SF86'
-    }
+      formType: 'SF86',
+    },
   })
 
   it('is visible', () => {
@@ -42,8 +41,8 @@ describe('The section component', () => {
     expect(component.find('div').length > 0).toBe(true)
   })
 
-  navigation.forEach(section => {
-    section.subsections.forEach(subsection => {
+  navigation.forEach((section) => {
+    section.subsections.forEach((subsection) => {
       if (shouldSkip(section, subsection)) {
         return
       }
@@ -53,7 +52,7 @@ describe('The section component', () => {
           authentication: {
             authenticated: true,
             token: 'fake-token',
-            formType: 'SF86'
+            formType: 'SF86',
           },
           section: { section: section.url, subsection: subsection.url },
         })

--- a/src/components/Section/Section.test.jsx
+++ b/src/components/Section/Section.test.jsx
@@ -54,8 +54,10 @@ describe('The section component', () => {
             authenticated: true,
             token: 'fake-token',
             formType: 'SF86'
-          }
+          },
+          section: { section: section.url, subsection: subsection.url },
         })
+
         testSnapshot(
           <Provider store={store}>
             <MemoryRouter>

--- a/src/components/Section/__snapshots__/Section.test.jsx.snap
+++ b/src/components/Section/__snapshots__/Section.test.jsx.snap
@@ -8759,302 +8759,288 @@ exports[`The section component renders foreign.travel 1`] = `
 `;
 
 exports[`The section component renders history.education 1`] = `
-<div>
+<div
+  className="history"
+>
   <div
     className="section-view"
   >
     <div
-      className="view view-history"
+      className="view view-education"
     >
       <div>
-        <div
-          className="history"
+        <h1
+          className="section-header"
         >
-          <div>
-            <div
-              className="section-view"
+          Where you went to school
+        </h1>
+        <div
+          aria-label="List the places you went to school"
+          className="field   no-margin-bottom"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h3
+            className="title h3"
+          >
+            List the places you went to school
+          </h3>
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
             >
-              <div
-                className="view view-education"
+              <span
+                className="component"
               >
                 <div>
-                  <h1
-                    className="section-header"
-                  >
-                    Where you went to school
-                  </h1>
-                  <div
-                    aria-label="List the places you went to school"
-                    className="field   no-margin-bottom"
-                    data-uuid="field-MOCK-GUID"
-                  >
-                    <a
-                      aria-hidden="true"
-                      className="anchor"
-                      id="field-MOCK-GUID"
-                      name="field-MOCK-GUID"
-                    />
-                    <h3
-                      className="title h3"
-                    >
-                      List the places you went to school
-                    </h3>
-                    <span
-                      className="icon"
-                    />
-                    <div
-                      className="table expand"
-                    >
-                      <span
-                        aria-live="polite"
-                        className="messages help-messages"
-                      />
-                    </div>
-                    <div
-                      className="table expand"
-                    >
-                      <span
-                        aria-live="polite"
-                        className="messages error-messages"
-                        role="alert"
-                      />
-                    </div>
-                    <div
-                      className="table"
-                    >
-                      <span
-                        className="content"
-                      >
-                        <span
-                          className="component"
-                        >
-                          <div>
-                            <p>
-                              Do not list education before your 18th birthday, unless to provide a minimum of two years education history.
-                            </p>
-                          </div>
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="Have you attended any schools in the last 10 years?"
-                    className="field required  branch"
-                    data-uuid="field-MOCK-GUID"
-                  >
-                    <a
-                      aria-hidden="true"
-                      className="anchor"
-                      id="field-MOCK-GUID"
-                      name="field-MOCK-GUID"
-                    />
-                    <h4
-                      className="title h4"
-                    >
-                      Have you attended any schools in the last 10 years?
-                    </h4>
-                    <span
-                      className="icon"
-                    >
-                      <a
-                        aria-label="Show help for Have you attended any schools in the last 10 years?"
-                        className="toggle h4  adjust-for-buttons"
-                        href="javascript:;"
-                        onClick={[Function]}
-                        title="Show help for Have you attended any schools in the last 10 years?"
-                      >
-                        <svg
-                          alt="Scalable vector graphic"
-                          focusable="false"
-                          height="14.57px"
-                          tabIndex="-1"
-                          viewBox="0 0 14.57 14.57"
-                          width="14.57px"
-                        >
-                          <g>
-                            <path
-                              className="eapp-help-icon"
-                              d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
-                            />
-                          </g>
-                        </svg>
-                      </a>
-                    </span>
-                    <div
-                      className="table expand"
-                    >
-                      <span
-                        aria-live="polite"
-                        className="messages help-messages"
-                      />
-                    </div>
-                    <div
-                      className="table expand"
-                    >
-                      <span
-                        aria-live="polite"
-                        className="messages error-messages"
-                        role="alert"
-                      />
-                    </div>
-                    <div
-                      className="table"
-                    >
-                      <span
-                        className="content"
-                      >
-                        <span
-                          className="component shrink"
-                        >
-                          <div
-                            className="content"
-                          />
-                          <div
-                            className="blocks option-list branch"
-                          >
-                            <div
-                              className="yes block"
-                            >
-                              <input
-                                aria-label="Yes for null"
-                                checked={false}
-                                className="usa-input-success"
-                                disabled={false}
-                                id="branch_school-MOCK-GUID"
-                                name="branch_school-MOCK-GUID"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onKeyDown={[Function]}
-                                type="radio"
-                                value="Yes"
-                              />
-                              <label
-                                className=""
-                                htmlFor="branch_school-MOCK-GUID"
-                              >
-                                <span>
-                                  Yes
-                                </span>
-                              </label>
-                            </div>
-                            <div
-                              className="no block"
-                            >
-                              <input
-                                aria-label="No for null"
-                                checked={false}
-                                className="usa-input-success"
-                                disabled={false}
-                                id="branch_school-MOCK-GUID"
-                                name="branch_school-MOCK-GUID"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onKeyDown={[Function]}
-                                type="radio"
-                                value="No"
-                              />
-                              <label
-                                className=""
-                                htmlFor="branch_school-MOCK-GUID"
-                              >
-                                <span>
-                                  No
-                                </span>
-                              </label>
-                            </div>
-                          </div>
-                        </span>
-                      </span>
-                    </div>
-                  </div>
+                  <p>
+                    Do not list education before your 18th birthday, unless to provide a minimum of two years education history.
+                  </p>
                 </div>
+              </span>
+            </span>
+          </div>
+        </div>
+        <div
+          aria-label="Have you attended any schools in the last 10 years?"
+          className="field required  branch"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h4
+            className="title h4"
+          >
+            Have you attended any schools in the last 10 years?
+          </h4>
+          <span
+            className="icon"
+          >
+            <a
+              aria-label="Show help for Have you attended any schools in the last 10 years?"
+              className="toggle h4  adjust-for-buttons"
+              href="javascript:;"
+              onClick={[Function]}
+              title="Show help for Have you attended any schools in the last 10 years?"
+            >
+              <svg
+                alt="Scalable vector graphic"
+                focusable="false"
+                height="14.57px"
+                tabIndex="-1"
+                viewBox="0 0 14.57 14.57"
+                width="14.57px"
+              >
+                <g>
+                  <path
+                    className="eapp-help-icon"
+                    d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                  />
+                </g>
+              </svg>
+            </a>
+          </span>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
+            >
+              <span
+                className="component shrink"
+              >
                 <div
-                  className="bottom-btns"
+                  className="content"
+                />
+                <div
+                  className="blocks option-list branch"
                 >
                   <div
-                    className="btn-wrap"
+                    className="yes block"
                   >
-                    <div
-                      className="btn-container"
+                    <input
+                      aria-label="Yes for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="branch_school-MOCK-GUID"
+                      name="branch_school-MOCK-GUID"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="Yes"
+                    />
+                    <label
+                      className=""
+                      htmlFor="branch_school-MOCK-GUID"
                     >
-                      <button
-                        aria-label="Go to previous section Employment history"
-                        className="btn-cell back"
-                        onClick={[Function]}
-                        title="Go to previous section Employment history"
-                      >
-                        <div
-                          className="actions back"
-                        >
-                          <div
-                            className="icon"
-                          >
-                            <i
-                              aria-hidden="true"
-                              className="fa fa-arrow-circle-left"
-                            />
-                          </div>
-                          <div
-                            className="text"
-                          >
-                            <div
-                              className="direction"
-                            >
-                              Back
-                            </div>
-                            <div
-                              className="label"
-                            >
-                              Employment history
-                            </div>
-                          </div>
-                        </div>
-                      </button>
-                      <div
-                        className="btn-spacer"
-                      />
-                      <button
-                        aria-label="Go to next section Former federal service"
-                        className="btn-cell next"
-                        onClick={[Function]}
-                        title="Go to next section Former federal service"
-                      >
-                        <div
-                          className="actions next"
-                        >
-                          <div
-                            className="text"
-                          >
-                            <div
-                              className="direction"
-                            >
-                              Next
-                            </div>
-                            <div
-                              className="label"
-                            >
-                              Former federal service
-                            </div>
-                          </div>
-                          <div
-                            className="icon"
-                          >
-                            <i
-                              aria-hidden="true"
-                              className="fa fa-arrow-circle-right"
-                            />
-                          </div>
-                        </div>
-                      </button>
-                    </div>
+                      <span>
+                        Yes
+                      </span>
+                    </label>
+                  </div>
+                  <div
+                    className="no block"
+                  >
+                    <input
+                      aria-label="No for null"
+                      checked={false}
+                      className="usa-input-success"
+                      disabled={false}
+                      id="branch_school-MOCK-GUID"
+                      name="branch_school-MOCK-GUID"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      type="radio"
+                      value="No"
+                    />
+                    <label
+                      className=""
+                      htmlFor="branch_school-MOCK-GUID"
+                    >
+                      <span>
+                        No
+                      </span>
+                    </label>
+                  </div>
+                </div>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="bottom-btns"
+      >
+        <div
+          className="btn-wrap"
+        >
+          <div
+            className="btn-container"
+          >
+            <button
+              aria-label="Go to previous section Employment history"
+              className="btn-cell back"
+              onClick={[Function]}
+              title="Go to previous section Employment history"
+            >
+              <div
+                className="actions back"
+              >
+                <div
+                  className="icon"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-arrow-circle-left"
+                  />
+                </div>
+                <div
+                  className="text"
+                >
+                  <div
+                    className="direction"
+                  >
+                    Back
+                  </div>
+                  <div
+                    className="label"
+                  >
+                    Employment history
                   </div>
                 </div>
               </div>
-            </div>
+            </button>
+            <div
+              className="btn-spacer"
+            />
+            <button
+              aria-label="Go to next section Former federal service"
+              className="btn-cell next"
+              onClick={[Function]}
+              title="Go to next section Former federal service"
+            >
+              <div
+                className="actions next"
+              >
+                <div
+                  className="text"
+                >
+                  <div
+                    className="direction"
+                  >
+                    Next
+                  </div>
+                  <div
+                    className="label"
+                  >
+                    Former federal service
+                  </div>
+                </div>
+                <div
+                  className="icon"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-arrow-circle-right"
+                  />
+                </div>
+              </div>
+            </button>
           </div>
         </div>
       </div>
@@ -9064,600 +9050,586 @@ exports[`The section component renders history.education 1`] = `
 `;
 
 exports[`The section component renders history.employment 1`] = `
-<div>
+<div
+  className="history"
+>
   <div
     className="section-view"
   >
     <div
-      className="view view-history"
+      className="view view-employment"
     >
       <div>
+        <h1
+          className="section-header"
+        >
+          Employment activities
+        </h1>
         <div
-          className="history"
+          aria-label="List where you have worked"
+          className="field   no-margin-bottom"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h3
+            className="title h3"
+          >
+            List where you have worked
+          </h3>
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
+            >
+              <span
+                className="component"
+              >
+                <div>
+                  <p>
+                    List all of your employment activities, including unemployment and self-employment, beginning with the present and working back 10 years. The entire period must be accounted for without breaks. If the employment activity was military duty, list separate employment activity periods to show each change of military duty station.
+                  </p>
+                  <p>
+                    Provide separate entries for employment activities with the same employer but having different physical addresses.
+                  </p>
+                </div>
+                <div>
+                  <p>
+                    Do not list employment before your 18th birthday unless to provide a minimum of 2 years employment history.
+                  </p>
+                </div>
+              </span>
+            </span>
+          </div>
+        </div>
+        <span
+          id="scrollToHistory"
+        />
+        <div
+          className="summary-progress residence"
+        >
+          <div
+            className="content"
+          >
+            <div>
+              <div
+                className="summary-icon"
+              >
+                <img
+                  alt="Years covered for your employment activities"
+                  className="svg"
+                  src="/img/employer-briefcase.svg"
+                />
+              </div>
+              <span
+                className="title"
+              >
+                Employment activities
+              </span>
+            </div>
+            <div
+              className="progress"
+            />
+          </div>
+          <div
+            className="stats"
+          >
+            <div
+              className="fraction"
+            >
+              <span
+                className="completed"
+              >
+                0
+              </span>
+              <span
+                className="slash"
+              >
+                /
+              </span>
+              <span
+                className="total"
+              >
+                10
+              </span>
+            </div>
+            <span
+              className="unit"
+            >
+              Years covered
+            </span>
+          </div>
+        </div>
+        <div
+          className="section-content employment"
+          data-section="history"
+          data-subsection="employment"
         >
           <div>
             <div
-              className="section-view"
+              className="accordion"
             >
-              <div
-                className="view view-employment"
+              <strong
+                className="aria-description"
               >
-                <div>
-                  <h1
-                    className="section-header"
-                  >
-                    Employment activities
-                  </h1>
-                  <div
-                    aria-label="List where you have worked"
-                    className="field   no-margin-bottom"
-                    data-uuid="field-MOCK-GUID"
-                  >
-                    <a
-                      aria-hidden="true"
-                      className="anchor"
-                      id="field-MOCK-GUID"
-                      name="field-MOCK-GUID"
-                    />
-                    <h3
-                      className="title h3"
-                    >
-                      List where you have worked
-                    </h3>
-                    <span
-                      className="icon"
-                    />
-                    <div
-                      className="table expand"
-                    >
-                      <span
-                        aria-live="polite"
-                        className="messages help-messages"
-                      />
-                    </div>
-                    <div
-                      className="table expand"
-                    >
-                      <span
-                        aria-live="polite"
-                        className="messages error-messages"
-                        role="alert"
-                      />
-                    </div>
-                    <div
-                      className="table"
-                    >
-                      <span
-                        className="content"
-                      >
-                        <span
-                          className="component"
-                        >
-                          <div>
-                            <p>
-                              List all of your employment activities, including unemployment and self-employment, beginning with the present and working back 10 years. The entire period must be accounted for without breaks. If the employment activity was military duty, list separate employment activity periods to show each change of military duty station.
-                            </p>
-                            <p>
-                              Provide separate entries for employment activities with the same employer but having different physical addresses.
-                            </p>
-                          </div>
-                          <div>
-                            <p>
-                              Do not list employment before your 18th birthday unless to provide a minimum of 2 years employment history.
-                            </p>
-                          </div>
-                        </span>
-                      </span>
-                    </div>
-                  </div>
+                Summary of your work history
+              </strong>
+              <div
+                className="items"
+              />
+              <div
+                className="append-button"
+              />
+            </div>
+            <div
+              aria-label="Do you have an additional employment activity to enter?"
+              className="field required  branch addendum no-margin-bottom"
+              data-uuid="field-MOCK-GUID"
+            >
+              <a
+                aria-hidden="true"
+                className="anchor"
+                id="field-MOCK-GUID"
+                name="field-MOCK-GUID"
+              />
+              <h4
+                className="title h4"
+              >
+                Do you have an additional employment activity to enter?
+              </h4>
+              <span
+                className="icon"
+              />
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages help-messages"
+                />
+              </div>
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages error-messages"
+                  role="alert"
+                />
+              </div>
+              <div
+                className="table"
+              >
+                <span
+                  className="content"
+                >
                   <span
-                    id="scrollToHistory"
-                  />
-                  <div
-                    className="summary-progress residence"
+                    className="component shrink"
                   >
                     <div
                       className="content"
-                    >
-                      <div>
-                        <div
-                          className="summary-icon"
-                        >
-                          <img
-                            alt="Years covered for your employment activities"
-                            className="svg"
-                            src="/img/employer-briefcase.svg"
-                          />
-                        </div>
-                        <span
-                          className="title"
-                        >
-                          Employment activities
-                        </span>
-                      </div>
-                      <div
-                        className="progress"
-                      />
-                    </div>
-                    <div
-                      className="stats"
-                    >
-                      <div
-                        className="fraction"
-                      >
-                        <span
-                          className="completed"
-                        >
-                          0
-                        </span>
-                        <span
-                          className="slash"
-                        >
-                          /
-                        </span>
-                        <span
-                          className="total"
-                        >
-                          10
-                        </span>
-                      </div>
-                      <span
-                        className="unit"
-                      >
-                        Years covered
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="section-content employment"
-                    data-section="history"
-                    data-subsection="employment"
-                  >
-                    <div>
-                      <div
-                        className="accordion"
-                      >
-                        <strong
-                          className="aria-description"
-                        >
-                          Summary of your work history
-                        </strong>
-                        <div
-                          className="items"
-                        />
-                        <div
-                          className="append-button"
-                        />
-                      </div>
-                      <div
-                        aria-label="Do you have an additional employment activity to enter?"
-                        className="field required  branch addendum no-margin-bottom"
-                        data-uuid="field-MOCK-GUID"
-                      >
-                        <a
-                          aria-hidden="true"
-                          className="anchor"
-                          id="field-MOCK-GUID"
-                          name="field-MOCK-GUID"
-                        />
-                        <h4
-                          className="title h4"
-                        >
-                          Do you have an additional employment activity to enter?
-                        </h4>
-                        <span
-                          className="icon"
-                        />
-                        <div
-                          className="table expand"
-                        >
-                          <span
-                            aria-live="polite"
-                            className="messages help-messages"
-                          />
-                        </div>
-                        <div
-                          className="table expand"
-                        >
-                          <span
-                            aria-live="polite"
-                            className="messages error-messages"
-                            role="alert"
-                          />
-                        </div>
-                        <div
-                          className="table"
-                        >
-                          <span
-                            className="content"
-                          >
-                            <span
-                              className="component shrink"
-                            >
-                              <div
-                                className="content"
-                              />
-                              <div
-                                className="blocks option-list branch"
-                              >
-                                <div
-                                  className="yes block"
-                                >
-                                  <input
-                                    aria-label="Yes for null"
-                                    checked={false}
-                                    className="usa-input-success"
-                                    disabled={false}
-                                    id="radio_input-MOCK-GUID"
-                                    name="radio_input-MOCK-GUID"
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    type="radio"
-                                    value="Yes"
-                                  />
-                                  <label
-                                    className=""
-                                    htmlFor="radio_input-MOCK-GUID"
-                                  >
-                                    <span>
-                                      Yes
-                                    </span>
-                                  </label>
-                                </div>
-                                <div
-                                  className="no block"
-                                >
-                                  <input
-                                    aria-label="No for null"
-                                    checked={false}
-                                    className="usa-input-success"
-                                    disabled={false}
-                                    id="radio_input-MOCK-GUID"
-                                    name="radio_input-MOCK-GUID"
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    type="radio"
-                                    value="No"
-                                  />
-                                  <label
-                                    className=""
-                                    htmlFor="radio_input-MOCK-GUID"
-                                  >
-                                    <span>
-                                      No
-                                    </span>
-                                  </label>
-                                </div>
-                              </div>
-                            </span>
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                    <hr
-                      className="section-divider"
                     />
                     <div
-                      aria-label="Have any of the following happened to you in the last seven (7) years at employment activities that you have not previously listed?"
-                      className="field required  branch employment-record"
-                      data-uuid="field-MOCK-GUID"
+                      className="blocks option-list branch"
                     >
-                      <a
-                        aria-hidden="true"
-                        className="anchor"
-                        id="field-MOCK-GUID"
-                        name="field-MOCK-GUID"
-                      />
-                      <h4
-                        className="title h4"
-                      >
-                        Have any of the following happened to you in the last seven (7) years at employment activities that you have not previously listed?
-                      </h4>
-                      <span
-                        className="icon"
-                      />
                       <div
-                        className="table expand"
+                        className="yes block"
                       >
-                        <span
-                          aria-live="polite"
-                          className="messages help-messages"
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="radio_input-MOCK-GUID"
+                          name="radio_input-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
                         />
-                      </div>
-                      <div
-                        className="table expand"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="messages error-messages"
-                          role="alert"
-                        />
-                      </div>
-                      <div
-                        className="table"
-                      >
-                        <span
-                          className="content"
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
                         >
-                          <span
-                            className="component shrink"
-                          >
-                            <div
-                              className="content"
-                            >
-                              <div>
-                                <ul>
-                                  <li>
-                                    Fired from a job?
-                                  </li>
-                                </ul>
-                              </div>
-                              <div>
-                                <ul>
-                                  <li>
-                                    Quit a job after being told you would be fired?
-                                  </li>
-                                </ul>
-                              </div>
-                              <div>
-                                <ul>
-                                  <li>
-                                    Have you left a job by mutual agreement following charges or allegations of misconduct?
-                                  </li>
-                                </ul>
-                              </div>
-                              <div>
-                                <ul>
-                                  <li>
-                                    Left a job by mutual agreement following notice of unsatisfactory performance?
-                                  </li>
-                                </ul>
-                              </div>
-                              <div>
-                                <ul>
-                                  <li>
-                                    Received a written warning, been officially reprimanded, suspended, or disciplined for misconduct in the workplace, such as violation of security policy?
-                                  </li>
-                                </ul>
-                              </div>
-                              <div>
-                                <p>
-                                  If you answer "Yes", you will be required to add an additional employment record above.
-                                </p>
-                              </div>
-                            </div>
-                            <div
-                              className="blocks option-list branch"
-                            >
-                              <div
-                                className="yes block"
-                              >
-                                <input
-                                  aria-label="Yes for null"
-                                  checked={false}
-                                  className="usa-input-success"
-                                  disabled={false}
-                                  id="radio_input-MOCK-GUID"
-                                  name="radio_input-MOCK-GUID"
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  type="radio"
-                                  value="Yes"
-                                />
-                                <label
-                                  className=""
-                                  htmlFor="radio_input-MOCK-GUID"
-                                >
-                                  <span>
-                                    Yes
-                                  </span>
-                                </label>
-                              </div>
-                              <div
-                                className="no block"
-                              >
-                                <input
-                                  aria-label="No for null"
-                                  checked={false}
-                                  className="usa-input-success"
-                                  disabled={false}
-                                  id="radio_input-MOCK-GUID"
-                                  name="radio_input-MOCK-GUID"
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  type="radio"
-                                  value="No"
-                                />
-                                <label
-                                  className=""
-                                  htmlFor="radio_input-MOCK-GUID"
-                                >
-                                  <span>
-                                    No
-                                  </span>
-                                </label>
-                              </div>
-                            </div>
+                          <span>
+                            Yes
                           </span>
-                        </span>
+                        </label>
+                      </div>
+                      <div
+                        className="no block"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="radio_input-MOCK-GUID"
+                          name="radio_input-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
+                        >
+                          <span>
+                            No
+                          </span>
+                        </label>
                       </div>
                     </div>
-                  </div>
-                  <div
-                    className="not-complete"
-                  >
-                    <hr
-                      className="section-divider"
-                    />
-                    <div
-                      aria-label="Before you leave this section"
-                      className="field   no-margin-bottom"
-                      data-uuid="field-MOCK-GUID"
-                    >
-                      <a
-                        aria-hidden="true"
-                        className="anchor"
-                        id="field-MOCK-GUID"
-                        name="field-MOCK-GUID"
-                      />
-                      <h4
-                        className="title h4"
-                      >
-                        Before you leave this section
-                      </h4>
-                      <span
-                        className="icon"
-                      />
-                      <div
-                        className="table expand"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="messages help-messages"
-                        />
-                      </div>
-                      <div
-                        className="table expand"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="messages error-messages"
-                          role="alert"
-                        />
-                      </div>
-                      <div
-                        className="table"
-                      >
-                        <span
-                          className="content"
-                        >
-                          <span
-                            className="component"
-                          >
-                            <div>
-                              <p>
-                                <strong>
-                                  The full 10 year period of employment history is not covered.
-                                </strong>
-                                 Your SF86 cannot be submitted until all 10 years are covered with no gaps.
-                                <span
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<br>",
-                                    }
-                                  }
-                                />
-                                <span
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<br>",
-                                    }
-                                  }
-                                />
-                                We will mark the gaps and highlight them for you when you come back.
-                              </p>
-                            </div>
-                          </span>
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  className="bottom-btns"
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+          <hr
+            className="section-divider"
+          />
+          <div
+            aria-label="Have any of the following happened to you in the last seven (7) years at employment activities that you have not previously listed?"
+            className="field required  branch employment-record"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h4
+              className="title h4"
+            >
+              Have any of the following happened to you in the last seven (7) years at employment activities that you have not previously listed?
+            </h4>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
                 >
                   <div
-                    className="btn-wrap"
+                    className="content"
+                  >
+                    <div>
+                      <ul>
+                        <li>
+                          Fired from a job?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <ul>
+                        <li>
+                          Quit a job after being told you would be fired?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <ul>
+                        <li>
+                          Have you left a job by mutual agreement following charges or allegations of misconduct?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <ul>
+                        <li>
+                          Left a job by mutual agreement following notice of unsatisfactory performance?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <ul>
+                        <li>
+                          Received a written warning, been officially reprimanded, suspended, or disciplined for misconduct in the workplace, such as violation of security policy?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <p>
+                        If you answer "Yes", you will be required to add an additional employment record above.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="blocks option-list branch"
                   >
                     <div
-                      className="btn-container"
+                      className="yes block"
                     >
-                      <button
-                        aria-label="Go to previous section Places you lived"
-                        className="btn-cell back"
+                      <input
+                        aria-label="Yes for null"
+                        checked={false}
+                        className="usa-input-success"
+                        disabled={false}
+                        id="radio_input-MOCK-GUID"
+                        name="radio_input-MOCK-GUID"
+                        onBlur={[Function]}
+                        onChange={[Function]}
                         onClick={[Function]}
-                        title="Go to previous section Places you lived"
-                      >
-                        <div
-                          className="actions back"
-                        >
-                          <div
-                            className="icon"
-                          >
-                            <i
-                              aria-hidden="true"
-                              className="fa fa-arrow-circle-left"
-                            />
-                          </div>
-                          <div
-                            className="text"
-                          >
-                            <div
-                              className="direction"
-                            >
-                              Back
-                            </div>
-                            <div
-                              className="label"
-                            >
-                              Places you lived
-                            </div>
-                          </div>
-                        </div>
-                      </button>
-                      <div
-                        className="btn-spacer"
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        type="radio"
+                        value="Yes"
                       />
-                      <button
-                        aria-label="Go to next section Schools & diplomas"
-                        className="btn-cell next"
-                        onClick={[Function]}
-                        title="Go to next section Schools & diplomas"
+                      <label
+                        className=""
+                        htmlFor="radio_input-MOCK-GUID"
                       >
-                        <div
-                          className="actions next"
-                        >
-                          <div
-                            className="text"
-                          >
-                            <div
-                              className="direction"
-                            >
-                              Next
-                            </div>
-                            <div
-                              className="label"
-                            >
-                              Schools & diplomas
-                            </div>
-                          </div>
-                          <div
-                            className="icon"
-                          >
-                            <i
-                              aria-hidden="true"
-                              className="fa fa-arrow-circle-right"
-                            />
-                          </div>
-                        </div>
-                      </button>
+                        <span>
+                          Yes
+                        </span>
+                      </label>
                     </div>
+                    <div
+                      className="no block"
+                    >
+                      <input
+                        aria-label="No for null"
+                        checked={false}
+                        className="usa-input-success"
+                        disabled={false}
+                        id="radio_input-MOCK-GUID"
+                        name="radio_input-MOCK-GUID"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        type="radio"
+                        value="No"
+                      />
+                      <label
+                        className=""
+                        htmlFor="radio_input-MOCK-GUID"
+                      >
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="not-complete"
+        >
+          <hr
+            className="section-divider"
+          />
+          <div
+            aria-label="Before you leave this section"
+            className="field   no-margin-bottom"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h4
+              className="title h4"
+            >
+              Before you leave this section
+            </h4>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div>
+                    <p>
+                      <strong>
+                        The full 10 year period of employment history is not covered.
+                      </strong>
+                       Your SF86 cannot be submitted until all 10 years are covered with no gaps.
+                      <span
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<br>",
+                          }
+                        }
+                      />
+                      <span
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<br>",
+                          }
+                        }
+                      />
+                      We will mark the gaps and highlight them for you when you come back.
+                    </p>
+                  </div>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="bottom-btns"
+      >
+        <div
+          className="btn-wrap"
+        >
+          <div
+            className="btn-container"
+          >
+            <button
+              aria-label="Go to previous section Places you lived"
+              className="btn-cell back"
+              onClick={[Function]}
+              title="Go to previous section Places you lived"
+            >
+              <div
+                className="actions back"
+              >
+                <div
+                  className="icon"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-arrow-circle-left"
+                  />
+                </div>
+                <div
+                  className="text"
+                >
+                  <div
+                    className="direction"
+                  >
+                    Back
+                  </div>
+                  <div
+                    className="label"
+                  >
+                    Places you lived
                   </div>
                 </div>
               </div>
-            </div>
+            </button>
+            <div
+              className="btn-spacer"
+            />
+            <button
+              aria-label="Go to next section Schools & diplomas"
+              className="btn-cell next"
+              onClick={[Function]}
+              title="Go to next section Schools & diplomas"
+            >
+              <div
+                className="actions next"
+              >
+                <div
+                  className="text"
+                >
+                  <div
+                    className="direction"
+                  >
+                    Next
+                  </div>
+                  <div
+                    className="label"
+                  >
+                    Schools & diplomas
+                  </div>
+                </div>
+                <div
+                  className="icon"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-arrow-circle-right"
+                  />
+                </div>
+              </div>
+            </button>
           </div>
         </div>
       </div>
@@ -9667,254 +9639,240 @@ exports[`The section component renders history.employment 1`] = `
 `;
 
 exports[`The section component renders history.federal 1`] = `
-<div>
+<div
+  className="history"
+>
   <div
     className="section-view"
   >
     <div
-      className="view view-history"
+      className="view view-federal"
     >
       <div>
-        <div
-          className="history"
+        <h1
+          className="section-header"
         >
-          <div>
-            <div
-              className="section-view"
+          Former federal service
+        </h1>
+        <div
+          className="section-content federal"
+          data-section="history"
+          data-subsection="federal"
+        >
+          <div
+            aria-label="Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h4
+              className="title h4"
             >
-              <div
-                className="view view-federal"
+              Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?
+            </h4>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
+                className="toggle h4  adjust-for-buttons"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
               >
-                <div>
-                  <h1
-                    className="section-header"
-                  >
-                    Former federal service
-                  </h1>
-                  <div
-                    className="section-content federal"
-                    data-section="history"
-                    data-subsection="federal"
-                  >
-                    <div
-                      aria-label="Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
-                      className="field required  branch"
-                      data-uuid="field-MOCK-GUID"
-                    >
-                      <a
-                        aria-hidden="true"
-                        className="anchor"
-                        id="field-MOCK-GUID"
-                        name="field-MOCK-GUID"
-                      />
-                      <h4
-                        className="title h4"
-                      >
-                        Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?
-                      </h4>
-                      <span
-                        className="icon"
-                      >
-                        <a
-                          aria-label="Show help for Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
-                          className="toggle h4  adjust-for-buttons"
-                          href="javascript:;"
-                          onClick={[Function]}
-                          title="Show help for Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
-                        >
-                          <svg
-                            alt="Scalable vector graphic"
-                            focusable="false"
-                            height="14.57px"
-                            tabIndex="-1"
-                            viewBox="0 0 14.57 14.57"
-                            width="14.57px"
-                          >
-                            <g>
-                              <path
-                                className="eapp-help-icon"
-                                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
-                              />
-                            </g>
-                          </svg>
-                        </a>
-                      </span>
-                      <div
-                        className="table expand"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="messages help-messages"
-                        />
-                      </div>
-                      <div
-                        className="table expand"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="messages error-messages"
-                          role="alert"
-                        />
-                      </div>
-                      <div
-                        className="table"
-                      >
-                        <span
-                          className="content"
-                        >
-                          <span
-                            className="component shrink"
-                          >
-                            <div
-                              className="content"
-                            />
-                            <div
-                              className="blocks option-list branch"
-                            >
-                              <div
-                                className="yes block"
-                              >
-                                <input
-                                  aria-label="Yes for null"
-                                  checked={false}
-                                  className="usa-input-success"
-                                  disabled={false}
-                                  id="has_federalservice-MOCK-GUID"
-                                  name="has_federalservice-MOCK-GUID"
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  type="radio"
-                                  value="Yes"
-                                />
-                                <label
-                                  className=""
-                                  htmlFor="has_federalservice-MOCK-GUID"
-                                >
-                                  <span>
-                                    Yes
-                                  </span>
-                                </label>
-                              </div>
-                              <div
-                                className="no block"
-                              >
-                                <input
-                                  aria-label="No for null"
-                                  checked={false}
-                                  className="usa-input-success"
-                                  disabled={false}
-                                  id="has_federalservice-MOCK-GUID"
-                                  name="has_federalservice-MOCK-GUID"
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  type="radio"
-                                  value="No"
-                                />
-                                <label
-                                  className=""
-                                  htmlFor="has_federalservice-MOCK-GUID"
-                                >
-                                  <span>
-                                    No
-                                  </span>
-                                </label>
-                              </div>
-                            </div>
-                          </span>
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  className="bottom-btns"
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
                 >
                   <div
-                    className="btn-wrap"
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch"
                   >
                     <div
-                      className="btn-container"
+                      className="yes block"
                     >
-                      <button
-                        aria-label="Go to previous section Schools & diplomas"
-                        className="btn-cell back"
+                      <input
+                        aria-label="Yes for null"
+                        checked={false}
+                        className="usa-input-success"
+                        disabled={false}
+                        id="has_federalservice-MOCK-GUID"
+                        name="has_federalservice-MOCK-GUID"
+                        onBlur={[Function]}
+                        onChange={[Function]}
                         onClick={[Function]}
-                        title="Go to previous section Schools & diplomas"
-                      >
-                        <div
-                          className="actions back"
-                        >
-                          <div
-                            className="icon"
-                          >
-                            <i
-                              aria-hidden="true"
-                              className="fa fa-arrow-circle-left"
-                            />
-                          </div>
-                          <div
-                            className="text"
-                          >
-                            <div
-                              className="direction"
-                            >
-                              Back
-                            </div>
-                            <div
-                              className="label"
-                            >
-                              Schools & diplomas
-                            </div>
-                          </div>
-                        </div>
-                      </button>
-                      <div
-                        className="btn-spacer"
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        type="radio"
+                        value="Yes"
                       />
-                      <button
-                        aria-label="Go to next section Review your history"
-                        className="btn-cell next"
-                        onClick={[Function]}
-                        title="Go to next section Review your history"
+                      <label
+                        className=""
+                        htmlFor="has_federalservice-MOCK-GUID"
                       >
-                        <div
-                          className="actions next"
-                        >
-                          <div
-                            className="text"
-                          >
-                            <div
-                              className="direction"
-                            >
-                              Next
-                            </div>
-                            <div
-                              className="label"
-                            >
-                              Review your history
-                            </div>
-                          </div>
-                          <div
-                            className="icon"
-                          >
-                            <i
-                              aria-hidden="true"
-                              className="fa fa-arrow-circle-right"
-                            />
-                          </div>
-                        </div>
-                      </button>
+                        <span>
+                          Yes
+                        </span>
+                      </label>
                     </div>
+                    <div
+                      className="no block"
+                    >
+                      <input
+                        aria-label="No for null"
+                        checked={false}
+                        className="usa-input-success"
+                        disabled={false}
+                        id="has_federalservice-MOCK-GUID"
+                        name="has_federalservice-MOCK-GUID"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        type="radio"
+                        value="No"
+                      />
+                      <label
+                        className=""
+                        htmlFor="has_federalservice-MOCK-GUID"
+                      >
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="bottom-btns"
+      >
+        <div
+          className="btn-wrap"
+        >
+          <div
+            className="btn-container"
+          >
+            <button
+              aria-label="Go to previous section Schools & diplomas"
+              className="btn-cell back"
+              onClick={[Function]}
+              title="Go to previous section Schools & diplomas"
+            >
+              <div
+                className="actions back"
+              >
+                <div
+                  className="icon"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-arrow-circle-left"
+                  />
+                </div>
+                <div
+                  className="text"
+                >
+                  <div
+                    className="direction"
+                  >
+                    Back
+                  </div>
+                  <div
+                    className="label"
+                  >
+                    Schools & diplomas
                   </div>
                 </div>
               </div>
-            </div>
+            </button>
+            <div
+              className="btn-spacer"
+            />
+            <button
+              aria-label="Go to next section Review your history"
+              className="btn-cell next"
+              onClick={[Function]}
+              title="Go to next section Review your history"
+            >
+              <div
+                className="actions next"
+              >
+                <div
+                  className="text"
+                >
+                  <div
+                    className="direction"
+                  >
+                    Next
+                  </div>
+                  <div
+                    className="label"
+                  >
+                    Review your history
+                  </div>
+                </div>
+                <div
+                  className="icon"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-arrow-circle-right"
+                  />
+                </div>
+              </div>
+            </button>
           </div>
         </div>
       </div>
@@ -9924,163 +9882,149 @@ exports[`The section component renders history.federal 1`] = `
 `;
 
 exports[`The section component renders history.intro 1`] = `
-<div>
+<div
+  className="history"
+>
   <div
     className="section-view"
   >
     <div
-      className="view view-history"
+      className="view view-intro"
     >
       <div>
-        <div
-          className="history"
+        <h1
+          className="section-header"
         >
-          <div>
-            <div
-              className="section-view"
+          Section 2: Your history
+        </h1>
+        <div
+          aria-label=""
+          className="field   no-margin-bottom"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
             >
-              <div
-                className="view view-intro"
+              <span
+                className="component"
               >
                 <div>
-                  <h1
-                    className="section-header"
-                  >
-                    Section 2: Your history
-                  </h1>
-                  <div
-                    aria-label=""
-                    className="field   no-margin-bottom"
-                    data-uuid="field-MOCK-GUID"
-                  >
-                    <a
-                      aria-hidden="true"
-                      className="anchor"
-                      id="field-MOCK-GUID"
-                      name="field-MOCK-GUID"
-                    />
-                    <span
-                      className="icon"
-                    />
-                    <div
-                      className="table expand"
-                    >
-                      <span
-                        aria-live="polite"
-                        className="messages help-messages"
-                      />
-                    </div>
-                    <div
-                      className="table expand"
-                    >
-                      <span
-                        aria-live="polite"
-                        className="messages error-messages"
-                        role="alert"
-                      />
-                    </div>
-                    <div
-                      className="table"
-                    >
-                      <span
-                        className="content"
-                      >
-                        <span
-                          className="component"
-                        >
-                          <div>
-                            <p>
-                              You will be asked questions about your history and be asked to provide details if necessary. This section includes where you have lived, where you have worked, and where you went to school.
-                            </p>
-                          </div>
-                        </span>
-                      </span>
-                    </div>
-                  </div>
+                  <p>
+                    You will be asked questions about your history and be asked to provide details if necessary. This section includes where you have lived, where you have worked, and where you went to school.
+                  </p>
+                </div>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="bottom-btns"
+      >
+        <div
+          className="btn-wrap"
+        >
+          <div
+            className="btn-container"
+          >
+            <button
+              aria-label="Go to previous section Review Identification"
+              className="btn-cell back"
+              onClick={[Function]}
+              title="Go to previous section Review Identification"
+            >
+              <div
+                className="actions back"
+              >
+                <div
+                  className="icon"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-arrow-circle-left"
+                  />
                 </div>
                 <div
-                  className="bottom-btns"
+                  className="text"
                 >
                   <div
-                    className="btn-wrap"
+                    className="direction"
                   >
-                    <div
-                      className="btn-container"
-                    >
-                      <button
-                        aria-label="Go to previous section Review Identification"
-                        className="btn-cell back"
-                        onClick={[Function]}
-                        title="Go to previous section Review Identification"
-                      >
-                        <div
-                          className="actions back"
-                        >
-                          <div
-                            className="icon"
-                          >
-                            <i
-                              aria-hidden="true"
-                              className="fa fa-arrow-circle-left"
-                            />
-                          </div>
-                          <div
-                            className="text"
-                          >
-                            <div
-                              className="direction"
-                            >
-                              Back
-                            </div>
-                            <div
-                              className="label"
-                            >
-                              Review Identification
-                            </div>
-                          </div>
-                        </div>
-                      </button>
-                      <div
-                        className="btn-spacer"
-                      />
-                      <button
-                        aria-label="Go to next section Places you lived"
-                        className="btn-cell next"
-                        onClick={[Function]}
-                        title="Go to next section Places you lived"
-                      >
-                        <div
-                          className="actions next"
-                        >
-                          <div
-                            className="text"
-                          >
-                            <div
-                              className="direction"
-                            >
-                              Next
-                            </div>
-                            <div
-                              className="label"
-                            >
-                              Places you lived
-                            </div>
-                          </div>
-                          <div
-                            className="icon"
-                          >
-                            <i
-                              aria-hidden="true"
-                              className="fa fa-arrow-circle-right"
-                            />
-                          </div>
-                        </div>
-                      </button>
-                    </div>
+                    Back
+                  </div>
+                  <div
+                    className="label"
+                  >
+                    Review Identification
                   </div>
                 </div>
               </div>
-            </div>
+            </button>
+            <div
+              className="btn-spacer"
+            />
+            <button
+              aria-label="Go to next section Places you lived"
+              className="btn-cell next"
+              onClick={[Function]}
+              title="Go to next section Places you lived"
+            >
+              <div
+                className="actions next"
+              >
+                <div
+                  className="text"
+                >
+                  <div
+                    className="direction"
+                  >
+                    Next
+                  </div>
+                  <div
+                    className="label"
+                  >
+                    Places you lived
+                  </div>
+                </div>
+                <div
+                  className="icon"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-arrow-circle-right"
+                  />
+                </div>
+              </div>
+            </button>
           </div>
         </div>
       </div>
@@ -10090,478 +10034,464 @@ exports[`The section component renders history.intro 1`] = `
 `;
 
 exports[`The section component renders history.residence 1`] = `
-<div>
+<div
+  className="history"
+>
   <div
     className="section-view"
   >
     <div
-      className="view view-history"
+      className="view view-residence"
     >
       <div>
+        <h1
+          className="section-header"
+        >
+          Where you have lived
+        </h1>
         <div
-          className="history"
+          aria-label="List the places where you have lived beginning with your present residence and working back 10 years."
+          className="field   no-margin-bottom"
+          data-uuid="field-MOCK-GUID"
+        >
+          <a
+            aria-hidden="true"
+            className="anchor"
+            id="field-MOCK-GUID"
+            name="field-MOCK-GUID"
+          />
+          <h3
+            className="title h3"
+          >
+            List the places where you have lived beginning with your present residence and working back 10 years.
+          </h3>
+          <span
+            className="icon"
+          />
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages help-messages"
+            />
+          </div>
+          <div
+            className="table expand"
+          >
+            <span
+              aria-live="polite"
+              className="messages error-messages"
+              role="alert"
+            />
+          </div>
+          <div
+            className="table"
+          >
+            <span
+              className="content"
+            >
+              <span
+                className="component"
+              >
+                <div>
+                  <p>
+                    Residences for the entire period must be accounted for without breaks.
+                  </p>
+                </div>
+                <div>
+                  <ul>
+                    <li>
+                      <strong>
+                        Indicate the actual physical location of your residence
+                      </strong>
+                      , not a Post Office box or a permanent residence when you were not physically located there.
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <ul>
+                    <li>
+                      <strong>
+                        If you split your time between one or more residences during a time period
+                      </strong>
+                      , you must list all residences.
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <ul>
+                    <li>
+                      <strong>
+                        Do not list residences before your 18th birthday
+                      </strong>
+                       unless to provide a minimum of 2 years residence history.
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <ul>
+                    <li>
+                      <strong>
+                        You are not required to list temporary locations of less than 90 days
+                      </strong>
+                       that did not serve as your permanent or mailing address.
+                    </li>
+                  </ul>
+                </div>
+              </span>
+            </span>
+          </div>
+        </div>
+        <span
+          id="scrollToHistory"
+        />
+        <div
+          className="summary-progress residence"
+        >
+          <div
+            className="content"
+          >
+            <div>
+              <div
+                className="summary-icon"
+              >
+                <img
+                  alt="Years covered for locations you have lived"
+                  className="svg"
+                  src="/img/residence-house.svg"
+                />
+              </div>
+              <span
+                className="title"
+              >
+                Where you have lived
+              </span>
+            </div>
+            <div
+              className="progress"
+            />
+          </div>
+          <div
+            className="stats"
+          >
+            <div
+              className="fraction"
+            >
+              <span
+                className="completed"
+              >
+                0
+              </span>
+              <span
+                className="slash"
+              >
+                /
+              </span>
+              <span
+                className="total"
+              >
+                10
+              </span>
+            </div>
+            <span
+              className="unit"
+            >
+              Years covered
+            </span>
+          </div>
+        </div>
+        <div
+          className="section-content residence"
+          data-section="history"
+          data-subsection="residence"
         >
           <div>
             <div
-              className="section-view"
+              className="accordion"
             >
-              <div
-                className="view view-residence"
+              <strong
+                className="aria-description"
               >
-                <div>
-                  <h1
-                    className="section-header"
-                  >
-                    Where you have lived
-                  </h1>
-                  <div
-                    aria-label="List the places where you have lived beginning with your present residence and working back 10 years."
-                    className="field   no-margin-bottom"
-                    data-uuid="field-MOCK-GUID"
-                  >
-                    <a
-                      aria-hidden="true"
-                      className="anchor"
-                      id="field-MOCK-GUID"
-                      name="field-MOCK-GUID"
-                    />
-                    <h3
-                      className="title h3"
-                    >
-                      List the places where you have lived beginning with your present residence and working back 10 years.
-                    </h3>
-                    <span
-                      className="icon"
-                    />
-                    <div
-                      className="table expand"
-                    >
-                      <span
-                        aria-live="polite"
-                        className="messages help-messages"
-                      />
-                    </div>
-                    <div
-                      className="table expand"
-                    >
-                      <span
-                        aria-live="polite"
-                        className="messages error-messages"
-                        role="alert"
-                      />
-                    </div>
-                    <div
-                      className="table"
-                    >
-                      <span
-                        className="content"
-                      >
-                        <span
-                          className="component"
-                        >
-                          <div>
-                            <p>
-                              Residences for the entire period must be accounted for without breaks.
-                            </p>
-                          </div>
-                          <div>
-                            <ul>
-                              <li>
-                                <strong>
-                                  Indicate the actual physical location of your residence
-                                </strong>
-                                , not a Post Office box or a permanent residence when you were not physically located there.
-                              </li>
-                            </ul>
-                          </div>
-                          <div>
-                            <ul>
-                              <li>
-                                <strong>
-                                  If you split your time between one or more residences during a time period
-                                </strong>
-                                , you must list all residences.
-                              </li>
-                            </ul>
-                          </div>
-                          <div>
-                            <ul>
-                              <li>
-                                <strong>
-                                  Do not list residences before your 18th birthday
-                                </strong>
-                                 unless to provide a minimum of 2 years residence history.
-                              </li>
-                            </ul>
-                          </div>
-                          <div>
-                            <ul>
-                              <li>
-                                <strong>
-                                  You are not required to list temporary locations of less than 90 days
-                                </strong>
-                                 that did not serve as your permanent or mailing address.
-                              </li>
-                            </ul>
-                          </div>
-                        </span>
-                      </span>
-                    </div>
-                  </div>
+                Summary of places you have lived
+              </strong>
+              <div
+                className="items"
+              />
+              <div
+                className="append-button"
+              />
+            </div>
+            <div
+              aria-label="Do you have an additional residence to report?"
+              className="field required  branch addendum"
+              data-uuid="field-MOCK-GUID"
+            >
+              <a
+                aria-hidden="true"
+                className="anchor"
+                id="field-MOCK-GUID"
+                name="field-MOCK-GUID"
+              />
+              <h4
+                className="title h4"
+              >
+                Do you have an additional residence to report?
+              </h4>
+              <span
+                className="icon"
+              />
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages help-messages"
+                />
+              </div>
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages error-messages"
+                  role="alert"
+                />
+              </div>
+              <div
+                className="table"
+              >
+                <span
+                  className="content"
+                >
                   <span
-                    id="scrollToHistory"
-                  />
-                  <div
-                    className="summary-progress residence"
+                    className="component shrink"
                   >
                     <div
                       className="content"
-                    >
-                      <div>
-                        <div
-                          className="summary-icon"
-                        >
-                          <img
-                            alt="Years covered for locations you have lived"
-                            className="svg"
-                            src="/img/residence-house.svg"
-                          />
-                        </div>
-                        <span
-                          className="title"
-                        >
-                          Where you have lived
-                        </span>
-                      </div>
-                      <div
-                        className="progress"
-                      />
-                    </div>
-                    <div
-                      className="stats"
-                    >
-                      <div
-                        className="fraction"
-                      >
-                        <span
-                          className="completed"
-                        >
-                          0
-                        </span>
-                        <span
-                          className="slash"
-                        >
-                          /
-                        </span>
-                        <span
-                          className="total"
-                        >
-                          10
-                        </span>
-                      </div>
-                      <span
-                        className="unit"
-                      >
-                        Years covered
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="section-content residence"
-                    data-section="history"
-                    data-subsection="residence"
-                  >
-                    <div>
-                      <div
-                        className="accordion"
-                      >
-                        <strong
-                          className="aria-description"
-                        >
-                          Summary of places you have lived
-                        </strong>
-                        <div
-                          className="items"
-                        />
-                        <div
-                          className="append-button"
-                        />
-                      </div>
-                      <div
-                        aria-label="Do you have an additional residence to report?"
-                        className="field required  branch addendum"
-                        data-uuid="field-MOCK-GUID"
-                      >
-                        <a
-                          aria-hidden="true"
-                          className="anchor"
-                          id="field-MOCK-GUID"
-                          name="field-MOCK-GUID"
-                        />
-                        <h4
-                          className="title h4"
-                        >
-                          Do you have an additional residence to report?
-                        </h4>
-                        <span
-                          className="icon"
-                        />
-                        <div
-                          className="table expand"
-                        >
-                          <span
-                            aria-live="polite"
-                            className="messages help-messages"
-                          />
-                        </div>
-                        <div
-                          className="table expand"
-                        >
-                          <span
-                            aria-live="polite"
-                            className="messages error-messages"
-                            role="alert"
-                          />
-                        </div>
-                        <div
-                          className="table"
-                        >
-                          <span
-                            className="content"
-                          >
-                            <span
-                              className="component shrink"
-                            >
-                              <div
-                                className="content"
-                              />
-                              <div
-                                className="blocks option-list branch"
-                              >
-                                <div
-                                  className="yes block"
-                                >
-                                  <input
-                                    aria-label="Yes for null"
-                                    checked={false}
-                                    className="usa-input-success"
-                                    disabled={false}
-                                    id="radio_input-MOCK-GUID"
-                                    name="radio_input-MOCK-GUID"
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    type="radio"
-                                    value="Yes"
-                                  />
-                                  <label
-                                    className=""
-                                    htmlFor="radio_input-MOCK-GUID"
-                                  >
-                                    <span>
-                                      Yes
-                                    </span>
-                                  </label>
-                                </div>
-                                <div
-                                  className="no block"
-                                >
-                                  <input
-                                    aria-label="No for null"
-                                    checked={false}
-                                    className="usa-input-success"
-                                    disabled={false}
-                                    id="radio_input-MOCK-GUID"
-                                    name="radio_input-MOCK-GUID"
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    type="radio"
-                                    value="No"
-                                  />
-                                  <label
-                                    className=""
-                                    htmlFor="radio_input-MOCK-GUID"
-                                  >
-                                    <span>
-                                      No
-                                    </span>
-                                  </label>
-                                </div>
-                              </div>
-                            </span>
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="not-complete"
-                  >
-                    <hr
-                      className="section-divider"
                     />
                     <div
-                      aria-label="Before you leave this section"
-                      className="field   no-margin-bottom"
-                      data-uuid="field-MOCK-GUID"
+                      className="blocks option-list branch"
                     >
-                      <a
-                        aria-hidden="true"
-                        className="anchor"
-                        id="field-MOCK-GUID"
-                        name="field-MOCK-GUID"
-                      />
-                      <h4
-                        className="title h4"
-                      >
-                        Before you leave this section
-                      </h4>
-                      <span
-                        className="icon"
-                      />
                       <div
-                        className="table expand"
+                        className="yes block"
                       >
-                        <span
-                          aria-live="polite"
-                          className="messages help-messages"
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="radio_input-MOCK-GUID"
+                          name="radio_input-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
                         />
-                      </div>
-                      <div
-                        className="table expand"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="messages error-messages"
-                          role="alert"
-                        />
-                      </div>
-                      <div
-                        className="table"
-                      >
-                        <span
-                          className="content"
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
                         >
-                          <span
-                            className="component"
-                          >
-                            <div>
-                              <p>
-                                <strong>
-                                  The full 10 year period of residence history is not covered.
-                                </strong>
-                                 Your SF86 cannot be submitted until all 10 years are covered with no gaps.
-                                <span
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<br>",
-                                    }
-                                  }
-                                />
-                                <span
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<br>",
-                                    }
-                                  }
-                                />
-                                We will mark the gaps and highlight them for you when you come back.
-                              </p>
-                            </div>
+                          <span>
+                            Yes
                           </span>
-                        </span>
+                        </label>
+                      </div>
+                      <div
+                        className="no block"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="radio_input-MOCK-GUID"
+                          name="radio_input-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
+                        >
+                          <span>
+                            No
+                          </span>
+                        </label>
                       </div>
                     </div>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="not-complete"
+        >
+          <hr
+            className="section-divider"
+          />
+          <div
+            aria-label="Before you leave this section"
+            className="field   no-margin-bottom"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h4
+              className="title h4"
+            >
+              Before you leave this section
+            </h4>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div>
+                    <p>
+                      <strong>
+                        The full 10 year period of residence history is not covered.
+                      </strong>
+                       Your SF86 cannot be submitted until all 10 years are covered with no gaps.
+                      <span
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<br>",
+                          }
+                        }
+                      />
+                      <span
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<br>",
+                          }
+                        }
+                      />
+                      We will mark the gaps and highlight them for you when you come back.
+                    </p>
                   </div>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="bottom-btns"
+      >
+        <div
+          className="btn-wrap"
+        >
+          <div
+            className="btn-container"
+          >
+            <button
+              aria-label="Go to previous section History intro"
+              className="btn-cell back"
+              onClick={[Function]}
+              title="Go to previous section History intro"
+            >
+              <div
+                className="actions back"
+              >
+                <div
+                  className="icon"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-arrow-circle-left"
+                  />
                 </div>
                 <div
-                  className="bottom-btns"
+                  className="text"
                 >
                   <div
-                    className="btn-wrap"
+                    className="direction"
                   >
-                    <div
-                      className="btn-container"
-                    >
-                      <button
-                        aria-label="Go to previous section History intro"
-                        className="btn-cell back"
-                        onClick={[Function]}
-                        title="Go to previous section History intro"
-                      >
-                        <div
-                          className="actions back"
-                        >
-                          <div
-                            className="icon"
-                          >
-                            <i
-                              aria-hidden="true"
-                              className="fa fa-arrow-circle-left"
-                            />
-                          </div>
-                          <div
-                            className="text"
-                          >
-                            <div
-                              className="direction"
-                            >
-                              Back
-                            </div>
-                            <div
-                              className="label"
-                            >
-                              History intro
-                            </div>
-                          </div>
-                        </div>
-                      </button>
-                      <div
-                        className="btn-spacer"
-                      />
-                      <button
-                        aria-label="Go to next section Employment history"
-                        className="btn-cell next"
-                        onClick={[Function]}
-                        title="Go to next section Employment history"
-                      >
-                        <div
-                          className="actions next"
-                        >
-                          <div
-                            className="text"
-                          >
-                            <div
-                              className="direction"
-                            >
-                              Next
-                            </div>
-                            <div
-                              className="label"
-                            >
-                              Employment history
-                            </div>
-                          </div>
-                          <div
-                            className="icon"
-                          >
-                            <i
-                              aria-hidden="true"
-                              className="fa fa-arrow-circle-right"
-                            />
-                          </div>
-                        </div>
-                      </button>
-                    </div>
+                    Back
+                  </div>
+                  <div
+                    className="label"
+                  >
+                    History intro
                   </div>
                 </div>
               </div>
-            </div>
+            </button>
+            <div
+              className="btn-spacer"
+            />
+            <button
+              aria-label="Go to next section Employment history"
+              className="btn-cell next"
+              onClick={[Function]}
+              title="Go to next section Employment history"
+            >
+              <div
+                className="actions next"
+              >
+                <div
+                  className="text"
+                >
+                  <div
+                    className="direction"
+                  >
+                    Next
+                  </div>
+                  <div
+                    className="label"
+                  >
+                    Employment history
+                  </div>
+                </div>
+                <div
+                  className="icon"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-arrow-circle-right"
+                  />
+                </div>
+              </div>
+            </button>
           </div>
         </div>
       </div>
@@ -10571,1100 +10501,1068 @@ exports[`The section component renders history.residence 1`] = `
 `;
 
 exports[`The section component renders history.review 1`] = `
-<div>
+<div
+  className="history"
+>
   <div
     className="section-view"
   >
-    <div
-      className="view view-history"
+    <h1
+      className="title"
     >
+      Review your answers
+    </h1>
+    <div>
+      <p>
+        View the full section to make sure everything looks right and make changes if needed.
+      </p>
+    </div>
+    <div
+      className="view view-review"
+    >
+      <div
+        className="top-btns"
+      />
       <div>
         <div
-          className="history"
+          className="summary-progress residence"
+        >
+          <div
+            className="content"
+          >
+            <div>
+              <div
+                className="summary-icon"
+              >
+                <img
+                  alt="Years covered for locations you have lived"
+                  className="svg"
+                  src="/img/residence-house.svg"
+                />
+              </div>
+              <span
+                className="title"
+              >
+                Where you have lived
+              </span>
+            </div>
+            <div
+              className="progress"
+            />
+          </div>
+          <div
+            className="stats"
+          >
+            <div
+              className="fraction"
+            >
+              <span
+                className="completed"
+              >
+                0
+              </span>
+              <span
+                className="slash"
+              >
+                /
+              </span>
+              <span
+                className="total"
+              >
+                10
+              </span>
+            </div>
+            <span
+              className="unit"
+            >
+              Years covered
+            </span>
+          </div>
+        </div>
+        <div
+          className="summary-progress residence"
+        >
+          <div
+            className="content"
+          >
+            <div>
+              <div
+                className="summary-icon"
+              >
+                <img
+                  alt="Years covered for your employment activities"
+                  className="svg"
+                  src="/img/employer-briefcase.svg"
+                />
+              </div>
+              <span
+                className="title"
+              >
+                Employment activities
+              </span>
+            </div>
+            <div
+              className="progress"
+            />
+          </div>
+          <div
+            className="stats"
+          >
+            <div
+              className="fraction"
+            >
+              <span
+                className="completed"
+              >
+                0
+              </span>
+              <span
+                className="slash"
+              >
+                /
+              </span>
+              <span
+                className="total"
+              >
+                10
+              </span>
+            </div>
+            <span
+              className="unit"
+            >
+              Years covered
+            </span>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <h1
+          className="section-header"
+        >
+          Where you have lived
+        </h1>
+        <div
+          className="section-content residence"
+          data-section="history"
+          data-subsection="residence"
         >
           <div>
             <div
-              className="section-view"
+              className="accordion"
             >
-              <h1
-                className="title"
+              <strong
+                className="aria-description"
               >
-                Review your answers
-              </h1>
-              <div>
-                <p>
-                  View the full section to make sure everything looks right and make changes if needed.
-                </p>
+                Summary of places you have lived
+              </strong>
+              <div
+                className="items"
+              />
+              <div
+                className="append-button"
+              />
+            </div>
+            <div
+              aria-label="Do you have an additional residence to report?"
+              className="field required  branch addendum"
+              data-uuid="field-MOCK-GUID"
+            >
+              <a
+                aria-hidden="true"
+                className="anchor"
+                id="field-MOCK-GUID"
+                name="field-MOCK-GUID"
+              />
+              <h4
+                className="title h4"
+              >
+                Do you have an additional residence to report?
+              </h4>
+              <span
+                className="icon"
+              />
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages help-messages"
+                />
               </div>
               <div
-                className="view view-review"
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages error-messages"
+                  role="alert"
+                >
+                  <div
+                    aria-live="polite"
+                    className="message error usa-alert usa-alert-error"
+                    role="alert"
+                  >
+                    <div
+                      className="usa-alert-body"
+                    >
+                      <div
+                        data-i18n="error.required"
+                      >
+                        <h5
+                          className="usa-alert-heading"
+                        >
+                          Your response is required
+                        </h5>
+                        
+                        
+                      </div>
+                    </div>
+                  </div>
+                </span>
+              </div>
+              <div
+                className="table"
+              >
+                <span
+                  className="content"
+                >
+                  <span
+                    className="component shrink"
+                  >
+                    <div
+                      className="content"
+                    />
+                    <div
+                      className="blocks option-list branch usa-input-error"
+                    >
+                      <div
+                        className="yes block"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="radio_input-MOCK-GUID"
+                          name="radio_input-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
+                        >
+                          <span>
+                            Yes
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="no block"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="radio_input-MOCK-GUID"
+                          name="radio_input-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
+                        >
+                          <span>
+                            No
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <h1
+          className="section-header"
+        >
+          Employment activities
+        </h1>
+        <div
+          className="section-content employment"
+          data-section="history"
+          data-subsection="employment"
+        >
+          <div>
+            <div
+              className="accordion"
+            >
+              <strong
+                className="aria-description"
+              >
+                Summary of your work history
+              </strong>
+              <div
+                className="items"
+              />
+              <div
+                className="append-button"
+              />
+            </div>
+            <div
+              aria-label="Do you have an additional employment activity to enter?"
+              className="field required  branch addendum no-margin-bottom"
+              data-uuid="field-MOCK-GUID"
+            >
+              <a
+                aria-hidden="true"
+                className="anchor"
+                id="field-MOCK-GUID"
+                name="field-MOCK-GUID"
+              />
+              <h4
+                className="title h4"
+              >
+                Do you have an additional employment activity to enter?
+              </h4>
+              <span
+                className="icon"
+              />
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages help-messages"
+                />
+              </div>
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages error-messages"
+                  role="alert"
+                >
+                  <div
+                    aria-live="polite"
+                    className="message error usa-alert usa-alert-error"
+                    role="alert"
+                  >
+                    <div
+                      className="usa-alert-body"
+                    >
+                      <div
+                        data-i18n="error.required"
+                      >
+                        <h5
+                          className="usa-alert-heading"
+                        >
+                          Your response is required
+                        </h5>
+                        
+                        
+                      </div>
+                    </div>
+                  </div>
+                </span>
+              </div>
+              <div
+                className="table"
+              >
+                <span
+                  className="content"
+                >
+                  <span
+                    className="component shrink"
+                  >
+                    <div
+                      className="content"
+                    />
+                    <div
+                      className="blocks option-list branch usa-input-error"
+                    >
+                      <div
+                        className="yes block"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="radio_input-MOCK-GUID"
+                          name="radio_input-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
+                        >
+                          <span>
+                            Yes
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="no block"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="radio_input-MOCK-GUID"
+                          name="radio_input-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <label
+                          className=""
+                          htmlFor="radio_input-MOCK-GUID"
+                        >
+                          <span>
+                            No
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+          <hr
+            className="section-divider"
+          />
+          <div
+            aria-label="Have any of the following happened to you in the last seven (7) years at employment activities that you have not previously listed?"
+            className="field required  branch employment-record"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h4
+              className="title h4"
+            >
+              Have any of the following happened to you in the last seven (7) years at employment activities that you have not previously listed?
+            </h4>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
               >
                 <div
-                  className="top-btns"
-                />
-                <div>
+                  aria-live="polite"
+                  className="message error usa-alert usa-alert-error"
+                  role="alert"
+                >
                   <div
-                    className="summary-progress residence"
+                    className="usa-alert-body"
                   >
                     <div
-                      className="content"
+                      data-i18n="error.required"
                     >
-                      <div>
-                        <div
-                          className="summary-icon"
-                        >
-                          <img
-                            alt="Years covered for locations you have lived"
-                            className="svg"
-                            src="/img/residence-house.svg"
-                          />
-                        </div>
-                        <span
-                          className="title"
-                        >
-                          Where you have lived
-                        </span>
-                      </div>
-                      <div
-                        className="progress"
-                      />
-                    </div>
-                    <div
-                      className="stats"
-                    >
-                      <div
-                        className="fraction"
+                      <h5
+                        className="usa-alert-heading"
                       >
-                        <span
-                          className="completed"
-                        >
-                          0
-                        </span>
-                        <span
-                          className="slash"
-                        >
-                          /
-                        </span>
-                        <span
-                          className="total"
-                        >
-                          10
-                        </span>
-                      </div>
-                      <span
-                        className="unit"
-                      >
-                        Years covered
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="summary-progress residence"
-                  >
-                    <div
-                      className="content"
-                    >
-                      <div>
-                        <div
-                          className="summary-icon"
-                        >
-                          <img
-                            alt="Years covered for your employment activities"
-                            className="svg"
-                            src="/img/employer-briefcase.svg"
-                          />
-                        </div>
-                        <span
-                          className="title"
-                        >
-                          Employment activities
-                        </span>
-                      </div>
-                      <div
-                        className="progress"
-                      />
-                    </div>
-                    <div
-                      className="stats"
-                    >
-                      <div
-                        className="fraction"
-                      >
-                        <span
-                          className="completed"
-                        >
-                          0
-                        </span>
-                        <span
-                          className="slash"
-                        >
-                          /
-                        </span>
-                        <span
-                          className="total"
-                        >
-                          10
-                        </span>
-                      </div>
-                      <span
-                        className="unit"
-                      >
-                        Years covered
-                      </span>
-                    </div>
-                  </div>
-                  <hr
-                    className="section-divider"
-                  />
-                  <h1
-                    className="section-header"
-                  >
-                    Where you have lived
-                  </h1>
-                  <div
-                    className="section-content residence"
-                    data-section="history"
-                    data-subsection="residence"
-                  >
-                    <div>
-                      <div
-                        className="accordion"
-                      >
-                        <strong
-                          className="aria-description"
-                        >
-                          Summary of places you have lived
-                        </strong>
-                        <div
-                          className="items"
-                        />
-                        <div
-                          className="append-button"
-                        />
-                      </div>
-                      <div
-                        aria-label="Do you have an additional residence to report?"
-                        className="field required  branch addendum"
-                        data-uuid="field-MOCK-GUID"
-                      >
-                        <a
-                          aria-hidden="true"
-                          className="anchor"
-                          id="field-MOCK-GUID"
-                          name="field-MOCK-GUID"
-                        />
-                        <h4
-                          className="title h4"
-                        >
-                          Do you have an additional residence to report?
-                        </h4>
-                        <span
-                          className="icon"
-                        />
-                        <div
-                          className="table expand"
-                        >
-                          <span
-                            aria-live="polite"
-                            className="messages help-messages"
-                          />
-                        </div>
-                        <div
-                          className="table expand"
-                        >
-                          <span
-                            aria-live="polite"
-                            className="messages error-messages"
-                            role="alert"
-                          >
-                            <div
-                              aria-live="polite"
-                              className="message error usa-alert usa-alert-error"
-                              role="alert"
-                            >
-                              <div
-                                className="usa-alert-body"
-                              >
-                                <div
-                                  data-i18n="error.required"
-                                >
-                                  <h5
-                                    className="usa-alert-heading"
-                                  >
-                                    Your response is required
-                                  </h5>
-                                  
-                                  
-                                </div>
-                              </div>
-                            </div>
-                          </span>
-                        </div>
-                        <div
-                          className="table"
-                        >
-                          <span
-                            className="content"
-                          >
-                            <span
-                              className="component shrink"
-                            >
-                              <div
-                                className="content"
-                              />
-                              <div
-                                className="blocks option-list branch usa-input-error"
-                              >
-                                <div
-                                  className="yes block"
-                                >
-                                  <input
-                                    aria-label="Yes for null"
-                                    checked={false}
-                                    className="usa-input-success"
-                                    disabled={false}
-                                    id="radio_input-MOCK-GUID"
-                                    name="radio_input-MOCK-GUID"
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    type="radio"
-                                    value="Yes"
-                                  />
-                                  <label
-                                    className=""
-                                    htmlFor="radio_input-MOCK-GUID"
-                                  >
-                                    <span>
-                                      Yes
-                                    </span>
-                                  </label>
-                                </div>
-                                <div
-                                  className="no block"
-                                >
-                                  <input
-                                    aria-label="No for null"
-                                    checked={false}
-                                    className="usa-input-success"
-                                    disabled={false}
-                                    id="radio_input-MOCK-GUID"
-                                    name="radio_input-MOCK-GUID"
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    type="radio"
-                                    value="No"
-                                  />
-                                  <label
-                                    className=""
-                                    htmlFor="radio_input-MOCK-GUID"
-                                  >
-                                    <span>
-                                      No
-                                    </span>
-                                  </label>
-                                </div>
-                              </div>
-                            </span>
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <hr
-                    className="section-divider"
-                  />
-                  <h1
-                    className="section-header"
-                  >
-                    Employment activities
-                  </h1>
-                  <div
-                    className="section-content employment"
-                    data-section="history"
-                    data-subsection="employment"
-                  >
-                    <div>
-                      <div
-                        className="accordion"
-                      >
-                        <strong
-                          className="aria-description"
-                        >
-                          Summary of your work history
-                        </strong>
-                        <div
-                          className="items"
-                        />
-                        <div
-                          className="append-button"
-                        />
-                      </div>
-                      <div
-                        aria-label="Do you have an additional employment activity to enter?"
-                        className="field required  branch addendum no-margin-bottom"
-                        data-uuid="field-MOCK-GUID"
-                      >
-                        <a
-                          aria-hidden="true"
-                          className="anchor"
-                          id="field-MOCK-GUID"
-                          name="field-MOCK-GUID"
-                        />
-                        <h4
-                          className="title h4"
-                        >
-                          Do you have an additional employment activity to enter?
-                        </h4>
-                        <span
-                          className="icon"
-                        />
-                        <div
-                          className="table expand"
-                        >
-                          <span
-                            aria-live="polite"
-                            className="messages help-messages"
-                          />
-                        </div>
-                        <div
-                          className="table expand"
-                        >
-                          <span
-                            aria-live="polite"
-                            className="messages error-messages"
-                            role="alert"
-                          >
-                            <div
-                              aria-live="polite"
-                              className="message error usa-alert usa-alert-error"
-                              role="alert"
-                            >
-                              <div
-                                className="usa-alert-body"
-                              >
-                                <div
-                                  data-i18n="error.required"
-                                >
-                                  <h5
-                                    className="usa-alert-heading"
-                                  >
-                                    Your response is required
-                                  </h5>
-                                  
-                                  
-                                </div>
-                              </div>
-                            </div>
-                          </span>
-                        </div>
-                        <div
-                          className="table"
-                        >
-                          <span
-                            className="content"
-                          >
-                            <span
-                              className="component shrink"
-                            >
-                              <div
-                                className="content"
-                              />
-                              <div
-                                className="blocks option-list branch usa-input-error"
-                              >
-                                <div
-                                  className="yes block"
-                                >
-                                  <input
-                                    aria-label="Yes for null"
-                                    checked={false}
-                                    className="usa-input-success"
-                                    disabled={false}
-                                    id="radio_input-MOCK-GUID"
-                                    name="radio_input-MOCK-GUID"
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    type="radio"
-                                    value="Yes"
-                                  />
-                                  <label
-                                    className=""
-                                    htmlFor="radio_input-MOCK-GUID"
-                                  >
-                                    <span>
-                                      Yes
-                                    </span>
-                                  </label>
-                                </div>
-                                <div
-                                  className="no block"
-                                >
-                                  <input
-                                    aria-label="No for null"
-                                    checked={false}
-                                    className="usa-input-success"
-                                    disabled={false}
-                                    id="radio_input-MOCK-GUID"
-                                    name="radio_input-MOCK-GUID"
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    type="radio"
-                                    value="No"
-                                  />
-                                  <label
-                                    className=""
-                                    htmlFor="radio_input-MOCK-GUID"
-                                  >
-                                    <span>
-                                      No
-                                    </span>
-                                  </label>
-                                </div>
-                              </div>
-                            </span>
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                    <hr
-                      className="section-divider"
-                    />
-                    <div
-                      aria-label="Have any of the following happened to you in the last seven (7) years at employment activities that you have not previously listed?"
-                      className="field required  branch employment-record"
-                      data-uuid="field-MOCK-GUID"
-                    >
-                      <a
-                        aria-hidden="true"
-                        className="anchor"
-                        id="field-MOCK-GUID"
-                        name="field-MOCK-GUID"
-                      />
-                      <h4
-                        className="title h4"
-                      >
-                        Have any of the following happened to you in the last seven (7) years at employment activities that you have not previously listed?
-                      </h4>
-                      <span
-                        className="icon"
-                      />
-                      <div
-                        className="table expand"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="messages help-messages"
-                        />
-                      </div>
-                      <div
-                        className="table expand"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="messages error-messages"
-                          role="alert"
-                        >
-                          <div
-                            aria-live="polite"
-                            className="message error usa-alert usa-alert-error"
-                            role="alert"
-                          >
-                            <div
-                              className="usa-alert-body"
-                            >
-                              <div
-                                data-i18n="error.required"
-                              >
-                                <h5
-                                  className="usa-alert-heading"
-                                >
-                                  Your response is required
-                                </h5>
-                                
-                                
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </div>
-                      <div
-                        className="table"
-                      >
-                        <span
-                          className="content"
-                        >
-                          <span
-                            className="component shrink"
-                          >
-                            <div
-                              className="content"
-                            >
-                              <div>
-                                <ul>
-                                  <li>
-                                    Fired from a job?
-                                  </li>
-                                </ul>
-                              </div>
-                              <div>
-                                <ul>
-                                  <li>
-                                    Quit a job after being told you would be fired?
-                                  </li>
-                                </ul>
-                              </div>
-                              <div>
-                                <ul>
-                                  <li>
-                                    Have you left a job by mutual agreement following charges or allegations of misconduct?
-                                  </li>
-                                </ul>
-                              </div>
-                              <div>
-                                <ul>
-                                  <li>
-                                    Left a job by mutual agreement following notice of unsatisfactory performance?
-                                  </li>
-                                </ul>
-                              </div>
-                              <div>
-                                <ul>
-                                  <li>
-                                    Received a written warning, been officially reprimanded, suspended, or disciplined for misconduct in the workplace, such as violation of security policy?
-                                  </li>
-                                </ul>
-                              </div>
-                              <div>
-                                <p>
-                                  If you answer "Yes", you will be required to add an additional employment record above.
-                                </p>
-                              </div>
-                            </div>
-                            <div
-                              className="blocks option-list branch usa-input-error"
-                            >
-                              <div
-                                className="yes block"
-                              >
-                                <input
-                                  aria-label="Yes for null"
-                                  checked={false}
-                                  className="usa-input-success"
-                                  disabled={false}
-                                  id="radio_input-MOCK-GUID"
-                                  name="radio_input-MOCK-GUID"
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  type="radio"
-                                  value="Yes"
-                                />
-                                <label
-                                  className=""
-                                  htmlFor="radio_input-MOCK-GUID"
-                                >
-                                  <span>
-                                    Yes
-                                  </span>
-                                </label>
-                              </div>
-                              <div
-                                className="no block"
-                              >
-                                <input
-                                  aria-label="No for null"
-                                  checked={false}
-                                  className="usa-input-success"
-                                  disabled={false}
-                                  id="radio_input-MOCK-GUID"
-                                  name="radio_input-MOCK-GUID"
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  type="radio"
-                                  value="No"
-                                />
-                                <label
-                                  className=""
-                                  htmlFor="radio_input-MOCK-GUID"
-                                >
-                                  <span>
-                                    No
-                                  </span>
-                                </label>
-                              </div>
-                            </div>
-                          </span>
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <hr
-                    className="section-divider"
-                  />
-                  <h1
-                    className="section-header"
-                  >
-                    Where you went to school
-                  </h1>
-                  <div
-                    aria-label="List the places you went to school"
-                    className="field   no-margin-bottom"
-                    data-uuid="field-MOCK-GUID"
-                  >
-                    <a
-                      aria-hidden="true"
-                      className="anchor"
-                      id="field-MOCK-GUID"
-                      name="field-MOCK-GUID"
-                    />
-                    <h4
-                      className="title h4"
-                    >
-                      List the places you went to school
-                    </h4>
-                    <span
-                      className="icon"
-                    />
-                    <div
-                      className="table expand"
-                    >
-                      <span
-                        aria-live="polite"
-                        className="messages help-messages"
-                      />
-                    </div>
-                    <div
-                      className="table expand"
-                    >
-                      <span
-                        aria-live="polite"
-                        className="messages error-messages"
-                        role="alert"
-                      />
-                    </div>
-                    <div
-                      className="table"
-                    >
-                      <span
-                        className="content"
-                      >
-                        <span
-                          className="component"
-                        >
-                          <div>
-                            <p>
-                              Do not list education before your 18th birthday, unless to provide a minimum of two years education history.
-                            </p>
-                          </div>
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="Have you attended any schools in the last 10 years?"
-                    className="field required  branch"
-                    data-uuid="field-MOCK-GUID"
-                  >
-                    <a
-                      aria-hidden="true"
-                      className="anchor"
-                      id="field-MOCK-GUID"
-                      name="field-MOCK-GUID"
-                    />
-                    <h3
-                      className="title h3"
-                    >
-                      Have you attended any schools in the last 10 years?
-                    </h3>
-                    <span
-                      className="icon"
-                    >
-                      <a
-                        aria-label="Show help for Have you attended any schools in the last 10 years?"
-                        className="toggle h3  adjust-for-buttons"
-                        href="javascript:;"
-                        onClick={[Function]}
-                        title="Show help for Have you attended any schools in the last 10 years?"
-                      >
-                        <svg
-                          alt="Scalable vector graphic"
-                          focusable="false"
-                          height="14.57px"
-                          tabIndex="-1"
-                          viewBox="0 0 14.57 14.57"
-                          width="14.57px"
-                        >
-                          <g>
-                            <path
-                              className="eapp-help-icon"
-                              d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
-                            />
-                          </g>
-                        </svg>
-                      </a>
-                    </span>
-                    <div
-                      className="table expand"
-                    >
-                      <span
-                        aria-live="polite"
-                        className="messages help-messages"
-                      />
-                    </div>
-                    <div
-                      className="table expand"
-                    >
-                      <span
-                        aria-live="polite"
-                        className="messages error-messages"
-                        role="alert"
-                      />
-                    </div>
-                    <div
-                      className="table"
-                    >
-                      <span
-                        className="content"
-                      >
-                        <span
-                          className="component shrink"
-                        >
-                          <div
-                            className="content"
-                          />
-                          <div
-                            className="blocks option-list branch"
-                          >
-                            <div
-                              className="yes block"
-                            >
-                              <input
-                                aria-label="Yes for null"
-                                checked={false}
-                                className="usa-input-success"
-                                disabled={false}
-                                id="branch_school-MOCK-GUID"
-                                name="branch_school-MOCK-GUID"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onKeyDown={[Function]}
-                                type="radio"
-                                value="Yes"
-                              />
-                              <label
-                                className=""
-                                htmlFor="branch_school-MOCK-GUID"
-                              >
-                                <span>
-                                  Yes
-                                </span>
-                              </label>
-                            </div>
-                            <div
-                              className="no block"
-                            >
-                              <input
-                                aria-label="No for null"
-                                checked={false}
-                                className="usa-input-success"
-                                disabled={false}
-                                id="branch_school-MOCK-GUID"
-                                name="branch_school-MOCK-GUID"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onKeyDown={[Function]}
-                                type="radio"
-                                value="No"
-                              />
-                              <label
-                                className=""
-                                htmlFor="branch_school-MOCK-GUID"
-                              >
-                                <span>
-                                  No
-                                </span>
-                              </label>
-                            </div>
-                          </div>
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                  <hr
-                    className="section-divider"
-                  />
-                  <h1
-                    className="section-header"
-                  >
-                    Former federal service
-                  </h1>
-                  <div
-                    className="section-content federal"
-                    data-section="history"
-                    data-subsection="federal"
-                  >
-                    <div
-                      aria-label="Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
-                      className="field required  branch"
-                      data-uuid="field-MOCK-GUID"
-                    >
-                      <a
-                        aria-hidden="true"
-                        className="anchor"
-                        id="field-MOCK-GUID"
-                        name="field-MOCK-GUID"
-                      />
-                      <h4
-                        className="title h4"
-                      >
-                        Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?
-                      </h4>
-                      <span
-                        className="icon"
-                      >
-                        <a
-                          aria-label="Show help for Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
-                          className="toggle h4  adjust-for-buttons"
-                          href="javascript:;"
-                          onClick={[Function]}
-                          title="Show help for Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
-                        >
-                          <svg
-                            alt="Scalable vector graphic"
-                            focusable="false"
-                            height="14.57px"
-                            tabIndex="-1"
-                            viewBox="0 0 14.57 14.57"
-                            width="14.57px"
-                          >
-                            <g>
-                              <path
-                                className="eapp-help-icon"
-                                d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
-                              />
-                            </g>
-                          </svg>
-                        </a>
-                      </span>
-                      <div
-                        className="table expand"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="messages help-messages"
-                        />
-                      </div>
-                      <div
-                        className="table expand"
-                      >
-                        <span
-                          aria-live="polite"
-                          className="messages error-messages"
-                          role="alert"
-                        >
-                          <div
-                            aria-live="polite"
-                            className="message error usa-alert usa-alert-error"
-                            role="alert"
-                          >
-                            <div
-                              className="usa-alert-body"
-                            >
-                              <div
-                                data-i18n="error.required"
-                              >
-                                <h5
-                                  className="usa-alert-heading"
-                                >
-                                  Your response is required
-                                </h5>
-                                
-                                
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </div>
-                      <div
-                        className="table"
-                      >
-                        <span
-                          className="content"
-                        >
-                          <span
-                            className="component shrink"
-                          >
-                            <div
-                              className="content"
-                            />
-                            <div
-                              className="blocks option-list branch usa-input-error"
-                            >
-                              <div
-                                className="yes block"
-                              >
-                                <input
-                                  aria-label="Yes for null"
-                                  checked={false}
-                                  className="usa-input-success"
-                                  disabled={false}
-                                  id="has_federalservice-MOCK-GUID"
-                                  name="has_federalservice-MOCK-GUID"
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  type="radio"
-                                  value="Yes"
-                                />
-                                <label
-                                  className=""
-                                  htmlFor="has_federalservice-MOCK-GUID"
-                                >
-                                  <span>
-                                    Yes
-                                  </span>
-                                </label>
-                              </div>
-                              <div
-                                className="no block"
-                              >
-                                <input
-                                  aria-label="No for null"
-                                  checked={false}
-                                  className="usa-input-success"
-                                  disabled={false}
-                                  id="has_federalservice-MOCK-GUID"
-                                  name="has_federalservice-MOCK-GUID"
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  type="radio"
-                                  value="No"
-                                />
-                                <label
-                                  className=""
-                                  htmlFor="has_federalservice-MOCK-GUID"
-                                >
-                                  <span>
-                                    No
-                                  </span>
-                                </label>
-                              </div>
-                            </div>
-                          </span>
-                        </span>
-                      </div>
+                        Your response is required
+                      </h5>
+                      
+                      
                     </div>
                   </div>
                 </div>
-                <div
-                  className="bottom-btns"
+              </span>
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
                 >
                   <div
-                    className="btn-wrap"
+                    className="content"
+                  >
+                    <div>
+                      <ul>
+                        <li>
+                          Fired from a job?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <ul>
+                        <li>
+                          Quit a job after being told you would be fired?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <ul>
+                        <li>
+                          Have you left a job by mutual agreement following charges or allegations of misconduct?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <ul>
+                        <li>
+                          Left a job by mutual agreement following notice of unsatisfactory performance?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <ul>
+                        <li>
+                          Received a written warning, been officially reprimanded, suspended, or disciplined for misconduct in the workplace, such as violation of security policy?
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <p>
+                        If you answer "Yes", you will be required to add an additional employment record above.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="blocks option-list branch usa-input-error"
                   >
                     <div
-                      className="btn-container"
+                      className="yes block"
                     >
-                      <button
-                        aria-label="Go to previous section Former federal service"
-                        className="btn-cell back"
+                      <input
+                        aria-label="Yes for null"
+                        checked={false}
+                        className="usa-input-success"
+                        disabled={false}
+                        id="radio_input-MOCK-GUID"
+                        name="radio_input-MOCK-GUID"
+                        onBlur={[Function]}
+                        onChange={[Function]}
                         onClick={[Function]}
-                        title="Go to previous section Former federal service"
-                      >
-                        <div
-                          className="actions back"
-                        >
-                          <div
-                            className="icon"
-                          >
-                            <i
-                              aria-hidden="true"
-                              className="fa fa-arrow-circle-left"
-                            />
-                          </div>
-                          <div
-                            className="text"
-                          >
-                            <div
-                              className="direction"
-                            >
-                              Back
-                            </div>
-                            <div
-                              className="label"
-                            >
-                              Former federal service
-                            </div>
-                          </div>
-                        </div>
-                      </button>
-                      <div
-                        className="btn-spacer"
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        type="radio"
+                        value="Yes"
                       />
-                      <button
-                        aria-label="Go to next section Relationships intro"
-                        className="btn-cell next"
-                        onClick={[Function]}
-                        title="Go to next section Relationships intro"
+                      <label
+                        className=""
+                        htmlFor="radio_input-MOCK-GUID"
                       >
-                        <div
-                          className="actions next"
-                        >
-                          <div
-                            className="text"
-                          >
-                            <div
-                              className="direction"
-                            >
-                              Next
-                            </div>
-                            <div
-                              className="label"
-                            >
-                              Relationships intro
-                            </div>
-                          </div>
-                          <div
-                            className="icon"
-                          >
-                            <i
-                              aria-hidden="true"
-                              className="fa fa-arrow-circle-right"
-                            />
-                          </div>
-                        </div>
-                      </button>
+                        <span>
+                          Yes
+                        </span>
+                      </label>
                     </div>
+                    <div
+                      className="no block"
+                    >
+                      <input
+                        aria-label="No for null"
+                        checked={false}
+                        className="usa-input-success"
+                        disabled={false}
+                        id="radio_input-MOCK-GUID"
+                        name="radio_input-MOCK-GUID"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        type="radio"
+                        value="No"
+                      />
+                      <label
+                        className=""
+                        htmlFor="radio_input-MOCK-GUID"
+                      >
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <h1
+          className="section-header"
+        >
+          Where you went to school
+        </h1>
+        <div>
+          <div
+            aria-label="List the places you went to school"
+            className="field   no-margin-bottom"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h4
+              className="title h4"
+            >
+              List the places you went to school
+            </h4>
+            <span
+              className="icon"
+            />
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component"
+                >
+                  <div>
+                    <p>
+                      Do not list education before your 18th birthday, unless to provide a minimum of two years education history.
+                    </p>
+                  </div>
+                </span>
+              </span>
+            </div>
+          </div>
+          <div
+            aria-label="Have you attended any schools in the last 10 years?"
+            className="field required  branch"
+            data-uuid="field-MOCK-GUID"
+          >
+            <a
+              aria-hidden="true"
+              className="anchor"
+              id="field-MOCK-GUID"
+              name="field-MOCK-GUID"
+            />
+            <h3
+              className="title h3"
+            >
+              Have you attended any schools in the last 10 years?
+            </h3>
+            <span
+              className="icon"
+            >
+              <a
+                aria-label="Show help for Have you attended any schools in the last 10 years?"
+                className="toggle h3  adjust-for-buttons"
+                href="javascript:;"
+                onClick={[Function]}
+                title="Show help for Have you attended any schools in the last 10 years?"
+              >
+                <svg
+                  alt="Scalable vector graphic"
+                  focusable="false"
+                  height="14.57px"
+                  tabIndex="-1"
+                  viewBox="0 0 14.57 14.57"
+                  width="14.57px"
+                >
+                  <g>
+                    <path
+                      className="eapp-help-icon"
+                      d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                    />
+                  </g>
+                </svg>
+              </a>
+            </span>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages help-messages"
+              />
+            </div>
+            <div
+              className="table expand"
+            >
+              <span
+                aria-live="polite"
+                className="messages error-messages"
+                role="alert"
+              />
+            </div>
+            <div
+              className="table"
+            >
+              <span
+                className="content"
+              >
+                <span
+                  className="component shrink"
+                >
+                  <div
+                    className="content"
+                  />
+                  <div
+                    className="blocks option-list branch"
+                  >
+                    <div
+                      className="yes block"
+                    >
+                      <input
+                        aria-label="Yes for null"
+                        checked={false}
+                        className="usa-input-success"
+                        disabled={false}
+                        id="branch_school-MOCK-GUID"
+                        name="branch_school-MOCK-GUID"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        type="radio"
+                        value="Yes"
+                      />
+                      <label
+                        className=""
+                        htmlFor="branch_school-MOCK-GUID"
+                      >
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="no block"
+                    >
+                      <input
+                        aria-label="No for null"
+                        checked={false}
+                        className="usa-input-success"
+                        disabled={false}
+                        id="branch_school-MOCK-GUID"
+                        name="branch_school-MOCK-GUID"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        type="radio"
+                        value="No"
+                      />
+                      <label
+                        className=""
+                        htmlFor="branch_school-MOCK-GUID"
+                      >
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <hr
+          className="section-divider"
+        />
+        <div>
+          <h1
+            className="section-header"
+          >
+            Former federal service
+          </h1>
+          <div
+            className="section-content federal"
+            data-section="history"
+            data-subsection="federal"
+          >
+            <div
+              aria-label="Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
+              className="field required  branch"
+              data-uuid="field-MOCK-GUID"
+            >
+              <a
+                aria-hidden="true"
+                className="anchor"
+                id="field-MOCK-GUID"
+                name="field-MOCK-GUID"
+              />
+              <h4
+                className="title h4"
+              >
+                Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?
+              </h4>
+              <span
+                className="icon"
+              >
+                <a
+                  aria-label="Show help for Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
+                  className="toggle h4  adjust-for-buttons"
+                  href="javascript:;"
+                  onClick={[Function]}
+                  title="Show help for Do you have former federal civilian employment, excluding military service, NOT indicated previously, to report?"
+                >
+                  <svg
+                    alt="Scalable vector graphic"
+                    focusable="false"
+                    height="14.57px"
+                    tabIndex="-1"
+                    viewBox="0 0 14.57 14.57"
+                    width="14.57px"
+                  >
+                    <g>
+                      <path
+                        className="eapp-help-icon"
+                        d="M13.59,3.63c0.65,1.12,0.98,2.34,0.98,3.66s-0.33,2.54-0.98,3.66c-0.65,1.12-1.54,2-2.65,2.65 s-2.33,0.98-3.66,0.98c-1.32,0-2.54-0.33-3.66-0.98s-2-1.54-2.65-2.65C0.33,9.83,0,8.61,0,7.29s0.33-2.54,0.98-3.66 c0.65-1.12,1.54-2,2.65-2.65S5.96,0,7.29,0c1.32,0,2.54,0.33,3.66,0.98S12.94,2.51,13.59,3.63z M10.93,5.46 c0-0.56-0.18-1.07-0.53-1.55c-0.35-0.47-0.79-0.84-1.31-1.1C8.56,2.56,8.03,2.43,7.48,2.43c-1.54,0-2.71,0.67-3.52,2.02 C3.86,4.6,3.89,4.73,4.03,4.85L5.28,5.8c0.04,0.04,0.1,0.06,0.18,0.06c0.1,0,0.18-0.04,0.24-0.11c0.33-0.43,0.61-0.72,0.82-0.87 C6.73,4.71,7,4.64,7.33,4.64c0.3,0,0.57,0.08,0.81,0.25C8.38,5.05,8.5,5.24,8.5,5.45c0,0.24-0.06,0.43-0.19,0.58 C8.18,6.17,7.97,6.31,7.67,6.45C7.27,6.63,6.9,6.9,6.57,7.27c-0.33,0.37-0.5,0.77-0.5,1.19V8.8c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.09,0.22,0.09H8.2c0.09,0,0.16-0.03,0.22-0.09C8.47,8.96,8.5,8.89,8.5,8.8c0-0.12,0.07-0.28,0.2-0.47 c0.14-0.19,0.31-0.35,0.52-0.47c0.2-0.11,0.36-0.21,0.46-0.27s0.25-0.18,0.44-0.33c0.18-0.15,0.32-0.31,0.42-0.46 c0.1-0.15,0.19-0.34,0.27-0.57C10.89,6,10.93,5.74,10.93,5.46z M8.5,11.84v-1.82c0-0.09-0.03-0.16-0.08-0.22 C8.36,9.74,8.29,9.71,8.2,9.71H6.38c-0.09,0-0.16,0.03-0.22,0.08C6.1,9.86,6.07,9.93,6.07,10.02v1.82c0,0.09,0.03,0.16,0.09,0.22 c0.06,0.06,0.13,0.08,0.22,0.08H8.2c0.09,0,0.16-0.03,0.22-0.08C8.47,12,8.5,11.93,8.5,11.84z"
+                      />
+                    </g>
+                  </svg>
+                </a>
+              </span>
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages help-messages"
+                />
+              </div>
+              <div
+                className="table expand"
+              >
+                <span
+                  aria-live="polite"
+                  className="messages error-messages"
+                  role="alert"
+                />
+              </div>
+              <div
+                className="table"
+              >
+                <span
+                  className="content"
+                >
+                  <span
+                    className="component shrink"
+                  >
+                    <div
+                      className="content"
+                    />
+                    <div
+                      className="blocks option-list branch"
+                    >
+                      <div
+                        className="yes block"
+                      >
+                        <input
+                          aria-label="Yes for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_federalservice-MOCK-GUID"
+                          name="has_federalservice-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="Yes"
+                        />
+                        <label
+                          className=""
+                          htmlFor="has_federalservice-MOCK-GUID"
+                        >
+                          <span>
+                            Yes
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="no block"
+                      >
+                        <input
+                          aria-label="No for null"
+                          checked={false}
+                          className="usa-input-success"
+                          disabled={false}
+                          id="has_federalservice-MOCK-GUID"
+                          name="has_federalservice-MOCK-GUID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          type="radio"
+                          value="No"
+                        />
+                        <label
+                          className=""
+                          htmlFor="has_federalservice-MOCK-GUID"
+                        >
+                          <span>
+                            No
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="bottom-btns"
+      >
+        <div
+          className="btn-wrap"
+        >
+          <div
+            className="btn-container"
+          >
+            <button
+              aria-label="Go to previous section Former federal service"
+              className="btn-cell back"
+              onClick={[Function]}
+              title="Go to previous section Former federal service"
+            >
+              <div
+                className="actions back"
+              >
+                <div
+                  className="icon"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-arrow-circle-left"
+                  />
+                </div>
+                <div
+                  className="text"
+                >
+                  <div
+                    className="direction"
+                  >
+                    Back
+                  </div>
+                  <div
+                    className="label"
+                  >
+                    Former federal service
                   </div>
                 </div>
               </div>
-            </div>
+            </button>
+            <div
+              className="btn-spacer"
+            />
+            <button
+              aria-label="Go to next section Relationships intro"
+              className="btn-cell next"
+              onClick={[Function]}
+              title="Go to next section Relationships intro"
+            >
+              <div
+                className="actions next"
+              >
+                <div
+                  className="text"
+                >
+                  <div
+                    className="direction"
+                  >
+                    Next
+                  </div>
+                  <div
+                    className="label"
+                  >
+                    Relationships intro
+                  </div>
+                </div>
+                <div
+                  className="icon"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-arrow-circle-right"
+                  />
+                </div>
+              </div>
+            </button>
           </div>
         </div>
       </div>
@@ -11678,7 +11576,7 @@ exports[`The section component renders identification.birthdate 1`] = `
   className="section-view"
 >
   <div
-    className="view view-intro"
+    className="view view-birthdate"
   >
     <div
       className="section-content birthdate"
@@ -11926,17 +11824,47 @@ exports[`The section component renders identification.birthdate 1`] = `
         <div
           className="btn-container"
         >
-          <div
-            className="btn-cell"
-          />
+          <button
+            aria-label="Go to previous section Full name"
+            className="btn-cell back"
+            onClick={[Function]}
+            title="Go to previous section Full name"
+          >
+            <div
+              className="actions back"
+            >
+              <div
+                className="icon"
+              >
+                <i
+                  aria-hidden="true"
+                  className="fa fa-arrow-circle-left"
+                />
+              </div>
+              <div
+                className="text"
+              >
+                <div
+                  className="direction"
+                >
+                  Back
+                </div>
+                <div
+                  className="label"
+                >
+                  Full name
+                </div>
+              </div>
+            </div>
+          </button>
           <div
             className="btn-spacer"
           />
           <button
-            aria-label="Go to next section Full name"
+            aria-label="Go to next section Place of birth"
             className="btn-cell next"
             onClick={[Function]}
-            title="Go to next section Full name"
+            title="Go to next section Place of birth"
           >
             <div
               className="actions next"
@@ -11952,7 +11880,7 @@ exports[`The section component renders identification.birthdate 1`] = `
                 <div
                   className="label"
                 >
-                  Full name
+                  Place of birth
                 </div>
               </div>
               <div
@@ -11977,7 +11905,7 @@ exports[`The section component renders identification.birthplace 1`] = `
   className="section-view"
 >
   <div
-    className="view view-intro"
+    className="view view-birthplace"
   >
     <div
       className="section-content applicant-birthplace"
@@ -12178,17 +12106,47 @@ exports[`The section component renders identification.birthplace 1`] = `
         <div
           className="btn-container"
         >
-          <div
-            className="btn-cell"
-          />
+          <button
+            aria-label="Go to previous section Date of birth"
+            className="btn-cell back"
+            onClick={[Function]}
+            title="Go to previous section Date of birth"
+          >
+            <div
+              className="actions back"
+            >
+              <div
+                className="icon"
+              >
+                <i
+                  aria-hidden="true"
+                  className="fa fa-arrow-circle-left"
+                />
+              </div>
+              <div
+                className="text"
+              >
+                <div
+                  className="direction"
+                >
+                  Back
+                </div>
+                <div
+                  className="label"
+                >
+                  Date of birth
+                </div>
+              </div>
+            </div>
+          </button>
           <div
             className="btn-spacer"
           />
           <button
-            aria-label="Go to next section Full name"
+            aria-label="Go to next section Social security number"
             className="btn-cell next"
             onClick={[Function]}
-            title="Go to next section Full name"
+            title="Go to next section Social security number"
           >
             <div
               className="actions next"
@@ -12204,7 +12162,7 @@ exports[`The section component renders identification.birthplace 1`] = `
                 <div
                   className="label"
                 >
-                  Full name
+                  Social security number
                 </div>
               </div>
               <div
@@ -12229,7 +12187,7 @@ exports[`The section component renders identification.contacts 1`] = `
   className="section-view"
 >
   <div
-    className="view view-intro"
+    className="view view-contacts"
   >
     <div
       className="section-content contact"
@@ -12639,17 +12597,47 @@ exports[`The section component renders identification.contacts 1`] = `
         <div
           className="btn-container"
         >
-          <div
-            className="btn-cell"
-          />
+          <button
+            aria-label="Go to previous section Other names used"
+            className="btn-cell back"
+            onClick={[Function]}
+            title="Go to previous section Other names used"
+          >
+            <div
+              className="actions back"
+            >
+              <div
+                className="icon"
+              >
+                <i
+                  aria-hidden="true"
+                  className="fa fa-arrow-circle-left"
+                />
+              </div>
+              <div
+                className="text"
+              >
+                <div
+                  className="direction"
+                >
+                  Back
+                </div>
+                <div
+                  className="label"
+                >
+                  Other names used
+                </div>
+              </div>
+            </div>
+          </button>
           <div
             className="btn-spacer"
           />
           <button
-            aria-label="Go to next section Full name"
+            aria-label="Go to next section Your identifying information"
             className="btn-cell next"
             onClick={[Function]}
-            title="Go to next section Full name"
+            title="Go to next section Your identifying information"
           >
             <div
               className="actions next"
@@ -12665,7 +12653,7 @@ exports[`The section component renders identification.contacts 1`] = `
                 <div
                   className="label"
                 >
-                  Full name
+                  Your identifying information
                 </div>
               </div>
               <div
@@ -12808,7 +12796,7 @@ exports[`The section component renders identification.name 1`] = `
   className="section-view"
 >
   <div
-    className="view view-intro"
+    className="view view-name"
   >
     <div
       className="section-content applicant-name"
@@ -13398,17 +13386,47 @@ exports[`The section component renders identification.name 1`] = `
         <div
           className="btn-container"
         >
-          <div
-            className="btn-cell"
-          />
+          <button
+            aria-label="Go to previous section Identification intro"
+            className="btn-cell back"
+            onClick={[Function]}
+            title="Go to previous section Identification intro"
+          >
+            <div
+              className="actions back"
+            >
+              <div
+                className="icon"
+              >
+                <i
+                  aria-hidden="true"
+                  className="fa fa-arrow-circle-left"
+                />
+              </div>
+              <div
+                className="text"
+              >
+                <div
+                  className="direction"
+                >
+                  Back
+                </div>
+                <div
+                  className="label"
+                >
+                  Identification intro
+                </div>
+              </div>
+            </div>
+          </button>
           <div
             className="btn-spacer"
           />
           <button
-            aria-label="Go to next section Full name"
+            aria-label="Go to next section Date of birth"
             className="btn-cell next"
             onClick={[Function]}
-            title="Go to next section Full name"
+            title="Go to next section Date of birth"
           >
             <div
               className="actions next"
@@ -13424,7 +13442,7 @@ exports[`The section component renders identification.name 1`] = `
                 <div
                   className="label"
                 >
-                  Full name
+                  Date of birth
                 </div>
               </div>
               <div
@@ -13449,7 +13467,7 @@ exports[`The section component renders identification.othernames 1`] = `
   className="section-view"
 >
   <div
-    className="view view-intro"
+    className="view view-othernames"
   >
     <div
       className="section-content other-names"
@@ -13659,17 +13677,47 @@ exports[`The section component renders identification.othernames 1`] = `
         <div
           className="btn-container"
         >
-          <div
-            className="btn-cell"
-          />
+          <button
+            aria-label="Go to previous section Social security number"
+            className="btn-cell back"
+            onClick={[Function]}
+            title="Go to previous section Social security number"
+          >
+            <div
+              className="actions back"
+            >
+              <div
+                className="icon"
+              >
+                <i
+                  aria-hidden="true"
+                  className="fa fa-arrow-circle-left"
+                />
+              </div>
+              <div
+                className="text"
+              >
+                <div
+                  className="direction"
+                >
+                  Back
+                </div>
+                <div
+                  className="label"
+                >
+                  Social security number
+                </div>
+              </div>
+            </div>
+          </button>
           <div
             className="btn-spacer"
           />
           <button
-            aria-label="Go to next section Full name"
+            aria-label="Go to next section Your contact information"
             className="btn-cell next"
             onClick={[Function]}
-            title="Go to next section Full name"
+            title="Go to next section Your contact information"
           >
             <div
               className="actions next"
@@ -13685,7 +13733,7 @@ exports[`The section component renders identification.othernames 1`] = `
                 <div
                   className="label"
                 >
-                  Full name
+                  Your contact information
                 </div>
               </div>
               <div
@@ -13710,7 +13758,7 @@ exports[`The section component renders identification.physical 1`] = `
   className="section-view"
 >
   <div
-    className="view view-intro"
+    className="view view-physical"
   >
     <div
       className="section-content physical"
@@ -15351,17 +15399,47 @@ exports[`The section component renders identification.physical 1`] = `
         <div
           className="btn-container"
         >
-          <div
-            className="btn-cell"
-          />
+          <button
+            aria-label="Go to previous section Your contact information"
+            className="btn-cell back"
+            onClick={[Function]}
+            title="Go to previous section Your contact information"
+          >
+            <div
+              className="actions back"
+            >
+              <div
+                className="icon"
+              >
+                <i
+                  aria-hidden="true"
+                  className="fa fa-arrow-circle-left"
+                />
+              </div>
+              <div
+                className="text"
+              >
+                <div
+                  className="direction"
+                >
+                  Back
+                </div>
+                <div
+                  className="label"
+                >
+                  Your contact information
+                </div>
+              </div>
+            </div>
+          </button>
           <div
             className="btn-spacer"
           />
           <button
-            aria-label="Go to next section Full name"
+            aria-label="Go to next section Review Identification"
             className="btn-cell next"
             onClick={[Function]}
-            title="Go to next section Full name"
+            title="Go to next section Review Identification"
           >
             <div
               className="actions next"
@@ -15377,7 +15455,7 @@ exports[`The section component renders identification.physical 1`] = `
                 <div
                   className="label"
                 >
-                  Full name
+                  Review Identification
                 </div>
               </div>
               <div
@@ -15401,9 +15479,22 @@ exports[`The section component renders identification.review 1`] = `
 <div
   className="section-view"
 >
-  <div
-    className="view view-intro"
+  <h1
+    className="title"
   >
+    Review your answers
+  </h1>
+  <div>
+    <p>
+      View the full section to make sure everything looks right and make changes if needed.
+    </p>
+  </div>
+  <div
+    className="view view-review"
+  >
+    <div
+      className="top-btns"
+    />
     <div>
       <div
         className="section-content applicant-name"
@@ -19138,17 +19229,47 @@ exports[`The section component renders identification.review 1`] = `
         <div
           className="btn-container"
         >
-          <div
-            className="btn-cell"
-          />
+          <button
+            aria-label="Go to previous section Your identifying information"
+            className="btn-cell back"
+            onClick={[Function]}
+            title="Go to previous section Your identifying information"
+          >
+            <div
+              className="actions back"
+            >
+              <div
+                className="icon"
+              >
+                <i
+                  aria-hidden="true"
+                  className="fa fa-arrow-circle-left"
+                />
+              </div>
+              <div
+                className="text"
+              >
+                <div
+                  className="direction"
+                >
+                  Back
+                </div>
+                <div
+                  className="label"
+                >
+                  Your identifying information
+                </div>
+              </div>
+            </div>
+          </button>
           <div
             className="btn-spacer"
           />
           <button
-            aria-label="Go to next section Full name"
+            aria-label="Go to next section History intro"
             className="btn-cell next"
             onClick={[Function]}
-            title="Go to next section Full name"
+            title="Go to next section History intro"
           >
             <div
               className="actions next"
@@ -19164,7 +19285,7 @@ exports[`The section component renders identification.review 1`] = `
                 <div
                   className="label"
                 >
-                  Full name
+                  History intro
                 </div>
               </div>
               <div
@@ -19189,7 +19310,7 @@ exports[`The section component renders identification.ssn 1`] = `
   className="section-view"
 >
   <div
-    className="view view-intro"
+    className="view view-ssn"
   >
     <div
       className="section-content applicant-ssn"
@@ -19413,17 +19534,47 @@ exports[`The section component renders identification.ssn 1`] = `
         <div
           className="btn-container"
         >
-          <div
-            className="btn-cell"
-          />
+          <button
+            aria-label="Go to previous section Place of birth"
+            className="btn-cell back"
+            onClick={[Function]}
+            title="Go to previous section Place of birth"
+          >
+            <div
+              className="actions back"
+            >
+              <div
+                className="icon"
+              >
+                <i
+                  aria-hidden="true"
+                  className="fa fa-arrow-circle-left"
+                />
+              </div>
+              <div
+                className="text"
+              >
+                <div
+                  className="direction"
+                >
+                  Back
+                </div>
+                <div
+                  className="label"
+                >
+                  Place of birth
+                </div>
+              </div>
+            </div>
+          </button>
           <div
             className="btn-spacer"
           />
           <button
-            aria-label="Go to next section Full name"
+            aria-label="Go to next section Other names used"
             className="btn-cell next"
             onClick={[Function]}
-            title="Go to next section Full name"
+            title="Go to next section Other names used"
           >
             <div
               className="actions next"
@@ -19439,7 +19590,7 @@ exports[`The section component renders identification.ssn 1`] = `
                 <div
                   className="label"
                 >
-                  Full name
+                  Other names used
                 </div>
               </div>
               <div

--- a/src/config/formSections/history.js
+++ b/src/config/formSections/history.js
@@ -6,14 +6,14 @@ export const HISTORY = {
   name: 'history',
   path: '/history',
   store: 'History',
-  label: i18n.t('history.section.name')
+  label: i18n.t('history.section.name'),
 }
 
 export const HISTORY_INTRO = {
   key: sections.HISTORY_INTRO,
   name: 'intro',
   path: `${HISTORY.path}/intro`,
-  label: i18n.t('history.subsection.intro')
+  label: i18n.t('history.subsection.intro'),
 }
 
 export const HISTORY_RESIDENCE = {
@@ -21,7 +21,7 @@ export const HISTORY_RESIDENCE = {
   name: 'residence',
   path: `${HISTORY.path}/residence`,
   storeKey: 'Residence',
-  label: i18n.t('history.subsection.residence')
+  label: i18n.t('history.subsection.residence'),
 }
 
 export const HISTORY_EMPLOYMENT = {
@@ -29,7 +29,7 @@ export const HISTORY_EMPLOYMENT = {
   name: 'employment',
   path: `${HISTORY.path}/employment`,
   storeKey: 'Employment',
-  label: i18n.t('history.subsection.employment')
+  label: i18n.t('history.subsection.employment'),
 }
 
 export const HISTORY_EDUCATION = {
@@ -37,7 +37,7 @@ export const HISTORY_EDUCATION = {
   name: 'education',
   path: `${HISTORY.path}/education`,
   storeKey: 'Education',
-  label: i18n.t('history.subsection.education')
+  label: i18n.t('history.subsection.education'),
 }
 
 export const HISTORY_FEDERAL = {
@@ -45,14 +45,14 @@ export const HISTORY_FEDERAL = {
   name: 'federal',
   path: `${HISTORY.path}/federal`,
   storeKey: 'Federal',
-  label: i18n.t('history.subsection.federal')
+  label: i18n.t('history.subsection.federal'),
 }
 
 export const HISTORY_REVIEW = {
   key: sections.HISTORY_REVIEW,
   name: 'review',
   path: `${HISTORY.path}/review`,
-  label: i18n.t('history.subsection.review')
+  label: i18n.t('history.subsection.review'),
 }
 
 export default {

--- a/src/config/formSections/history.js
+++ b/src/config/formSections/history.js
@@ -1,7 +1,7 @@
 import * as sections from 'constants/sections'
 import { i18n } from 'config'
 
-const HISTORY = {
+export const HISTORY = {
   key: sections.HISTORY,
   name: 'history',
   path: '/history',
@@ -9,14 +9,14 @@ const HISTORY = {
   label: i18n.t('history.section.name')
 }
 
-const HISTORY_INTRO = {
+export const HISTORY_INTRO = {
   key: sections.HISTORY_INTRO,
   name: 'intro',
   path: `${HISTORY.path}/intro`,
   label: i18n.t('history.subsection.intro')
 }
 
-const HISTORY_RESIDENCE = {
+export const HISTORY_RESIDENCE = {
   key: sections.HISTORY_RESIDENCE,
   name: 'residence',
   path: `${HISTORY.path}/residence`,
@@ -24,7 +24,7 @@ const HISTORY_RESIDENCE = {
   label: i18n.t('history.subsection.residence')
 }
 
-const HISTORY_EMPLOYMENT = {
+export const HISTORY_EMPLOYMENT = {
   key: sections.HISTORY_EMPLOYMENT,
   name: 'employment',
   path: `${HISTORY.path}/employment`,
@@ -32,7 +32,7 @@ const HISTORY_EMPLOYMENT = {
   label: i18n.t('history.subsection.employment')
 }
 
-const HISTORY_EDUCATION = {
+export const HISTORY_EDUCATION = {
   key: sections.HISTORY_EDUCATION,
   name: 'education',
   path: `${HISTORY.path}/education`,
@@ -40,7 +40,7 @@ const HISTORY_EDUCATION = {
   label: i18n.t('history.subsection.education')
 }
 
-const HISTORY_FEDERAL = {
+export const HISTORY_FEDERAL = {
   key: sections.HISTORY_FEDERAL,
   name: 'federal',
   path: `${HISTORY.path}/federal`,
@@ -48,7 +48,7 @@ const HISTORY_FEDERAL = {
   label: i18n.t('history.subsection.federal')
 }
 
-const HISTORY_REVIEW = {
+export const HISTORY_REVIEW = {
   key: sections.HISTORY_REVIEW,
   name: 'review',
   path: `${HISTORY.path}/review`,


### PR DESCRIPTION
## Description
- Fixes #1452 
- Render `History` section and its subsections using `<Route>` instead of `<SectionViews>`
- Created standalone components for summary progress for Education/Employment/Residence
- Created wrapper components for Education/Employment/Residence/Federal to bridge rendering & functions previously handled by the `History` component
  - This definitely deserves further cleanup, I think maybe after we work on the Accordion component
- Created `HistoryConnector` HOC and tests for it (replacing some `History.test.jsx` tests)
- Consolidated some common functions into `History/helpers.js`
- Converted `overrideInitial` prop to bool instead of function in order to simplify it
- _Not done:_ dynamic `totalYears` value based on form type -- I think this should be a separate story

## Checklist for Reveiwer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
