### PR TITLE
[WIP] Update section navigation buttons to support nested subsections

### DIFF
--- a/src/components/Section/SectionView.scss
+++ b/src/components/Section/SectionView.scss
@@ -24,6 +24,8 @@
       }
 
       .btn-cell {
+        color: $color-white;
+        text-decoration: none;
         width: 30%;
       }
 

--- a/src/components/Section/__snapshots__/Section.test.jsx.snap
+++ b/src/components/Section/__snapshots__/Section.test.jsx.snap
@@ -11910,18 +11910,24 @@ exports[`The section component renders identification.birthdate 1`] = `
         <div
           className="btn-container"
         >
-          <div
+          <a
+            aria-label="Go to previous section "
             className="btn-cell"
-          />
+            href="/"
+            onClick={[Function]}
+            title="Go to previous section "
+          >
+            
+          </a>
           <div
             className="btn-spacer"
           />
-          <button
+          <a
             aria-label="Go to next section Full name"
             className="btn-cell next"
+            href="/form/identification/name"
             onClick={[Function]}
             title="Go to next section Full name"
-            type="button"
           >
             <div
               className="actions next"
@@ -11949,7 +11955,7 @@ exports[`The section component renders identification.birthdate 1`] = `
                 />
               </div>
             </div>
-          </button>
+          </a>
         </div>
       </div>
     </div>
@@ -12163,18 +12169,24 @@ exports[`The section component renders identification.birthplace 1`] = `
         <div
           className="btn-container"
         >
-          <div
+          <a
+            aria-label="Go to previous section "
             className="btn-cell"
-          />
+            href="/"
+            onClick={[Function]}
+            title="Go to previous section "
+          >
+            
+          </a>
           <div
             className="btn-spacer"
           />
-          <button
+          <a
             aria-label="Go to next section Full name"
             className="btn-cell next"
+            href="/form/identification/name"
             onClick={[Function]}
             title="Go to next section Full name"
-            type="button"
           >
             <div
               className="actions next"
@@ -12202,7 +12214,7 @@ exports[`The section component renders identification.birthplace 1`] = `
                 />
               </div>
             </div>
-          </button>
+          </a>
         </div>
       </div>
     </div>
@@ -12625,18 +12637,24 @@ exports[`The section component renders identification.contacts 1`] = `
         <div
           className="btn-container"
         >
-          <div
+          <a
+            aria-label="Go to previous section "
             className="btn-cell"
-          />
+            href="/"
+            onClick={[Function]}
+            title="Go to previous section "
+          >
+            
+          </a>
           <div
             className="btn-spacer"
           />
-          <button
+          <a
             aria-label="Go to next section Full name"
             className="btn-cell next"
+            href="/form/identification/name"
             onClick={[Function]}
             title="Go to next section Full name"
-            type="button"
           >
             <div
               className="actions next"
@@ -12664,7 +12682,7 @@ exports[`The section component renders identification.contacts 1`] = `
                 />
               </div>
             </div>
-          </button>
+          </a>
         </div>
       </div>
     </div>
@@ -12744,18 +12762,24 @@ exports[`The section component renders identification.intro 1`] = `
         <div
           className="btn-container"
         >
-          <div
+          <a
+            aria-label="Go to previous section "
             className="btn-cell"
-          />
+            href="/"
+            onClick={[Function]}
+            title="Go to previous section "
+          >
+            
+          </a>
           <div
             className="btn-spacer"
           />
-          <button
+          <a
             aria-label="Go to next section Full name"
             className="btn-cell next"
+            href="/form/identification/name"
             onClick={[Function]}
             title="Go to next section Full name"
-            type="button"
           >
             <div
               className="actions next"
@@ -12783,7 +12807,7 @@ exports[`The section component renders identification.intro 1`] = `
                 />
               </div>
             </div>
-          </button>
+          </a>
         </div>
       </div>
     </div>
@@ -13386,18 +13410,24 @@ exports[`The section component renders identification.name 1`] = `
         <div
           className="btn-container"
         >
-          <div
+          <a
+            aria-label="Go to previous section "
             className="btn-cell"
-          />
+            href="/"
+            onClick={[Function]}
+            title="Go to previous section "
+          >
+            
+          </a>
           <div
             className="btn-spacer"
           />
-          <button
+          <a
             aria-label="Go to next section Full name"
             className="btn-cell next"
+            href="/form/identification/name"
             onClick={[Function]}
             title="Go to next section Full name"
-            type="button"
           >
             <div
               className="actions next"
@@ -13425,7 +13455,7 @@ exports[`The section component renders identification.name 1`] = `
                 />
               </div>
             </div>
-          </button>
+          </a>
         </div>
       </div>
     </div>
@@ -13648,18 +13678,24 @@ exports[`The section component renders identification.othernames 1`] = `
         <div
           className="btn-container"
         >
-          <div
+          <a
+            aria-label="Go to previous section "
             className="btn-cell"
-          />
+            href="/"
+            onClick={[Function]}
+            title="Go to previous section "
+          >
+            
+          </a>
           <div
             className="btn-spacer"
           />
-          <button
+          <a
             aria-label="Go to next section Full name"
             className="btn-cell next"
+            href="/form/identification/name"
             onClick={[Function]}
             title="Go to next section Full name"
-            type="button"
           >
             <div
               className="actions next"
@@ -13687,7 +13723,7 @@ exports[`The section component renders identification.othernames 1`] = `
                 />
               </div>
             </div>
-          </button>
+          </a>
         </div>
       </div>
     </div>
@@ -15341,18 +15377,24 @@ exports[`The section component renders identification.physical 1`] = `
         <div
           className="btn-container"
         >
-          <div
+          <a
+            aria-label="Go to previous section "
             className="btn-cell"
-          />
+            href="/"
+            onClick={[Function]}
+            title="Go to previous section "
+          >
+            
+          </a>
           <div
             className="btn-spacer"
           />
-          <button
+          <a
             aria-label="Go to next section Full name"
             className="btn-cell next"
+            href="/form/identification/name"
             onClick={[Function]}
             title="Go to next section Full name"
-            type="button"
           >
             <div
               className="actions next"
@@ -15380,7 +15422,7 @@ exports[`The section component renders identification.physical 1`] = `
                 />
               </div>
             </div>
-          </button>
+          </a>
         </div>
       </div>
     </div>
@@ -19129,18 +19171,24 @@ exports[`The section component renders identification.review 1`] = `
         <div
           className="btn-container"
         >
-          <div
+          <a
+            aria-label="Go to previous section "
             className="btn-cell"
-          />
+            href="/"
+            onClick={[Function]}
+            title="Go to previous section "
+          >
+            
+          </a>
           <div
             className="btn-spacer"
           />
-          <button
+          <a
             aria-label="Go to next section Full name"
             className="btn-cell next"
+            href="/form/identification/name"
             onClick={[Function]}
             title="Go to next section Full name"
-            type="button"
           >
             <div
               className="actions next"
@@ -19168,7 +19216,7 @@ exports[`The section component renders identification.review 1`] = `
                 />
               </div>
             </div>
-          </button>
+          </a>
         </div>
       </div>
     </div>
@@ -19405,18 +19453,24 @@ exports[`The section component renders identification.ssn 1`] = `
         <div
           className="btn-container"
         >
-          <div
+          <a
+            aria-label="Go to previous section "
             className="btn-cell"
-          />
+            href="/"
+            onClick={[Function]}
+            title="Go to previous section "
+          >
+            
+          </a>
           <div
             className="btn-spacer"
           />
-          <button
+          <a
             aria-label="Go to next section Full name"
             className="btn-cell next"
+            href="/form/identification/name"
             onClick={[Function]}
             title="Go to next section Full name"
-            type="button"
           >
             <div
               className="actions next"
@@ -19444,7 +19498,7 @@ exports[`The section component renders identification.ssn 1`] = `
                 />
               </div>
             </div>
-          </button>
+          </a>
         </div>
       </div>
     </div>

--- a/src/components/Section/__snapshots__/Section.test.jsx.snap
+++ b/src/components/Section/__snapshots__/Section.test.jsx.snap
@@ -11921,6 +11921,7 @@ exports[`The section component renders identification.birthdate 1`] = `
             className="btn-cell next"
             onClick={[Function]}
             title="Go to next section Full name"
+            type="button"
           >
             <div
               className="actions next"
@@ -12173,6 +12174,7 @@ exports[`The section component renders identification.birthplace 1`] = `
             className="btn-cell next"
             onClick={[Function]}
             title="Go to next section Full name"
+            type="button"
           >
             <div
               className="actions next"
@@ -12634,6 +12636,7 @@ exports[`The section component renders identification.contacts 1`] = `
             className="btn-cell next"
             onClick={[Function]}
             title="Go to next section Full name"
+            type="button"
           >
             <div
               className="actions next"
@@ -12752,6 +12755,7 @@ exports[`The section component renders identification.intro 1`] = `
             className="btn-cell next"
             onClick={[Function]}
             title="Go to next section Full name"
+            type="button"
           >
             <div
               className="actions next"
@@ -13393,6 +13397,7 @@ exports[`The section component renders identification.name 1`] = `
             className="btn-cell next"
             onClick={[Function]}
             title="Go to next section Full name"
+            type="button"
           >
             <div
               className="actions next"
@@ -13654,6 +13659,7 @@ exports[`The section component renders identification.othernames 1`] = `
             className="btn-cell next"
             onClick={[Function]}
             title="Go to next section Full name"
+            type="button"
           >
             <div
               className="actions next"
@@ -15346,6 +15352,7 @@ exports[`The section component renders identification.physical 1`] = `
             className="btn-cell next"
             onClick={[Function]}
             title="Go to next section Full name"
+            type="button"
           >
             <div
               className="actions next"
@@ -19133,6 +19140,7 @@ exports[`The section component renders identification.review 1`] = `
             className="btn-cell next"
             onClick={[Function]}
             title="Go to next section Full name"
+            type="button"
           >
             <div
               className="actions next"
@@ -19408,6 +19416,7 @@ exports[`The section component renders identification.ssn 1`] = `
             className="btn-cell next"
             onClick={[Function]}
             title="Go to next section Full name"
+            type="button"
           >
             <div
               className="actions next"

--- a/src/components/Section/shared/SectionNavButton.jsx
+++ b/src/components/Section/shared/SectionNavButton.jsx
@@ -2,7 +2,12 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const SectionNavButton = (props) => {
-  const { isEmpty, direction, label, onClick } = props
+  const {
+    isEmpty,
+    direction,
+    label,
+    onClick,
+  } = props
 
   if (isEmpty) {
     return <div className="btn-cell" />
@@ -27,6 +32,8 @@ const SectionNavButton = (props) => {
       directionClass = 'back'
       iconClass = 'fa-arrow-circle-left'
       break
+    default:
+      break
   }
 
   const ariaLabel = `Go to ${ariaDirectionText} section ${label}`
@@ -45,11 +52,15 @@ const SectionNavButton = (props) => {
   )
 
   return (
+    // TODO: Use Link
+    // https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/Link.md
     <button
       className={`btn-cell ${directionClass}`}
       title={ariaLabel}
       aria-label={ariaLabel}
-      onClick={onClick}>
+      onClick={onClick}
+      type="button"
+    >
       <div className={`actions ${directionClass}`}>
         {direction === 'back' && icon}
         {text}

--- a/src/components/Section/shared/SectionNavButton.jsx
+++ b/src/components/Section/shared/SectionNavButton.jsx
@@ -1,39 +1,25 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { Link } from 'react-router-dom'
+import classnames from 'classnames'
 
-const SectionNavButton = (props) => {
-  const {
-    isEmpty,
-    direction,
-    label,
-    onClick,
-  } = props
-
-  if (isEmpty) {
-    return <div className="btn-cell" />
-  }
-
+const SectionNavButton = ({ link, direction, label }) => {
   let directionText
   let ariaDirectionText
   let directionClass
   let iconClass
 
-  switch (direction) {
-    case 'next':
-      directionText = 'Next'
-      ariaDirectionText = 'next'
-      directionClass = 'next'
-      iconClass = 'fa-arrow-circle-right'
-      break
-
-    case 'back':
-      directionText = 'Back'
-      ariaDirectionText = 'previous'
-      directionClass = 'back'
-      iconClass = 'fa-arrow-circle-left'
-      break
-    default:
-      break
+  if (direction === 'next') {
+    directionText = 'Next'
+    ariaDirectionText = 'next'
+    directionClass = 'next'
+    iconClass = 'fa-arrow-circle-right'
+  }
+  if (direction === 'back') {
+    directionText = 'Back'
+    ariaDirectionText = 'previous'
+    directionClass = 'back'
+    iconClass = 'fa-arrow-circle-left'
   }
 
   const ariaLabel = `Go to ${ariaDirectionText} section ${label}`
@@ -44,43 +30,44 @@ const SectionNavButton = (props) => {
     </div>
   )
 
-  const text = (
-    <div className="text">
-      <div className="direction">{directionText}</div>
-      <div className="label">{label}</div>
-    </div>
-  )
-
   return (
-    // TODO: Use Link
-    // https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/Link.md
-    <button
-      className={`btn-cell ${directionClass}`}
+    <Link
+      className={classnames(
+        'btn-cell',
+        { [directionClass]: directionClass && link },
+      )}
       title={ariaLabel}
       aria-label={ariaLabel}
-      onClick={onClick}
-      type="button"
+      to={link}
     >
-      <div className={`actions ${directionClass}`}>
-        {direction === 'back' && icon}
-        {text}
-        {direction === 'next' && icon}
-      </div>
-    </button>
+      {link && (
+        <div
+          className={classnames(
+            'actions',
+            { [directionClass]: directionClass && link },
+          )}
+        >
+          {direction === 'back' && icon}
+          <div className="text">
+            <div className="direction">{directionText}</div>
+            <div className="label">{label}</div>
+          </div>
+          {direction === 'next' && icon}
+        </div>
+      )}
+    </Link>
   )
 }
 
 SectionNavButton.propTypes = {
   direction: PropTypes.oneOf(['back', 'next']).isRequired,
   label: PropTypes.string,
-  onClick: PropTypes.func,
-  isEmpty: PropTypes.bool,
+  link: PropTypes.string,
 }
 
 SectionNavButton.defaultProps = {
   label: '',
-  onClick: () => {},
-  isEmpty: false,
+  link: '',
 }
 
 export default SectionNavButton

--- a/src/components/Section/shared/SectionNavigation.jsx
+++ b/src/components/Section/shared/SectionNavigation.jsx
@@ -9,7 +9,11 @@ const SectionNavigation = ({ section, subsection, formType }) => {
   const formSections = formTypeConfig[formType]
   const sectionConfig = formSections.find(s => s.key === section)
   const sectionIndex = formSections.findIndex(s => s.key === section)
-  const subsectionIndex = sectionConfig.subsections.findIndex((s) => {
+
+  // Removes all subsections that don't have a path to navigate to.
+  // These are generally the parents that have nested subsections.
+  const subsections = sectionConfig.subsections.filter(s => s.path)
+  const subsectionIndex = subsections.findIndex((s) => {
     if (s.path) {
       return s.path.subsection === subsection
     }
@@ -22,11 +26,7 @@ const SectionNavigation = ({ section, subsection, formType }) => {
   let nextLabel
 
   if (subsectionIndex > 0) {
-    if (sectionConfig.subsections[subsectionIndex - 1].path) {
-      back = sectionConfig.subsections[subsectionIndex - 1]
-    } else {
-      back = sectionConfig.subsections[subsectionIndex - 2]
-    }
+    back = subsections[subsectionIndex - 1]
     backLabel = i18n.t(`${sectionConfig.name}.destination.${back.name}`)
   } else if (sectionIndex > 0) {
     // Go to the last subsection of the previous section
@@ -35,12 +35,8 @@ const SectionNavigation = ({ section, subsection, formType }) => {
     backLabel = i18n.t(`${previousSection.name}.destination.${back.name}`)
   }
 
-  if (subsectionIndex < sectionConfig.subsections.length - 1) {
-    if (sectionConfig.subsections[subsectionIndex + 1].path) {
-      next = sectionConfig.subsections[subsectionIndex + 1]
-    } else {
-      next = sectionConfig.subsections[subsectionIndex + 2]
-    }
+  if (subsectionIndex < subsections.length - 1) {
+    next = subsections[subsectionIndex + 1]
     nextLabel = i18n.t(`${sectionConfig.name}.destination.${next.name}`)
   } else if (sectionIndex < formSections.length - 1) {
     // Go to the first subsection of the next section

--- a/src/components/Section/shared/SectionNavigation.jsx
+++ b/src/components/Section/shared/SectionNavigation.jsx
@@ -1,18 +1,20 @@
 import React from 'react'
-
+import PropTypes from 'prop-types'
 import { i18n, env } from '@config'
 import * as formTypeConfig from '@config/formTypes'
-
-import * as sections from '@constants/sections'
 
 import SectionNavButton from './SectionNavButton'
 
 const SectionNavigation = ({ section, subsection, formType }) => {
   const formSections = formTypeConfig[formType]
-
   const sectionConfig = formSections.find(s => s.key === section)
   const sectionIndex = formSections.findIndex(s => s.key === section)
-  const subsectionIndex = sectionConfig.subsections.findIndex(s => s.name === subsection)
+  const subsectionIndex = sectionConfig.subsections.findIndex((s) => {
+    if (s.path) {
+      return s.path.subsection === subsection
+    }
+    return null
+  })
 
   let back
   let next
@@ -20,7 +22,11 @@ const SectionNavigation = ({ section, subsection, formType }) => {
   let nextLabel
 
   if (subsectionIndex > 0) {
-    back = sectionConfig.subsections[subsectionIndex - 1]
+    if (sectionConfig.subsections[subsectionIndex - 1].path) {
+      back = sectionConfig.subsections[subsectionIndex - 1]
+    } else {
+      back = sectionConfig.subsections[subsectionIndex - 2]
+    }
     backLabel = i18n.t(`${sectionConfig.name}.destination.${back.name}`)
   } else if (sectionIndex > 0) {
     // Go to the last subsection of the previous section
@@ -30,7 +36,11 @@ const SectionNavigation = ({ section, subsection, formType }) => {
   }
 
   if (subsectionIndex < sectionConfig.subsections.length - 1) {
-    next = sectionConfig.subsections[subsectionIndex + 1]
+    if (sectionConfig.subsections[subsectionIndex + 1].path) {
+      next = sectionConfig.subsections[subsectionIndex + 1]
+    } else {
+      next = sectionConfig.subsections[subsectionIndex + 2]
+    }
     nextLabel = i18n.t(`${sectionConfig.name}.destination.${next.name}`)
   } else if (sectionIndex < formSections.length - 1) {
     // Go to the first subsection of the next section
@@ -43,12 +53,13 @@ const SectionNavigation = ({ section, subsection, formType }) => {
     return null
   }
 
-  const goToSection = (path) => {
+  const goToSection = (subsectionConfig) => {
+    const path = `/form/${subsectionConfig.path.section}/${subsectionConfig.path.subsection || ''}`
     env.History().push(path)
   }
 
-  const backOnClick = back && (() => { goToSection(`/form${back.path}`) })
-  const nextOnClick = next && (() => { goToSection(`/form${next.path}`) })
+  const backOnClick = back && (() => { goToSection(back) })
+  const nextOnClick = next && (() => { goToSection(next) })
 
   return (
     <div className="bottom-btns">
@@ -58,17 +69,25 @@ const SectionNavigation = ({ section, subsection, formType }) => {
             direction="back"
             label={backLabel}
             onClick={backOnClick}
-            isEmpty={!back} />
+            isEmpty={!back}
+          />
           <div className="btn-spacer" />
           <SectionNavButton
             direction="next"
             label={nextLabel}
             onClick={nextOnClick}
-            isEmpty={!next} />
+            isEmpty={!next}
+          />
         </div>
       </div>
     </div>
   )
+}
+
+SectionNavigation.propTypes = {
+  section: PropTypes.string.isRequired,
+  subsection: PropTypes.string.isRequired,
+  formType: PropTypes.string.isRequired,
 }
 
 export default SectionNavigation

--- a/src/components/Section/shared/SectionNavigation.jsx
+++ b/src/components/Section/shared/SectionNavigation.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { i18n, env } from '@config'
+import { i18n } from '@config'
 import * as formTypeConfig from '@config/formTypes'
 
 import SectionNavButton from './SectionNavButton'
@@ -53,13 +53,12 @@ const SectionNavigation = ({ section, subsection, formType }) => {
     return null
   }
 
-  const goToSection = (subsectionConfig) => {
-    const path = `/form/${subsectionConfig.path.section}/${subsectionConfig.path.subsection || ''}`
-    env.History().push(path)
+  const getLink = (subsectionConfig) => {
+    if (subsectionConfig) {
+      return `/form/${subsectionConfig.path.section}/${subsectionConfig.path.subsection || ''}`
+    }
+    return ''
   }
-
-  const backOnClick = back && (() => { goToSection(back) })
-  const nextOnClick = next && (() => { goToSection(next) })
 
   return (
     <div className="bottom-btns">
@@ -68,15 +67,13 @@ const SectionNavigation = ({ section, subsection, formType }) => {
           <SectionNavButton
             direction="back"
             label={backLabel}
-            onClick={backOnClick}
-            isEmpty={!back}
+            link={getLink(back)}
           />
           <div className="btn-spacer" />
           <SectionNavButton
             direction="next"
             label={nextLabel}
-            onClick={nextOnClick}
-            isEmpty={!next}
+            link={getLink(next)}
           />
         </div>
       </div>

--- a/src/config/formSections/citizenship.js
+++ b/src/config/formSections/citizenship.js
@@ -16,7 +16,7 @@ const CITIZENSHIP_INTRO = {
   name: 'intro',
   path: {
     section: CITIZENSHIP.path.section,
-    subsection: '',
+    subsection: 'intro',
   },
   label: i18n.t('citizenship.subsection.intro'),
 }

--- a/src/config/formSections/citizenship.js
+++ b/src/config/formSections/citizenship.js
@@ -4,47 +4,64 @@ import { i18n } from '@config'
 const CITIZENSHIP = {
   key: sections.CITIZENSHIP,
   name: 'citizenship',
-  path: '/citizenship',
+  path: {
+    section: 'citizenship',
+  },
   store: 'Citizenship',
-  label: i18n.t('citizenship.section.name')
+  label: i18n.t('citizenship.section.name'),
 }
 
 const CITIZENSHIP_INTRO = {
   key: sections.CITIZENSHIP_INTRO,
   name: 'intro',
-  path: `${CITIZENSHIP.path}/intro`,
-  label: i18n.t('citizenship.subsection.intro')
+  path: {
+    section: CITIZENSHIP.path.section,
+    subsection: '',
+  },
+  label: i18n.t('citizenship.subsection.intro'),
 }
 
 const CITIZENSHIP_STATUS = {
   key: sections.CITIZENSHIP_STATUS,
   name: 'status',
-  path: `${CITIZENSHIP.path}/status`,
+  path: {
+    section: CITIZENSHIP.path.section,
+    subsection: 'status',
+  },
   storeKey: 'Status',
-  label: i18n.t('citizenship.subsection.status')
+  label: i18n.t('citizenship.subsection.status'),
 }
 
 const CITIZENSHIP_MULTIPLE = {
   key: sections.CITIZENSHIP_MULTIPLE,
   name: 'multiple',
-  path: `${CITIZENSHIP.path}/multiple`,
+  path: {
+    section: CITIZENSHIP.path.section,
+    subsection: 'multiple',
+  },
   storeKey: 'Multiple',
-  label: i18n.t('citizenship.subsection.multiple')
+  label: i18n.t('citizenship.subsection.multiple'),
 }
 
 const CITIZENSHIP_PASSPORTS = {
   key: sections.CITIZENSHIP_PASSPORTS,
   name: 'passports',
-  path: `${CITIZENSHIP.path}/passports`,
+  path: {
+    section: CITIZENSHIP.path.section,
+    subsection: 'passports',
+  },
   storeKey: 'Passports',
-  label: i18n.t('citizenship.subsection.passports')
+  label: i18n.t('citizenship.subsection.passports'),
 }
 
 const CITIZENSHIP_REVIEW = {
   key: sections.CITIZENSHIP_REVIEW,
   name: 'review',
-  path: `${CITIZENSHIP.path}/review`,
-  label: i18n.t('citizenship.subsection.review')
+  path: {
+    section: CITIZENSHIP.path.section,
+    subsection: 'review',
+  },
+  label: i18n.t('citizenship.subsection.review'),
 }
 
 export default {
@@ -53,5 +70,5 @@ export default {
   CITIZENSHIP_STATUS,
   CITIZENSHIP_MULTIPLE,
   CITIZENSHIP_PASSPORTS,
-  CITIZENSHIP_REVIEW
+  CITIZENSHIP_REVIEW,
 }

--- a/src/config/formSections/financial.js
+++ b/src/config/formSections/financial.js
@@ -4,80 +4,109 @@ import { i18n } from '@config'
 const FINANCIAL = {
   key: sections.FINANCIAL,
   name: 'financial',
-  path: '/financial',
+  path: {
+    section: 'financial',
+  },
   store: 'Financial',
-  label: i18n.t('financial.section.name')
+  label: i18n.t('financial.section.name'),
 }
 
 const FINANCIAL_INTRO = {
   key: sections.FINANCIAL_INTRO,
   name: 'intro',
-  path: `${FINANCIAL.path}/intro`,
-  label: i18n.t('financial.subsection.intro')
+  path: {
+    section: FINANCIAL.path.section,
+    subsection: 'intro',
+  },
+  label: i18n.t('financial.subsection.intro'),
 }
 
 const FINANCIAL_BANKRUPTCY = {
   key: sections.FINANCIAL_BANKRUPTCY,
   name: 'bankruptcy',
-  path: `${FINANCIAL.path}/bankruptcy`,
+  path: {
+    section: FINANCIAL.path.section,
+    subsection: 'bankruptcy',
+  },
   storeKey: 'Baankruptcy',
-  label: i18n.t('financial.subsection.bankruptcy')
+  label: i18n.t('financial.subsection.bankruptcy'),
 }
 
 const FINANCIAL_GAMBLING = {
   key: sections.FINANCIAL_GAMBLING,
   name: 'gambling',
-  path: `${FINANCIAL.path}/gambling`,
+  path: {
+    section: FINANCIAL.path.section,
+    subsection: 'gambling',
+  },
   storeKey: 'Gambling',
-  label: i18n.t('financial.subsection.gambling')
+  label: i18n.t('financial.subsection.gambling'),
 }
 
 const FINANCIAL_TAXES = {
   key: sections.FINANCIAL_TAXES,
   name: 'taxes',
-  path: `${FINANCIAL.path}/taxes`,
+  path: {
+    section: FINANCIAL.path.section,
+    subsection: 'taxes',
+  },
   storeKey: 'Taxes',
-  label: i18n.t('financial.subsection.taxes')
+  label: i18n.t('financial.subsection.taxes'),
 }
 
 const FINANCIAL_CARD = {
   key: sections.FINANCIAL_CARD,
   name: 'card',
-  path: `${FINANCIAL.path}/card`,
+  path: {
+    section: FINANCIAL.path.section,
+    subsection: 'card',
+  },
   storeKey: 'Card',
-  label: i18n.t('financial.subsection.card')
+  label: i18n.t('financial.subsection.card'),
 }
 
 const FINANCIAL_CREDIT = {
   key: sections.FINANCIAL_CREDIT,
   name: 'credit',
-  path: `${FINANCIAL.path}/credit`,
+  path: {
+    section: FINANCIAL.path.section,
+    subsection: 'credit',
+  },
   storeKey: 'Credit',
-  label: i18n.t('financial.subsection.credit')
+  label: i18n.t('financial.subsection.credit'),
 }
 
 const FINANCIAL_DELINQUENT = {
   key: sections.FINANCIAL_DELINQUENT,
   name: 'delinquent',
-  path: `${FINANCIAL.path}/delinquent`,
+  path: {
+    section: FINANCIAL.path.section,
+    subsection: 'delinquent',
+  },
   storeKey: 'Delinquent',
-  label: i18n.t('financial.subsection.delinquent')
+  label: i18n.t('financial.subsection.delinquent'),
 }
 
 const FINANCIAL_NONPAYMENT = {
   key: sections.FINANCIAL_NONPAYMENT,
   name: 'nonpayment',
-  path: `${FINANCIAL.path}/nonpayment`,
+  path: {
+    section: FINANCIAL.path.section,
+    subsection: 'nonpayment',
+  },
   storeKey: 'Nonpayment',
-  label: i18n.t('financial.subsection.nonpayment')
+  label: i18n.t('financial.subsection.nonpayment'),
 }
 
 const FINANCIAL_REVIEW = {
   key: sections.FINANCIAL_REVIEW,
   name: 'review',
-  path: `${FINANCIAL.path}/review`,
+  path: {
+    section: FINANCIAL.path.section,
+    subsection: 'review',
+  },
   storeKey: 'Review',
-  label: i18n.t('financial.subsection.review')
+  label: i18n.t('financial.subsection.review'),
 }
 
 export default {
@@ -90,5 +119,5 @@ export default {
   FINANCIAL_CREDIT,
   FINANCIAL_DELINQUENT,
   FINANCIAL_NONPAYMENT,
-  FINANCIAL_REVIEW
+  FINANCIAL_REVIEW,
 }

--- a/src/config/formSections/foreign.js
+++ b/src/config/formSections/foreign.js
@@ -4,173 +4,244 @@ import { i18n } from '@config'
 const FOREIGN = {
   key: sections.FOREIGN,
   name: 'foreign',
-  path: '/foreign',
+  path: {
+    section: 'foreign',
+  },
   store: 'Foreign',
-  label: i18n.t('foreign.section.name')
+  label: i18n.t('foreign.section.name'),
 }
 
 const FOREIGN_INTRO = {
   key: sections.FOREIGN_INTRO,
   name: 'intro',
-  path: `${FOREIGN.path}/intro`,
-  label: i18n.t('foreign.subsection.intro')
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'intro',
+  },
+  label: i18n.t('foreign.subsection.intro'),
 }
 
 const FOREIGN_PASSPORT = {
   key: sections.FOREIGN_PASSPORT,
   name: 'passport',
-  path: `${FOREIGN.path}/passport`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'passport',
+  },
   storeKey: 'Passport',
-  label: i18n.t('foreign.subsection.passport')
+  label: i18n.t('foreign.subsection.passport'),
 }
 
 const FOREIGN_CONTACTS = {
   key: sections.FOREIGN_CONTACTS,
   name: 'contacts',
-  path: `${FOREIGN.path}/contacts`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'contacts',
+  },
   storeKey: 'Contacts',
-  label: i18n.t('foreign.subsection.contacts')
+  label: i18n.t('foreign.subsection.contacts'),
 }
 
 const FOREIGN_ACTIVITIES = {
   key: sections.FOREIGN_ACTIVITIES,
   name: 'activities',
-  path: `${FOREIGN.path}/activities`,
-  label: i18n.t('foreign.subsection.activities.label')
+  label: i18n.t('foreign.subsection.activities.label'),
 }
 
 const FOREIGN_ACTIVITIES_DIRECT = {
   key: sections.FOREIGN_ACTIVITIES_DIRECT,
   name: 'direct',
-  path: `${FOREIGN_ACTIVITIES.path}/direct`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'activities/direct',
+  },
   storeKey: 'DirectActivity',
-  label: i18n.t('foreign.subsection.activities.direct')
+  label: i18n.t('foreign.subsection.activities.direct'),
+  parentKey: FOREIGN_ACTIVITIES.key,
 }
 
 const FOREIGN_ACTIVITIES_INDIRECT = {
   key: sections.FOREIGN_ACTIVITIES_INDIRECT,
   name: 'indirect',
-  path: `${FOREIGN_ACTIVITIES.path}/indirect`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'activities/indirect',
+  },
   storeKey: 'IndirectActivity',
-  label: i18n.t('foreign.subsection.activities.indirect')
+  label: i18n.t('foreign.subsection.activities.indirect'),
+  parentKey: FOREIGN_ACTIVITIES.key,
 }
 
 const FOREIGN_ACTIVITIES_REAL_ESTATE = {
   key: sections.FOREIGN_ACTIVITIES_REAL_ESTATE,
   name: 'realestate',
-  path: `${FOREIGN_ACTIVITIES.path}/realestate`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'activities/realestate',
+  },
   storeKey: 'RealEstateActivity',
-  label: i18n.t('foreign.subsection.activities.realestate')
+  label: i18n.t('foreign.subsection.activities.realestate'),
+  parentKey: FOREIGN_ACTIVITIES.key,
 }
 
 const FOREIGN_ACTIVITIES_BENEFITS = {
   key: sections.FOREIGN_ACTIVITIES_BENEFITS,
   name: 'benefits',
-  path: `${FOREIGN_ACTIVITIES.path}/benefits`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'activities/benefits',
+  },
   storeKey: 'BenefitActivity',
-  label: i18n.t('foreign.subsection.activities.benefits')
+  label: i18n.t('foreign.subsection.activities.benefits'),
+  parentKey: FOREIGN_ACTIVITIES.key,
 }
 
 const FOREIGN_ACTIVITIES_SUPPORT = {
   key: sections.FOREIGN_ACTIVITIES_SUPPORT,
   name: 'support',
-  path: `${FOREIGN_ACTIVITIES.path}/support`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'activities/support',
+  },
   storeKey: 'Support',
-  label: i18n.t('foreign.subsection.activities.support')
+  label: i18n.t('foreign.subsection.activities.support'),
+  parentKey: FOREIGN_ACTIVITIES.key,
 }
 
 const FOREIGN_BUSINESS = {
   key: sections.FOREIGN_BUSINESS,
   name: 'business',
-  path: `${FOREIGN.path}/business`,
-  label: i18n.t('foreign.subsection.business.label')
+  label: i18n.t('foreign.subsection.business.label'),
 }
 
 const FOREIGN_BUSINESS_ADVICE = {
   key: sections.FOREIGN_BUSINESS_ADVICE,
   name: 'advice',
-  path: `${FOREIGN_BUSINESS.path}/advice`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'business/advice',
+  },
   storeKey: 'Advice',
-  label: i18n.t('foreign.subsection.business.advice')
+  label: i18n.t('foreign.subsection.business.advice'),
+  parentKey: FOREIGN_BUSINESS.key,
 }
 
 const FOREIGN_BUSINESS_FAMILY = {
   key: sections.FOREIGN_BUSINESS_FAMILY,
   name: 'family',
-  path: `${FOREIGN_BUSINESS.path}/family`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'business/family',
+  },
   storeKey: 'Family',
-  label: i18n.t('foreign.subsection.business.family')
+  label: i18n.t('foreign.subsection.business.family'),
+  parentKey: FOREIGN_BUSINESS.key,
 }
 
 const FOREIGN_BUSINESS_EMPLOYMENT = {
   key: sections.FOREIGN_BUSINESS_EMPLOYMENT,
   name: 'employment',
-  path: `${FOREIGN_BUSINESS.path}/employment`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'business/employment',
+  },
   storeKey: 'Employment',
-  label: i18n.t('foreign.subsection.business.employment')
+  label: i18n.t('foreign.subsection.business.employment'),
+  parentKey: FOREIGN_BUSINESS.key,
 }
 
 const FOREIGN_BUSINESS_VENTURES = {
   key: sections.FOREIGN_BUSINESS_VENTURES,
-  name: 'ventues',
-  path: `${FOREIGN_BUSINESS.path}/ventures`,
+  name: 'ventures',
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'business/ventures',
+  },
   storeKey: 'Ventures',
-  label: i18n.t('foreign.subsection.business.ventures')
+  label: i18n.t('foreign.subsection.business.ventures'),
+  parentKey: FOREIGN_BUSINESS.key,
 }
 
 const FOREIGN_BUSINESS_CONFERENCES = {
   key: sections.FOREIGN_BUSINESS_CONFERENCES,
   name: 'conferences',
-  path: `${FOREIGN_BUSINESS.path}/conferences`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'business/conferences',
+  },
   storeKey: 'Conferences',
-  label: i18n.t('foreign.subsection.business.conferences')
+  label: i18n.t('foreign.subsection.business.conferences'),
+  parentKey: FOREIGN_BUSINESS.key,
 }
 
 const FOREIGN_BUSINESS_CONTACT = {
   key: sections.FOREIGN_BUSINESS_CONTACT,
   name: 'contact',
-  path: `${FOREIGN_BUSINESS.path}/contact`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'business/contact',
+  },
   storeKey: 'Contact',
-  label: i18n.t('foreign.subsection.business.contact')
+  label: i18n.t('foreign.subsection.business.contact'),
+  parentKey: FOREIGN_BUSINESS.key,
 }
 
 const FOREIGN_BUSINESS_SPONSORSHIP = {
   key: sections.FOREIGN_BUSINESS_SPONSORSHIP,
   name: 'sponsorship',
-  path: `${FOREIGN_BUSINESS.path}/sponsorship`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'business/sponsorship',
+  },
   storeKey: 'Sponsorship',
-  label: i18n.t('foreign.subsection.business.sponsorship')
+  label: i18n.t('foreign.subsection.business.sponsorship'),
+  parentKey: FOREIGN_BUSINESS.key,
 }
 
 const FOREIGN_BUSINESS_POLITICAL = {
   key: sections.FOREIGN_BUSINESS_POLITICAL,
   name: 'political',
-  path: `${FOREIGN_BUSINESS.path}/political`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'business/political',
+  },
   storeKey: 'Political',
-  label: i18n.t('foreign.subsection.business.political')
+  label: i18n.t('foreign.subsection.business.political'),
+  parentKey: FOREIGN_BUSINESS.key,
 }
 
 const FOREIGN_BUSINESS_VOTING = {
   key: sections.FOREIGN_BUSINESS_VOTING,
   name: 'voting',
-  path: `${FOREIGN_BUSINESS.path}/voting`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'business/voting',
+  },
   storeKey: 'Voting',
-  label: i18n.t('foreign.subsection.business.voting')
+  label: i18n.t('foreign.subsection.business.voting'),
+  parentKey: FOREIGN_BUSINESS.key,
 }
 
 const FOREIGN_TRAVEL = {
   key: sections.FOREIGN_TRAVEL,
   name: 'travel',
-  path: `${FOREIGN.path}/travel`,
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'travel',
+  },
   storeKey: 'Travel',
-  label: i18n.t('foreign.subsection.travel')
+  label: i18n.t('foreign.subsection.travel'),
 }
 
 const FOREIGN_REVIEW = {
   key: sections.FOREIGN_REVIEW,
   name: 'review',
-  path: `${FOREIGN.path}/review`,
-  label: i18n.t('foreign.subsection.review')
+  path: {
+    section: FOREIGN.path.section,
+    subsection: 'review',
+  },
+  label: i18n.t('foreign.subsection.review'),
 }
 
 export default {
@@ -195,8 +266,5 @@ export default {
   FOREIGN_BUSINESS_POLITICAL,
   FOREIGN_BUSINESS_VOTING,
   FOREIGN_TRAVEL,
-  FOREIGN_REVIEW
+  FOREIGN_REVIEW,
 }
-
-
-

--- a/src/config/formSections/history.js
+++ b/src/config/formSections/history.js
@@ -4,55 +4,75 @@ import { i18n } from '@config'
 const HISTORY = {
   key: sections.HISTORY,
   name: 'history',
-  path: '/history',
+  path: {
+    section: 'history',
+  },
   store: 'History',
-  label: i18n.t('history.section.name')
+  label: i18n.t('history.section.name'),
 }
 
 const HISTORY_INTRO = {
   key: sections.HISTORY_INTRO,
   name: 'intro',
-  path: `${HISTORY.path}/intro`,
-  label: i18n.t('history.subsection.intro')
+  path: {
+    section: HISTORY.path.section,
+    subsection: 'intro',
+  },
+  label: i18n.t('history.subsection.intro'),
 }
 
 const HISTORY_RESIDENCE = {
   key: sections.HISTORY_RESIDENCE,
   name: 'residence',
-  path: `${HISTORY.path}/residence`,
+  path: {
+    section: HISTORY.path.section,
+    subsection: 'residence',
+  },
   storeKey: 'Residence',
-  label: i18n.t('history.subsection.residence')
+  label: i18n.t('history.subsection.residence'),
 }
 
 const HISTORY_EMPLOYMENT = {
   key: sections.HISTORY_EMPLOYMENT,
   name: 'employment',
-  path: `${HISTORY.path}/employment`,
+  path: {
+    section: HISTORY.path.section,
+    subsection: 'employment',
+  },
   storeKey: 'Employment',
-  label: i18n.t('history.subsection.employment')
+  label: i18n.t('history.subsection.employment'),
 }
 
 const HISTORY_EDUCATION = {
   key: sections.HISTORY_EDUCATION,
   name: 'education',
-  path: `${HISTORY.path}/education`,
+  path: {
+    section: HISTORY.path.section,
+    subsection: 'education',
+  },
   storeKey: 'Education',
-  label: i18n.t('history.subsection.education')
+  label: i18n.t('history.subsection.education'),
 }
 
 const HISTORY_FEDERAL = {
   key: sections.HISTORY_FEDERAL,
   name: 'federal',
-  path: `${HISTORY.path}/federal`,
+  path: {
+    section: HISTORY.path.section,
+    subsection: 'federal',
+  },
   storeKey: 'Federal',
-  label: i18n.t('history.subsection.federal')
+  label: i18n.t('history.subsection.federal'),
 }
 
 const HISTORY_REVIEW = {
   key: sections.HISTORY_REVIEW,
   name: 'review',
-  path: `${HISTORY.path}/review`,
-  label: i18n.t('history.subsection.review')
+  path: {
+    section: HISTORY.path.section,
+    subsection: 'review',
+  },
+  label: i18n.t('history.subsection.review'),
 }
 
 export default {

--- a/src/config/formSections/identification.js
+++ b/src/config/formSections/identification.js
@@ -4,79 +4,107 @@ import { i18n } from '@config'
 export const IDENTIFICATION = {
   key: sections.IDENTIFICATION,
   name: 'identification',
-  path: '/identification',
+  path: {
+    section: 'identification',
+  },
   store: 'Identification',
-  label: i18n.t('identification.section.name')
+  label: i18n.t('identification.section.name'),
 }
 
 export const IDENTIFICATION_INTRO = {
   key: sections.IDENTIFICATION_INTRO,
   name: 'intro',
-  path: `${IDENTIFICATION.path}/intro`,
-  label: i18n.t('identification.subsection.intro')
+  path: {
+    section: IDENTIFICATION.path.section,
+    subsection: 'intro',
+  },
+  label: i18n.t('identification.subsection.intro'),
 }
 
 export const IDENTIFICATION_NAME = {
   key: sections.IDENTIFICATION_NAME,
   name: 'name',
-  path: `${IDENTIFICATION.path}/name`,
+  path: {
+    section: IDENTIFICATION.path.section,
+    subsection: 'name',
+  },
   storeKey: 'ApplicantName',
-  label: i18n.t('identification.subsection.name')
+  label: i18n.t('identification.subsection.name'),
 }
 
 export const IDENTIFICATION_BIRTH_DATE = {
   key: sections.IDENTIFICATION_BIRTH_DATE,
   name: 'birthdate',
-  path: `${IDENTIFICATION.path}/birthdate`,
+  path: {
+    section: IDENTIFICATION.path.section,
+    subsection: 'birthdate',
+  },
   storeKey: 'ApplicantBirthDate',
-  label: i18n.t('identification.subsection.birthdate')
+  label: i18n.t('identification.subsection.birthdate'),
 }
 
 export const IDENTIFICATION_BIRTH_PLACE = {
   key: sections.IDENTIFICATION_BIRTH_PLACE,
   name: 'birthplace',
-  path: `${IDENTIFICATION.path}/birthplace`,
-  storeKey: 'ApplicantBirthPlace',
-  label: i18n.t('identification.subsection.birthplace')
+  path: {
+    section: IDENTIFICATION.path.section,
+    subsection: 'birthplace',
+  },
+  label: i18n.t('identification.subsection.birthplace'),
 }
 
 export const IDENTIFICATION_SSN = {
   key: sections.IDENTIFICATION_SSN,
   name: 'ssn',
-  path: `${IDENTIFICATION.path}/ssn`,
+  path: {
+    section: IDENTIFICATION.path.section,
+    subsection: 'ssn',
+  },
   storeKey: 'ApplicantSSN',
-  label: i18n.t('identification.subsection.ssn')
+  label: i18n.t('identification.subsection.ssn'),
 }
 
 export const IDENTIFICATION_OTHER_NAMES = {
   key: sections.IDENTIFICATION_OTHER_NAMES,
   name: 'othernames',
-  path: `${IDENTIFICATION.path}/othernames`,
+  path: {
+    section: IDENTIFICATION.path.section,
+    subsection: 'othernames',
+  },
   storeKey: 'OtherNames',
-  label: i18n.t('identification.subsection.othernames')
+  label: i18n.t('identification.subsection.othernames'),
 }
 
 export const IDENTIFICATION_CONTACTS = {
   key: sections.IDENTIFICATION_CONTACTS,
   name: 'contacts',
-  path: `${IDENTIFICATION.path}/contacts`,
+  path: {
+    section: IDENTIFICATION.path.section,
+    subsection: 'contacts',
+  },
   storeKey: 'Contacts',
-  label: i18n.t('identification.subsection.contacts')
+  label: i18n.t('identification.subsection.contacts'),
 }
 
 export const IDENTIFICATION_PHYSICAL = {
   key: sections.IDENTIFICATION_PHYSICAL,
   name: 'physical',
-  path: `${IDENTIFICATION.path}/physical`,
+  path: {
+    section: IDENTIFICATION.path.section,
+    subsection: 'physical',
+  },
   storeKey: 'Physical',
-  label: i18n.t('identification.destination.physical')
+  label: i18n.t('identification.destination.physical'),
 }
 
 export const IDENTIFICATION_REVIEW = {
   key: sections.IDENTIFICATION_REVIEW,
   name: 'review',
-  path: `${IDENTIFICATION.path}/review`,
-  label: i18n.t('identification.subsection.review')
+  path: {
+    section: IDENTIFICATION.path.section,
+    subsection: 'review',
+  },
+  label: i18n.t('identification.subsection.review'),
 }
 
 export default {

--- a/src/config/formSections/legal.js
+++ b/src/config/formSections/legal.js
@@ -4,194 +4,269 @@ import { i18n } from '@config'
 const LEGAL = {
   key: sections.LEGAL,
   name: 'legal',
-  path: '/legal',
+  path: {
+    section: 'legal',
+  },
   store: 'Legal',
-  label: i18n.t('legal.section.name')
+  label: i18n.t('legal.section.name'),
 }
 
 const LEGAL_INTRO = {
   key: sections.LEGAL_INTRO,
   name: 'intro',
-  path: `${LEGAL.path}/intro`,
-  label: i18n.t('legal.subsection.intro')
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'intro',
+  },
+  label: i18n.t('legal.subsection.intro'),
 }
 
 const LEGAL_POLICE = {
   key: sections.LEGAL_POLICE,
   name: 'police',
-  path: `${LEGAL.path}/police`,
-  label: i18n.t('legal.subsection.police.label')
+  label: i18n.t('legal.subsection.police.label'),
 }
 
 const LEGAL_POLICE_INTRO = {
   key: sections.LEGAL_POLICE_INTRO,
   name: 'intro',
-  path: `${LEGAL_POLICE.path}/intro`,
-  label: i18n.t('legal.subsection.police.intro')
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'police/intro',
+  },
+  label: i18n.t('legal.subsection.police.intro'),
+  parentKey: LEGAL_POLICE.key,
 }
 
 const LEGAL_POLICE_OFFENSES = {
   key: sections.LEGAL_POLICE_OFFENSES,
   name: 'offenses',
-  path: `${LEGAL_POLICE.path}/offenses`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'police/offenses',
+  },
   storeKey: 'PoliceOffenses',
-  label: i18n.t('legal.subsection.police.offenses')
+  label: i18n.t('legal.subsection.police.offenses'),
+  parentKey: LEGAL_POLICE.key,
 }
 
 const LEGAL_POLICE_ADDITIONAL_OFFENSES = {
   key: sections.LEGAL_POLICE_ADDITIONAL_OFFENSES,
   name: 'additionaloffenses',
-  path: `${LEGAL_POLICE.path}/additionaloffenses`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'police/additionaloffenses',
+  },
   storeKey: 'PoliceOtherOffenses',
-  label: i18n.t('legal.subsection.police.additionalOffenses')
+  label: i18n.t('legal.subsection.police.additionalOffenses'),
+  parentKey: LEGAL_POLICE.key,
 }
 
 const LEGAL_POLICE_DOMESTIC_VIOLENCE = {
   key: sections.LEGAL_POLICE_DOMESTIC_VIOLENCE,
   name: 'domesticviolence',
-  path: `${LEGAL_POLICE.path}/domesticviolence`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'police/domesticviolence',
+  },
   storeKey: 'PoliceDomesticViolence',
-  label: i18n.t('legal.subsection.police.domesticViolence')
+  label: i18n.t('legal.subsection.police.domesticViolence'),
+  parentKey: LEGAL_POLICE.key,
 }
 
 const LEGAL_INVESTIGATIONS = {
   key: sections.LEGAL_INVESTIGATIONS,
   name: 'investigations',
-  path: `${LEGAL.path}/investigations`,
-  label: i18n.t('legal.subsection.investigations.label')
+  label: i18n.t('legal.subsection.investigations.label'),
 }
 
 const LEGAL_INVESTIGATIONS_HISTORY = {
   key: sections.LEGAL_INVESTIGATIONS_HISTORY,
   name: 'history',
-  path: `${LEGAL_INVESTIGATIONS.path}/history`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'investigations/history',
+  },
   storeKey: 'History',
-  label: i18n.t('legal.subsection.investigations.history')
+  label: i18n.t('legal.subsection.investigations.history'),
+  parentKey: LEGAL_INVESTIGATIONS.key,
 }
 
 const LEGAL_INVESTIGATIONS_REVOKED = {
   key: sections.LEGAL_INVESTIGATIONS_REVOKED,
   name: 'revoked',
-  path: `${LEGAL_INVESTIGATIONS.path}/revoked`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'investigations/revoked',
+  },
   storeKey: 'Revoked',
-  label: i18n.t('legal.subsection.investigations.revoked')
+  label: i18n.t('legal.subsection.investigations.revoked'),
+  parentKey: LEGAL_INVESTIGATIONS.key,
 }
 
 const LEGAL_INVESTIGATIONS_DEBARRED = {
   key: sections.LEGAL_INVESTIGATIONS_DEBARRED,
   name: 'debarred',
-  path: `${LEGAL_INVESTIGATIONS.path}/debarred`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'investigations/debarred',
+  },
   storeKey: 'Debarred',
-  label: i18n.t('legal.subsection.investigations.debarred')
+  label: i18n.t('legal.subsection.investigations.debarred'),
+  parentKey: LEGAL_INVESTIGATIONS.key,
 }
 
 const LEGAL_COURT = {
   key: sections.LEGAL_COURT,
   name: 'court',
-  path: `${LEGAL.path}/court`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'court',
+  },
   storeKey: 'NonCrimincalCourtActions',
-  label: i18n.t('legal.subsection.court')
+  label: i18n.t('legal.subsection.court'),
 }
 
 const LEGAL_TECHNOLOGY = {
   key: sections.LEGAL_TECHNOLOGY,
   name: 'technology',
-  path: `${LEGAL.path}/technology`,
-  label: i18n.t('legal.subsection.technology.label')
+  label: i18n.t('legal.subsection.technology.label'),
 }
 
 const LEGAL_TECHNOLOGY_UNAUTHORIZED = {
   key: sections.LEGAL_TECHNOLOGY_UNAUTHORIZED,
   name: 'unauthorized',
-  path: `${LEGAL_TECHNOLOGY.path}/unauthorized`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'technology/unauthorized',
+  },
   storeKey: 'Unauthorized',
-  label: i18n.t('legal.subsection.technology.unauthorized')
+  label: i18n.t('legal.subsection.technology.unauthorized'),
+  parentKey: LEGAL_TECHNOLOGY.key,
 }
 
 const LEGAL_TECHNOLOGY_MANIPULATING = {
   key: sections.LEGAL_TECHNOLOGY_MANIPULATING,
   name: 'manipulating',
-  path: `${LEGAL_TECHNOLOGY.path}/manipulating`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'technology/manipulating',
+  },
   storeKey: 'Manipulating',
-  label: i18n.t('legal.subsection.technology.manipulating')
+  label: i18n.t('legal.subsection.technology.manipulating'),
+  parentKey: LEGAL_TECHNOLOGY.key,
 }
 
 const LEGAL_TECHNOLOGY_UNLAWFUL = {
   key: sections.LEGAL_TECHNOLOGY_UNLAWFUL,
   name: 'unlawful',
-  path: `${LEGAL_TECHNOLOGY.path}/unlawful`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'technology/unlawful',
+  },
   storeKey: 'Unlawful',
-  label: i18n.t('legal.subsection.technology.unlawful')
+  label: i18n.t('legal.subsection.technology.unlawful'),
+  parentKey: LEGAL_TECHNOLOGY.key,
 }
 
 const LEGAL_ASSOCIATIONS = {
   key: sections.LEGAL_ASSOCIATIONS,
   name: 'associations',
-  path: `${LEGAL.path}/associations`,
-  label: i18n.t('legal.subsection.associations.label')
+  label: i18n.t('legal.subsection.associations.label'),
 }
 
 const LEGAL_ASSOCIATIONS_TERRORIST_ORGANIZATION = {
   key: sections.LEGAL_ASSOCIATIONS_TERRORIST_ORGANIZATION,
   name: 'terrorist-organization',
-  path: `${LEGAL_ASSOCIATIONS.path}/terrorist-organization`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'associations/terrorist-organization',
+  },
   storeKey: 'TerroristOrganization',
-  label: i18n.t('legal.subsection.associations.terroristOrganization')
+  label: i18n.t('legal.subsection.associations.terroristOrganization'),
+  parentKey: LEGAL_ASSOCIATIONS.key,
 }
 
 const LEGAL_ASSOCIATIONS_ENGAGED_IN_TERRORISM = {
   key: sections.LEGAL_ASSOCIATIONS_ENGAGED_IN_TERRORISM,
   name: 'engaged-in-terrorism',
-  path: `${LEGAL_ASSOCIATIONS.path}/engaged-in-terrorism`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'associations/engaged-in-terrorism',
+  },
   storeKey: 'EngagedInTerrorism',
-  label: i18n.t('legal.subsection.associations.engagedTerrorism')
+  label: i18n.t('legal.subsection.associations.engagedTerrorism'),
+  parentKey: LEGAL_ASSOCIATIONS.key,
 }
 
 const LEGAL_ASSOCIATIONS_ADVOCATING = {
   key: sections.LEGAL_ASSOCIATIONS_ADVOCATING,
   name: 'advocating',
-  path: `${LEGAL_ASSOCIATIONS.path}/advocating`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'associations/advocating',
+  },
   storeKey: 'Advocating',
-  label: i18n.t('legal.subsection.associations.advocating')
+  label: i18n.t('legal.subsection.associations.advocating'),
+  parentKey: LEGAL_ASSOCIATIONS.key,
 }
 
 const LEGAL_ASSOCIATIONS_MEMBERSHIP_OVERTHROW = {
   key: sections.LEGAL_ASSOCIATIONS_MEMBERSHIP_OVERTHROW,
   name: 'membership-overthrow',
-  path: `${LEGAL_ASSOCIATIONS.path}/membership-overthrow`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'associations/membership-overthrow',
+  },
   storeKey: 'MembershipOverthrow',
-  label: i18n.t('legal.subsection.associations.overthrow')
+  label: i18n.t('legal.subsection.associations.overthrow'),
+  parentKey: LEGAL_ASSOCIATIONS.key,
 }
 
 const LEGAL_ASSOCIATIONS_MEMBERSHIP_VIOLENCE = {
   key: sections.LEGAL_ASSOCIATIONS_MEMBERSHIP_VIOLENCE,
   name: 'membership-violence-or-force',
-  path: `${LEGAL_ASSOCIATIONS.path}/membership-violence-or-force`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'associations/membership-violence-or-force',
+  },
   storeKey: 'MembershipViolence',
-  label: i18n.t('legal.subsection.associations.violence')
+  label: i18n.t('legal.subsection.associations.violence'),
+  parentKey: LEGAL_ASSOCIATIONS.key,
 }
 
 const LEGAL_ASSOCIATIONS_ACTIVITIES_TO_OVERTHROW = {
   key: sections.LEGAL_ASSOCIATIONS_ACTIVITIES_TO_OVERTHROW,
   name: 'activities-to-overthrow',
-  path: `${LEGAL_ASSOCIATIONS.path}/activities-to-overthrow`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'associations/activities-to-overthrow',
+  },
   storeKey: 'ActivitiesToOverthrow',
-  label: i18n.t('legal.subsection.associations.activitiesOverthrow')
+  label: i18n.t('legal.subsection.associations.activitiesOverthrow'),
+  parentKey: LEGAL_ASSOCIATIONS.key,
 }
 
 const LEGAL_ASSOCIATIONS_TERRORISM_ASSOCIATION = {
   key: sections.LEGAL_ASSOCIATIONS_TERRORISM_ASSOCIATION,
   name: 'terrorism-association',
-  path: `${LEGAL_ASSOCIATIONS.path}/terrorism-association`,
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'associations/terrorism-association',
+  },
   storeKey: 'TerrorismAssociation',
-  label: i18n.t('legal.subsection.associations.terrorismAssociation')
+  label: i18n.t('legal.subsection.associations.terrorismAssociation'),
+  parentKey: LEGAL_ASSOCIATIONS.key,
 }
 
 const LEGAL_REVIEW = {
   key: sections.LEGAL_REVIEW,
   name: 'review',
-  path: `${LEGAL.path}/review`,
-  label: i18n.t('legal.subsection.review')
+  path: {
+    section: LEGAL.path.section,
+    subsection: 'review',
+  },
+  label: i18n.t('legal.subsection.review'),
 }
 
 export default {
@@ -219,5 +294,5 @@ export default {
   LEGAL_ASSOCIATIONS_MEMBERSHIP_VIOLENCE,
   LEGAL_ASSOCIATIONS_ACTIVITIES_TO_OVERTHROW,
   LEGAL_ASSOCIATIONS_TERRORISM_ASSOCIATION,
-  LEGAL_REVIEW
+  LEGAL_REVIEW,
 }

--- a/src/config/formSections/military.js
+++ b/src/config/formSections/military.js
@@ -4,55 +4,75 @@ import { i18n } from '@config'
 const MILITARY = {
   key: sections.MILITARY,
   name: 'military',
-  path: '/military',
+  path: {
+    section: 'military',
+  },
   store: 'Military',
-  label: i18n.t('military.section.name')
+  label: i18n.t('military.section.name'),
 }
 
 const MILITARY_INTRO = {
   key: sections.MILITARY_INTRO,
   name: 'intro',
-  path: `${MILITARY.path}/intro`,
-  label: i18n.t('military.subsection.intro')
+  path: {
+    section: MILITARY.path.section,
+    subsection: 'intro',
+  },
+  label: i18n.t('military.subsection.intro'),
 }
 
 const MILITARY_SELECTIVE = {
   key: sections.MILITARY_SELECTIVE,
   name: 'selective',
-  path: `${MILITARY.path}/selective`,
+  path: {
+    section: MILITARY.path.section,
+    subsection: 'selective',
+  },
   storeKey: 'Selective',
-  label: i18n.t('military.subsection.selective')
+  label: i18n.t('military.subsection.selective'),
 }
 
 const MILITARY_HISTORY = {
   key: sections.MILITARY_HISTORY,
   name: 'history',
-  path: `${MILITARY.path}/history`,
+  path: {
+    section: MILITARY.path.section,
+    subsection: 'history',
+  },
   storeKey: 'History',
-  label: i18n.t('military.subsection.history')
+  label: i18n.t('military.subsection.history'),
 }
 
 const MILITARY_DISCIPLINARY = {
   key: sections.MILITARY_DISCIPLINARY,
   name: 'disciplinary',
-  path: `${MILITARY.path}/disciplinary`,
+  path: {
+    section: MILITARY.path.section,
+    subsection: 'disciplinary',
+  },
   storeKey: 'Disciplinary',
-  label: i18n.t('military.subsection.disciplinary')
+  label: i18n.t('military.subsection.disciplinary'),
 }
 
 const MILITARY_FOREIGN = {
   key: sections.MILITARY_FOREIGN,
   name: 'foreign',
-  path: `${MILITARY.path}/foreign`,
+  path: {
+    section: MILITARY.path.section,
+    subsection: 'foreign',
+  },
   storeKey: 'Foreign',
-  label: i18n.t('military.subsection.foreign')
+  label: i18n.t('military.subsection.foreign'),
 }
 
 const MILITARY_REVIEW = {
   key: sections.MILITARY_REVIEW,
   name: 'review',
-  path: `${MILITARY.path}/review`,
-  label: i18n.t('military.subsection.review')
+  path: {
+    section: MILITARY.path.section,
+    subsection: 'review',
+  },
+  label: i18n.t('military.subsection.review'),
 }
 
 export default {
@@ -62,5 +82,5 @@ export default {
   MILITARY_HISTORY,
   MILITARY_DISCIPLINARY,
   MILITARY_FOREIGN,
-  MILITARY_REVIEW
+  MILITARY_REVIEW,
 }

--- a/src/config/formSections/psychological.js
+++ b/src/config/formSections/psychological.js
@@ -4,62 +4,85 @@ import { i18n } from '@config'
 const PSYCHOLOGICAL = {
   key: sections.PSYCHOLOGICAL,
   name: 'psychological',
-  path: '/psychological',
+  path: {
+    section: 'psychological',
+  },
   store: 'Psychological',
-  label: i18n.t('psychological.section.name')
+  label: i18n.t('psychological.section.name'),
 }
 
 const PSYCHOLOGICAL_INTRO = {
   key: sections.PSYCHOLOGICAL_INTRO,
   name: 'intro',
-  path: `${PSYCHOLOGICAL.path}/intro`,
-  label: i18n.t('psychological.subsection.intro')
+  path: {
+    section: PSYCHOLOGICAL.path.section,
+    subsection: 'intro',
+  },
+  label: i18n.t('psychological.subsection.intro'),
 }
 
 const PSYCHOLOGICAL_COMPETENCE = {
   key: sections.PSYCHOLOGICAL_COMPETENCE,
   name: 'competence',
-  path: `${PSYCHOLOGICAL.path}/competence`,
+  path: {
+    section: PSYCHOLOGICAL.path.section,
+    subsection: 'competence',
+  },
   storeKey: 'Competence',
-  label: i18n.t('psychological.subsection.competence')
+  label: i18n.t('psychological.subsection.competence'),
 }
 
 const PSYCHOLOGICAL_CONSULTATIONS = {
   key: sections.PSYCHOLOGICAL_CONSULTATIONS,
   name: 'consultations',
-  path: `${PSYCHOLOGICAL.path}/consultations`,
+  path: {
+    section: PSYCHOLOGICAL.path.section,
+    subsection: 'consultations',
+  },
   storeKey: 'Consultations',
-  label: i18n.t('psychological.subsection.consultations')
+  label: i18n.t('psychological.subsection.consultations'),
 }
 const PSYCHOLOGICAL_HOSPITALIZATIONS = {
   key: sections.PSYCHOLOGICAL_HOSPITALIZATIONS,
   name: 'hospitalizations',
-  path: `${PSYCHOLOGICAL.path}/hospitalizations`,
+  path: {
+    section: PSYCHOLOGICAL.path.section,
+    subsection: 'hospitalizations',
+  },
   storeKey: 'Hospitalizations',
-  label: i18n.t('psychological.subsection.hospitalizations')
+  label: i18n.t('psychological.subsection.hospitalizations'),
 }
 
 const PSYCHOLOGICAL_DIAGNOSES = {
   key: sections.PSYCHOLOGICAL_DIAGNOSES,
   name: 'diagnoses',
-  path: `${PSYCHOLOGICAL.path}/diagnoses`,
+  path: {
+    section: PSYCHOLOGICAL.path.section,
+    subsection: 'diagnoses',
+  },
   storeKey: 'Diagnoses',
-  label: i18n.t('psychological.subsection.diagnoses')
+  label: i18n.t('psychological.subsection.diagnoses'),
 }
 
 const PSYCHOLOGICAL_CONDITIONS = {
   key: sections.PSYCHOLOGICAL_CONDITIONS,
   name: 'conditions',
-  path: `${PSYCHOLOGICAL.path}/conditions`,
+  path: {
+    section: PSYCHOLOGICAL.path.section,
+    subsection: 'conditions',
+  },
   storeKey: 'Conditions',
-  label: i18n.t('psychological.subsection.conditions')
+  label: i18n.t('psychological.subsection.conditions'),
 }
 
 const PSYCHOLOGICAL_REVIEW = {
   key: sections.PSYCHOLOGICAL_REVIEW,
   name: 'review',
-  path: `${PSYCHOLOGICAL.path}/review`,
-  label: i18n.t('psychological.subsection.review')
+  path: {
+    section: PSYCHOLOGICAL.path.section,
+    subsection: 'review',
+  },
+  label: i18n.t('psychological.subsection.review'),
 }
 
 export default {
@@ -70,5 +93,5 @@ export default {
   PSYCHOLOGICAL_HOSPITALIZATIONS,
   PSYCHOLOGICAL_DIAGNOSES,
   PSYCHOLOGICAL_CONDITIONS,
-  PSYCHOLOGICAL_REVIEW
+  PSYCHOLOGICAL_REVIEW,
 }

--- a/src/config/formSections/relationships.js
+++ b/src/config/formSections/relationships.js
@@ -4,61 +4,83 @@ import { i18n } from '@config'
 const RELATIONSHIPS = {
   key: sections.RELATIONSHIPS,
   name: 'relationships',
-  path: '/relationships',
+  path: {
+    section: 'relationships',
+  },
   store: 'Relationships',
-  label: i18n.t('relationships.section.name')
+  label: i18n.t('relationships.section.name'),
 }
 
 const RELATIONSHIPS_INTRO = {
   key: sections.RELATIONSHIPS_INTRO,
   name: 'intro',
-  path: `${RELATIONSHIPS.path}/intro`,
-  label: i18n.t('relationships.subsection.intro')
+  path: {
+    section: RELATIONSHIPS.path.section,
+    subsection: 'intro',
+  },
+  label: i18n.t('relationships.subsection.intro'),
 }
 
 const RELATIONSHIPS_STATUS = {
   key: sections.RELATIONSHIPS_STATUS,
   name: 'status',
-  label: i18n.t('relationships.subsection.status')
+  label: i18n.t('relationships.subsection.status'),
 }
 
 const RELATIONSHIPS_STATUS_MARITAL = {
   key: sections.RELATIONSHIPS_STATUS_MARITAL,
   name: 'marital',
-  path: `${RELATIONSHIPS_STATUS.path}/marital`,
+  path: {
+    section: RELATIONSHIPS.path.section,
+    subsection: 'status/marital',
+  },
   storeKey: 'Marital',
-  label: i18n.t('relationships.subsection.marital')
+  label: i18n.t('relationships.subsection.marital'),
+  parentKey: RELATIONSHIPS_STATUS.key,
 }
 
 const RELATIONSHIPS_STATUS_COHABITANTS = {
   key: sections.RELATIONSHIPS_STATUS_COHABITANTS,
   name: 'cohabitants',
-  path: `${RELATIONSHIPS_STATUS.path}/cohabitants`,
+  path: {
+    section: RELATIONSHIPS.path.section,
+    subsection: 'status/cohabitants',
+  },
   storeKey: 'Cohabitants',
-  label: i18n.t('relationships.subsection.cohabitants')
+  label: i18n.t('relationships.subsection.cohabitants'),
+  parentKey: RELATIONSHIPS_STATUS.key,
 }
 
 const RELATIONSHIPS_PEOPLE = {
   key: sections.RELATIONSHIPS_PEOPLE,
   name: 'people',
-  path: `${RELATIONSHIPS.path}/people`,
+  path: {
+    section: RELATIONSHIPS.path.section,
+    subsection: 'people',
+  },
   storeKey: 'People',
-  label: i18n.t('relationships.subsection.people')
+  label: i18n.t('relationships.subsection.people'),
 }
 
 const RELATIONSHIPS_RELATIVES = {
   key: sections.RELATIONSHIPS_RELATIVES,
   name: 'relatives',
-  path: `${RELATIONSHIPS.path}/relatives`,
+  path: {
+    section: RELATIONSHIPS.path.section,
+    subsection: 'relatives',
+  },
   storeKey: 'Relatives',
-  label: i18n.t('relationships.subsection.relatives')
+  label: i18n.t('relationships.subsection.relatives'),
 }
 
 const RELATIONSHIPS_REVIEW = {
   key: sections.RELATIONSHIPS_REVIEW,
   name: 'review',
-  path: `${RELATIONSHIPS.path}/review`,
-  label: i18n.t('relationships.subsection.review')
+  path: {
+    section: RELATIONSHIPS.path.section,
+    subsection: 'review',
+  },
+  label: i18n.t('relationships.subsection.review'),
 }
 
 export default {
@@ -69,5 +91,5 @@ export default {
   RELATIONSHIPS_STATUS_COHABITANTS,
   RELATIONSHIPS_PEOPLE,
   RELATIONSHIPS_RELATIVES,
-  RELATIONSHIPS_REVIEW
+  RELATIONSHIPS_REVIEW,
 }

--- a/src/config/formSections/substanceUse.js
+++ b/src/config/formSections/substanceUse.js
@@ -4,125 +4,175 @@ import { i18n } from '@config'
 const SUBSTANCE_USE = {
   key: sections.SUBSTANCE_USE,
   name: 'substance',
-  path: '/substance',
+  path: {
+    section: 'substance',
+  },
   store: 'Substance',
-  label: i18n.t('substance.section.name')
+  label: i18n.t('substance.section.name'),
 }
 
 const SUBSTANCE_USE_INTRO = {
   key: sections.SUBSTANCE_USE_INTRO,
   name: 'intro',
-  path: `${SUBSTANCE_USE.path}/intro`,
-  label: i18n.t('substance.subsection.intro')
+  path: {
+    section: SUBSTANCE_USE.path.section,
+    subsection: 'intro',
+  },
+  label: i18n.t('substance.subsection.intro'),
 }
 
 const SUBSTANCE_USE_DRUGS = {
   key: sections.SUBSTANCE_USE_DRUGS,
   name: 'drugs',
-  path: `${SUBSTANCE_USE.path}/drugs`,
-  label: i18n.t('substance.subsection.drugs.label')
+  label: i18n.t('substance.subsection.drugs.label'),
 }
 
 const SUBSTANCE_USE_DRUGS_USAGE = {
   key: sections.SUBSTANCE_USE_DRUGS_USAGE,
   name: 'usage',
-  path: `${SUBSTANCE_USE_DRUGS.path}/usage`,
+  path: {
+    section: SUBSTANCE_USE.path.section,
+    subsection: 'drugs/usage',
+  },
   storeKey: 'DrugUses',
-  label: i18n.t('substance.subsection.drugs.usage')
+  label: i18n.t('substance.subsection.drugs.usage'),
+  parentKey: SUBSTANCE_USE_DRUGS.key,
 }
 
 const SUBSTANCE_USE_DRUGS_PURCHASE = {
   key: sections.SUBSTANCE_USE_DRUGS_PURCHASE,
   name: 'purchase',
-  path: `${SUBSTANCE_USE_DRUGS.path}/purchase`,
+  path: {
+    section: SUBSTANCE_USE.path.section,
+    subsection: 'drugs/purchase',
+  },
   storeKey: 'DrugInvolvements',
-  label: i18n.t('substance.subsection.drugs.purchase')
+  label: i18n.t('substance.subsection.drugs.purchase'),
+  parentKey: SUBSTANCE_USE_DRUGS.key,
 }
 
 const SUBSTANCE_USE_DRUGS_CLEARANCE = {
   key: sections.SUBSTANCE_USE_DRUGS_CLEARANCE,
   name: 'clearance',
-  path: `${SUBSTANCE_USE_DRUGS.path}/clearance`,
+  path: {
+    section: SUBSTANCE_USE.path.section,
+    subsection: 'drugs/clearance',
+  },
   storeKey: 'DrugClearanceUses',
-  label: i18n.t('substance.subsection.drugs.clearance')
+  label: i18n.t('substance.subsection.drugs.clearance'),
+  parentKey: SUBSTANCE_USE_DRUGS.key,
 }
 
 const SUBSTANCE_USE_DRUGS_PUBLIC_SAFETY = {
   key: sections.SUBSTANCE_USE_DRUGS_PUBLIC_SAFETY,
   name: 'publicsafety',
-  path: `${SUBSTANCE_USE_DRUGS.path}/publicsafety`,
+  path: {
+    section: SUBSTANCE_USE.path.section,
+    subsection: 'drugs/publicsafety',
+  },
   storeKey: 'DrugPublicSafetyUses',
-  label: i18n.t('substance.subsection.drugs.publicsafety')
+  label: i18n.t('substance.subsection.drugs.publicsafety'),
+  parentKey: SUBSTANCE_USE_DRUGS.key,
 }
 
 const SUBSTANCE_USE_DRUGS_MISUSE = {
   key: sections.SUBSTANCE_USE_DRUGS_MISUSE,
   name: 'misuse',
-  path: `${SUBSTANCE_USE_DRUGS.path}/misuse`,
+  path: {
+    section: SUBSTANCE_USE.path.section,
+    subsection: 'drugs/misuse',
+  },
   storeKey: 'PrescriptionUses',
-  label: i18n.t('substance.subsection.drugs.misuse')
+  label: i18n.t('substance.subsection.drugs.misuse'),
+  parentKey: SUBSTANCE_USE_DRUGS.key,
 }
 
 const SUBSTANCE_USE_DRUGS_ORDERED = {
   key: sections.SUBSTANCE_USE_DRUGS_ORDERED,
   name: 'ordered',
-  path: `${SUBSTANCE_USE_DRUGS.path}/ordered`,
+  path: {
+    section: SUBSTANCE_USE.path.section,
+    subsection: 'drugs/misuse',
+  },
   storeKey: 'OrderedTreatments',
-  label: i18n.t('substance.subsection.drugs.ordered')
+  label: i18n.t('substance.subsection.drugs.ordered'),
+  parentKey: SUBSTANCE_USE_DRUGS.key,
 }
 
 const SUBSTANCE_USE_DRUGS_VOLUNTARY = {
   key: sections.SUBSTANCE_USE_DRUGS_VOLUNTARY,
   name: 'voluntary',
-  path: `${SUBSTANCE_USE_DRUGS.path}/voluntary`,
+  path: {
+    section: SUBSTANCE_USE.path.section,
+    subsection: 'drugs/volutary',
+  },
   storeKey: 'VoluntaryTreatments',
-  label: i18n.t('substance.subsection.drugs.voluntary')
+  label: i18n.t('substance.subsection.drugs.voluntary'),
+  parentKey: SUBSTANCE_USE_DRUGS.key,
 }
 
 const SUBSTANCE_USE_ALCOHOL = {
   key: sections.SUBSTANCE_USE_ALCOHOL,
   name: 'alcohol',
-  path: `${SUBSTANCE_USE.path}/alcohol`,
-  label: i18n.t('substance.subsection.alcohol.label')
+  label: i18n.t('substance.subsection.alcohol.label'),
 }
 
 const SUBSTANCE_USE_ALCOHOL_NEGATIVE = {
   key: sections.SUBSTANCE_USE_ALCOHOL_NEGATIVE,
   name: 'negative',
-  path: `${SUBSTANCE_USE_ALCOHOL.path}/negative`,
+  path: {
+    section: SUBSTANCE_USE.path.section,
+    subsection: 'alcohol/negative',
+  },
   storeKey: 'NegativeImpact',
-  label: i18n.t('substance.subsection.alcohol.negative')
+  label: i18n.t('substance.subsection.alcohol.negative'),
+  parentKey: SUBSTANCE_USE_ALCOHOL.key,
 }
 
 const SUBSTANCE_USE_ALCOHOL_ORDERED = {
   key: sections.SUBSTANCE_USE_ALCOHOL_ORDERED,
   name: 'ordered',
-  path: `${SUBSTANCE_USE_ALCOHOL.path}/ordered`,
+  path: {
+    section: SUBSTANCE_USE.path.section,
+    subsection: 'alcohol/ordered',
+  },
   storeKey: 'OrderedCounselings',
-  label: i18n.t('substance.subsection.alcohol.ordered')
+  label: i18n.t('substance.subsection.alcohol.ordered'),
+  parentKey: SUBSTANCE_USE_ALCOHOL.key,
 }
 
 const SUBSTANCE_USE_ALCOHOL_VOLUNTARY = {
   key: sections.SUBSTANCE_USE_ALCOHOL_VOLUNTARY,
   name: 'voluntary',
-  path: `${SUBSTANCE_USE_ALCOHOL.path}/voluntary`,
+  path: {
+    section: SUBSTANCE_USE.path.section,
+    subsection: 'alcohol/voluntary',
+  },
   storeKey: 'VoluntaryCounselings',
-  label: i18n.t('substance.subsection.alcohol.voluntary')
+  label: i18n.t('substance.subsection.alcohol.voluntary'),
+  parentKey: SUBSTANCE_USE_ALCOHOL.key,
 }
 
 const SUBSTANCE_USE_ALCOHOL_ADDITIONAL = {
   key: sections.SUBSTANCE_USE_ALCOHOL_ADDITIONAL,
   name: 'additional',
-  path: `${SUBSTANCE_USE_ALCOHOL.path}/additional`,
+  path: {
+    section: SUBSTANCE_USE.path.section,
+    subsection: 'alcohol/additional',
+  },
   storeKey: 'ReceivedCounselings',
-  label: i18n.t('substance.subsection.alcohol.additional')
+  label: i18n.t('substance.subsection.alcohol.additional'),
+  parentKey: SUBSTANCE_USE_ALCOHOL.key,
 }
 
 const SUBSTANCE_USE_REVIEW = {
   key: sections.SUBSTANCE_USE_REVIEW,
   name: 'review',
-  path: `${SUBSTANCE_USE.path}/review`,
-  label: i18n.t('substance.subsection.review')
+  path: {
+    section: SUBSTANCE_USE.path.section,
+    subsection: 'review',
+  },
+  label: i18n.t('substance.subsection.review'),
 }
 
 export default {
@@ -141,6 +191,5 @@ export default {
   SUBSTANCE_USE_ALCOHOL_ORDERED,
   SUBSTANCE_USE_ALCOHOL_VOLUNTARY,
   SUBSTANCE_USE_ALCOHOL_ADDITIONAL,
-  SUBSTANCE_USE_REVIEW
+  SUBSTANCE_USE_REVIEW,
 }
-

--- a/src/config/formSections/substanceUse.js
+++ b/src/config/formSections/substanceUse.js
@@ -104,7 +104,7 @@ const SUBSTANCE_USE_DRUGS_VOLUNTARY = {
   name: 'voluntary',
   path: {
     section: SUBSTANCE_USE.path.section,
-    subsection: 'drugs/volutary',
+    subsection: 'drugs/voluntary',
   },
   storeKey: 'VoluntaryTreatments',
   label: i18n.t('substance.subsection.drugs.voluntary'),

--- a/src/config/formTypes.js
+++ b/src/config/formTypes.js
@@ -33,7 +33,7 @@ export const SF85 = [
       formSections.CITIZENSHIP_MULTIPLE,
       formSections.CITIZENSHIP_PASSPORTS,
       formSections.CITIZENSHIP_REVIEW,
-    ]
+    ],
   },
   {
     ...formSections.MILITARY,
@@ -42,16 +42,16 @@ export const SF85 = [
       formSections.MILITARY_SELECTIVE,
       formSections.MILITARY_HISTORY,
       formSections.MILITARY_FOREIGN,
-      formSections.MILITARY_REVIEW
-    ]
+      formSections.MILITARY_REVIEW,
+    ],
   },
   {
     ...formSections.FOREIGN,
     subsections: [
       formSections.FOREIGN_INTRO,
       formSections.FOREIGN_PASSPORT,
-      formSections.FOREIGN_REVIEW
-    ]
+      formSections.FOREIGN_REVIEW,
+    ],
   },
   {
     ...formSections.FOREIGN,
@@ -64,8 +64,8 @@ export const SF85 = [
       formSections.FINANCIAL_CREDIT,
       formSections.FINANCIAL_DELINQUENT,
       formSections.FINANCIAL_NONPAYMENT,
-      formSections.FINANCIAL_REVIEW
-    ]
+      formSections.FINANCIAL_REVIEW,
+    ],
   },
   {
     ...formSections.SUBSTANCE_USE,
@@ -80,7 +80,7 @@ export const SF85 = [
       formSections.SUBSTANCE_USE_DRUGS_ORDERED,
       formSections.SUBSTANCE_USE_DRUGS_VOLUNTARY,
       formSections.SUBSTANCE_USE_REVIEW,
-    ]
+    ],
   },
   {
     ...formSections.LEGAL_INTRO,
@@ -102,9 +102,9 @@ export const SF85 = [
       formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_VIOLENCE,
       formSections.LEGAL_ASSOCIATIONS_ACTIVITIES_TO_OVERTHROW,
       formSections.LEGAL_ASSOCIATIONS_TERRORISM_ASSOCIATION,
-      formSections.LEGAL_REVIEW
-    ]
-  }
+      formSections.LEGAL_REVIEW,
+    ],
+  },
 ]
 
 export const SF85P = [
@@ -143,8 +143,8 @@ export const SF85P = [
       formSections.RELATIONSHIPS_STATUS_COHABITANTS,
       formSections.RELATIONSHIPS_PEOPLE,
       formSections.RELATIONSHIPS_RELATIVES,
-      formSections.RELATIONSHIPS_REVIEW
-    ]
+      formSections.RELATIONSHIPS_REVIEW,
+    ],
   },
   {
     ...formSections.CITIZENSHIP,
@@ -153,8 +153,8 @@ export const SF85P = [
       formSections.CITIZENSHIP_STATUS,
       formSections.CITIZENSHIP_MULTIPLE,
       formSections.CITIZENSHIP_PASSPORTS,
-      formSections.CITIZENSHIP_REVIEW
-    ]
+      formSections.CITIZENSHIP_REVIEW,
+    ],
   },
   {
     ...formSections.MILITARY,
@@ -163,8 +163,8 @@ export const SF85P = [
       formSections.MILITARY_SELECTIVE,
       formSections.MILITARY_HISTORY,
       formSections.MILITARY_FOREIGN,
-      formSections.MILITARY_REVIEW
-    ]
+      formSections.MILITARY_REVIEW,
+    ],
   },
   {
     ...formSections.FOREIGN,
@@ -172,8 +172,8 @@ export const SF85P = [
       formSections.FOREIGN_INTRO,
       formSections.FOREIGN_PASSPORT,
       formSections.FOREIGN_TRAVEL,
-      formSections.FOREIGN_REVIEW
-    ]
+      formSections.FOREIGN_REVIEW,
+    ],
   },
   {
     ...formSections.FINANCIAL,
@@ -186,8 +186,8 @@ export const SF85P = [
       formSections.FINANCIAL_CREDIT,
       formSections.FINANCIAL_DELINQUENT,
       formSections.FINANCIAL_NONPAYMENT,
-      formSections.FINANCIAL_REVIEW
-    ]
+      formSections.FINANCIAL_REVIEW,
+    ],
   },
   {
     ...formSections.SUBSTANCE_USE,
@@ -207,8 +207,8 @@ export const SF85P = [
       formSections.SUBSTANCE_USE_ALCOHOL_ORDERED,
       formSections.SUBSTANCE_USE_ALCOHOL_VOLUNTARY,
       formSections.SUBSTANCE_USE_ALCOHOL_ADDITIONAL,
-      formSections.SUBSTANCE_USE_REVIEW
-    ]
+      formSections.SUBSTANCE_USE_REVIEW,
+    ],
   },
   {
     ...formSections.LEGAL,
@@ -236,9 +236,9 @@ export const SF85P = [
       formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_VIOLENCE,
       formSections.LEGAL_ASSOCIATIONS_ACTIVITIES_TO_OVERTHROW,
       formSections.LEGAL_ASSOCIATIONS_TERRORISM_ASSOCIATION,
-      formSections.LEGAL_REVIEW
-    ]
-  }
+      formSections.LEGAL_REVIEW,
+    ],
+  },
 ]
 
 export const SF86 = [
@@ -253,8 +253,8 @@ export const SF86 = [
       formSections.IDENTIFICATION_OTHER_NAMES,
       formSections.IDENTIFICATION_CONTACTS,
       formSections.IDENTIFICATION_PHYSICAL,
-      formSections.IDENTIFICATION_REVIEW
-    ]
+      formSections.IDENTIFICATION_REVIEW,
+    ],
   },
   {
     ...formSections.HISTORY,
@@ -264,8 +264,8 @@ export const SF86 = [
       formSections.HISTORY_EMPLOYMENT,
       formSections.HISTORY_EDUCATION,
       formSections.HISTORY_FEDERAL,
-      formSections.HISTORY_REVIEW
-    ]
+      formSections.HISTORY_REVIEW,
+    ],
   },
   {
     ...formSections.RELATIONSHIPS,
@@ -276,8 +276,8 @@ export const SF86 = [
       formSections.RELATIONSHIPS_STATUS_COHABITANTS,
       formSections.RELATIONSHIPS_PEOPLE,
       formSections.RELATIONSHIPS_RELATIVES,
-      formSections.RELATIONSHIPS_REVIEW
-    ]
+      formSections.RELATIONSHIPS_REVIEW,
+    ],
   },
   {
     ...formSections.CITIZENSHIP,
@@ -286,8 +286,8 @@ export const SF86 = [
       formSections.CITIZENSHIP_STATUS,
       formSections.CITIZENSHIP_MULTIPLE,
       formSections.CITIZENSHIP_PASSPORTS,
-      formSections.CITIZENSHIP_REVIEW
-    ]
+      formSections.CITIZENSHIP_REVIEW,
+    ],
   },
   {
     ...formSections.MILITARY,
@@ -297,8 +297,8 @@ export const SF86 = [
       formSections.MILITARY_HISTORY,
       formSections.MILITARY_DISCIPLINARY,
       formSections.MILITARY_FOREIGN,
-      formSections.MILITARY_REVIEW
-    ]
+      formSections.MILITARY_REVIEW,
+    ],
   },
   {
     ...formSections.FOREIGN,
@@ -323,8 +323,8 @@ export const SF86 = [
       formSections.FOREIGN_BUSINESS_POLITICAL,
       formSections.FOREIGN_BUSINESS_VOTING,
       formSections.FOREIGN_TRAVEL,
-      formSections.FOREIGN_REVIEW
-    ]
+      formSections.FOREIGN_REVIEW,
+    ],
   },
   {
     ...formSections.FINANCIAL,
@@ -337,8 +337,8 @@ export const SF86 = [
       formSections.FINANCIAL_CREDIT,
       formSections.FINANCIAL_DELINQUENT,
       formSections.FINANCIAL_NONPAYMENT,
-      formSections.FINANCIAL_REVIEW
-    ]
+      formSections.FINANCIAL_REVIEW,
+    ],
   },
   {
     ...formSections.SUBSTANCE_USE,
@@ -358,8 +358,8 @@ export const SF86 = [
       formSections.SUBSTANCE_USE_ALCOHOL_ORDERED,
       formSections.SUBSTANCE_USE_ALCOHOL_VOLUNTARY,
       formSections.SUBSTANCE_USE_ALCOHOL_ADDITIONAL,
-      formSections.SUBSTANCE_USE_REVIEW
-    ]
+      formSections.SUBSTANCE_USE_REVIEW,
+    ],
   },
   {
     ...formSections.LEGAL,
@@ -387,8 +387,8 @@ export const SF86 = [
       formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_VIOLENCE,
       formSections.LEGAL_ASSOCIATIONS_ACTIVITIES_TO_OVERTHROW,
       formSections.LEGAL_ASSOCIATIONS_TERRORISM_ASSOCIATION,
-      formSections.LEGAL_REVIEW
-    ]
+      formSections.LEGAL_REVIEW,
+    ],
   },
   {
     ...formSections.PSYCHOLOGICAL,
@@ -399,7 +399,7 @@ export const SF86 = [
       formSections.PSYCHOLOGICAL_HOSPITALIZATIONS,
       formSections.PSYCHOLOGICAL_DIAGNOSES,
       formSections.PSYCHOLOGICAL_CONDITIONS,
-      formSections.PSYCHOLOGICAL_REVIEW
-    ]
-  }
+      formSections.PSYCHOLOGICAL_REVIEW,
+    ],
+  },
 ]

--- a/src/config/formTypes.js
+++ b/src/config/formTypes.js
@@ -353,7 +353,6 @@ export const SF86 = [
       formSections.SUBSTANCE_USE_DRUGS_ORDERED,
       formSections.SUBSTANCE_USE_DRUGS_VOLUNTARY,
       formSections.SUBSTANCE_USE_ALCOHOL,
-      formSections.SUBSTANCE_USE_ALCOHOL,
       formSections.SUBSTANCE_USE_ALCOHOL_NEGATIVE,
       formSections.SUBSTANCE_USE_ALCOHOL_ORDERED,
       formSections.SUBSTANCE_USE_ALCOHOL_VOLUNTARY,

--- a/src/config/formTypes.js
+++ b/src/config/formTypes.js
@@ -71,56 +71,38 @@ export const SF85 = [
     ...formSections.SUBSTANCE_USE,
     subsections: [
       formSections.SUBSTANCE_USE_INTRO,
-      {
-        ...formSections.SUBSTANCE_USE_DRUGS,
-        subsections: [
-          formSections.SUBSTANCE_USE_DRUGS_USAGE,
-          formSections.SUBSTANCE_USE_DRUGS_PURCHASE,
-          formSections.SUBSTANCE_USE_DRUGS_CLEARANCE,
-          formSections.SUBSTANCE_USE_DRUGS_PUBLIC_SAFETY,
-          formSections.SUBSTANCE_USE_DRUGS_MISUSE,
-          formSections.SUBSTANCE_USE_DRUGS_ORDERED,
-          formSections.SUBSTANCE_USE_DRUGS_VOLUNTARY
-        ]
-      },
+      formSections.SUBSTANCE_USE_DRUGS,
+      formSections.SUBSTANCE_USE_DRUGS_USAGE,
+      formSections.SUBSTANCE_USE_DRUGS_PURCHASE,
+      formSections.SUBSTANCE_USE_DRUGS_CLEARANCE,
+      formSections.SUBSTANCE_USE_DRUGS_PUBLIC_SAFETY,
+      formSections.SUBSTANCE_USE_DRUGS_MISUSE,
+      formSections.SUBSTANCE_USE_DRUGS_ORDERED,
+      formSections.SUBSTANCE_USE_DRUGS_VOLUNTARY,
       formSections.SUBSTANCE_USE_REVIEW,
     ]
   },
   {
-    ...formSections.LEGAL,
+    ...formSections.LEGAL_INTRO,
     subsections: [
-      formSections.LEGAL_INTRO,
-      {
-        ...formSections.LEGAL_POLICE,
-        subsections: [
-          formSections.LEGAL_POLICE_INTRO,
-          formSections.LEGAL_POLICE_OFFENSES,
-          formSections.LEGAL_POLICE_ADDITIONAL_OFFENSES,
-          formSections.LEGAL_POLICE_DOMESTIC_VIOLENCE
-        ]
-      },
-      {
-        ...formSections.LEGAL_INVESTIGATIONS,
-        subsections: [
-          formSections.LEGAL_INVESTIGATIONS_HISTORY,
-          formSections.LEGAL_INVESTIGATIONS_REVOKED,
-          formSections.LEGAL_INVESTIGATIONS_DEBARRED
-        ]
-      },
-      {
-        ...formSections.LEGAL_ASSOCIATIONS,
-        subsections: [
-          formSections.LEGAL_ASSOCIATIONS_TERRORIST_ORGANIZATION,
-          formSections.LEGAL_ASSOCIATIONS_ENGAGED_IN_TERRORISM,
-          formSections.LEGAL_ASSOCIATIONS_ADVOCATING,
-          formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_OVERTHROW,
-          formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_VIOLENCE,
-          formSections.LEGAL_ASSOCIATIONS_ACTIVITIES_TO_OVERTHROW,
-          formSections.LEGAL_ASSOCIATIONS_TERRORISM_ASSOCIATION
-        ]
-      },
+      formSections.LEGAL_POLICE,
+      formSections.LEGAL_POLICE_INTRO,
+      formSections.LEGAL_POLICE_OFFENSES,
+      formSections.LEGAL_POLICE_ADDITIONAL_OFFENSES,
+      formSections.LEGAL_POLICE_DOMESTIC_VIOLENCE,
+      formSections.LEGAL_INVESTIGATIONS,
+      formSections.LEGAL_INVESTIGATIONS_HISTORY,
+      formSections.LEGAL_INVESTIGATIONS_REVOKED,
+      formSections.LEGAL_INVESTIGATIONS_DEBARRED,
+      formSections.LEGAL_ASSOCIATIONS,
+      formSections.LEGAL_ASSOCIATIONS_TERRORIST_ORGANIZATION,
+      formSections.LEGAL_ASSOCIATIONS_ENGAGED_IN_TERRORISM,
+      formSections.LEGAL_ASSOCIATIONS_ADVOCATING,
+      formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_OVERTHROW,
+      formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_VIOLENCE,
+      formSections.LEGAL_ASSOCIATIONS_ACTIVITIES_TO_OVERTHROW,
+      formSections.LEGAL_ASSOCIATIONS_TERRORISM_ASSOCIATION,
       formSections.LEGAL_REVIEW
-
     ]
   }
 ]
@@ -156,13 +138,9 @@ export const SF85P = [
     ...formSections.RELATIONSHIPS,
     subsections: [
       formSections.RELATIONSHIPS_INTRO,
-      {
-        ...formSections.RELATIONSHIPS_STATUS,
-        subsections: [
-          formSections.RELATIONSHIPS_STATUS_MARITAL,
-          formSections.RELATIONSHIPS_STATUS_COHABITANTS
-        ]
-      },
+      formSections.RELATIONSHIPS_STATUS,
+      formSections.RELATIONSHIPS_STATUS_MARITAL,
+      formSections.RELATIONSHIPS_STATUS_COHABITANTS,
       formSections.RELATIONSHIPS_PEOPLE,
       formSections.RELATIONSHIPS_RELATIVES,
       formSections.RELATIONSHIPS_REVIEW
@@ -215,28 +193,20 @@ export const SF85P = [
     ...formSections.SUBSTANCE_USE,
     subsections: [
       formSections.SUBSTANCE_USE_INTRO,
-      {
-        ...formSections.SUBSTANCE_USE_DRUGS,
-        subsections: [
-          formSections.SUBSTANCE_USE_DRUGS_USAGE,
-          formSections.SUBSTANCE_USE_DRUGS_PURCHASE,
-          formSections.SUBSTANCE_USE_DRUGS_CLEARANCE,
-          formSections.SUBSTANCE_USE_DRUGS_PUBLIC_SAFETY,
-          formSections.SUBSTANCE_USE_DRUGS_MISUSE,
-          formSections.SUBSTANCE_USE_DRUGS_ORDERED,
-          formSections.SUBSTANCE_USE_DRUGS_VOLUNTARY
-        ]
-      },
-      {
-        ...formSections.SUBSTANCE_USE_ALCOHOL,
-        subsections: [
-          formSections.SUBSTANCE_USE_ALCOHOL,
-          formSections.SUBSTANCE_USE_ALCOHOL_NEGATIVE,
-          formSections.SUBSTANCE_USE_ALCOHOL_ORDERED,
-          formSections.SUBSTANCE_USE_ALCOHOL_VOLUNTARY,
-          formSections.SUBSTANCE_USE_ALCOHOL_ADDITIONAL
-        ]
-      },
+      formSections.SUBSTANCE_USE_DRUGS,
+      formSections.SUBSTANCE_USE_DRUGS_USAGE,
+      formSections.SUBSTANCE_USE_DRUGS_PURCHASE,
+      formSections.SUBSTANCE_USE_DRUGS_CLEARANCE,
+      formSections.SUBSTANCE_USE_DRUGS_PUBLIC_SAFETY,
+      formSections.SUBSTANCE_USE_DRUGS_MISUSE,
+      formSections.SUBSTANCE_USE_DRUGS_ORDERED,
+      formSections.SUBSTANCE_USE_DRUGS_VOLUNTARY,
+      formSections.SUBSTANCE_USE_ALCOHOL,
+      formSections.SUBSTANCE_USE_ALCOHOL,
+      formSections.SUBSTANCE_USE_ALCOHOL_NEGATIVE,
+      formSections.SUBSTANCE_USE_ALCOHOL_ORDERED,
+      formSections.SUBSTANCE_USE_ALCOHOL_VOLUNTARY,
+      formSections.SUBSTANCE_USE_ALCOHOL_ADDITIONAL,
       formSections.SUBSTANCE_USE_REVIEW
     ]
   },
@@ -244,44 +214,28 @@ export const SF85P = [
     ...formSections.LEGAL,
     subsections: [
       formSections.LEGAL_INTRO,
-      {
-        ...formSections.LEGAL_POLICE,
-        subsections: [
-          formSections.LEGAL_POLICE_INTRO,
-          formSections.LEGAL_POLICE_OFFENSES,
-          formSections.LEGAL_POLICE_ADDITIONAL_OFFENSES,
-          formSections.LEGAL_POLICE_DOMESTIC_VIOLENCE
-        ]
-      },
-      {
-        ...formSections.LEGAL_INVESTIGATIONS,
-        subsections: [
-          formSections.LEGAL_INVESTIGATIONS_HISTORY,
-          formSections.LEGAL_INVESTIGATIONS_REVOKED,
-          formSections.LEGAL_INVESTIGATIONS_DEBARRED
-        ]
-      },
+      formSections.LEGAL_POLICE,
+      formSections.LEGAL_POLICE_INTRO,
+      formSections.LEGAL_POLICE_OFFENSES,
+      formSections.LEGAL_POLICE_ADDITIONAL_OFFENSES,
+      formSections.LEGAL_POLICE_DOMESTIC_VIOLENCE,
+      formSections.LEGAL_INVESTIGATIONS,
+      formSections.LEGAL_INVESTIGATIONS_HISTORY,
+      formSections.LEGAL_INVESTIGATIONS_REVOKED,
+      formSections.LEGAL_INVESTIGATIONS_DEBARRED,
       formSections.LEGAL_COURT,
-      {
-        ...formSections.LEGAL_TECHNOLOGY,
-        subsections: [
-          formSections.LEGAL_TECHNOLOGY_UNAUTHORIZED,
-          formSections.LEGAL_TECHNOLOGY_MANIPULATING,
-          formSections.LEGAL_TECHNOLOGY_UNLAWFUL
-        ]
-      },
-      {
-        ...formSections.LEGAL_ASSOCIATIONS,
-        subsections: [
-          formSections.LEGAL_ASSOCIATIONS_TERRORIST_ORGANIZATION,
-          formSections.LEGAL_ASSOCIATIONS_ENGAGED_IN_TERRORISM,
-          formSections.LEGAL_ASSOCIATIONS_ADVOCATING,
-          formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_OVERTHROW,
-          formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_VIOLENCE,
-          formSections.LEGAL_ASSOCIATIONS_ACTIVITIES_TO_OVERTHROW,
-          formSections.LEGAL_ASSOCIATIONS_TERRORISM_ASSOCIATION
-        ]
-      },
+      formSections.LEGAL_TECHNOLOGY,
+      formSections.LEGAL_TECHNOLOGY_UNAUTHORIZED,
+      formSections.LEGAL_TECHNOLOGY_MANIPULATING,
+      formSections.LEGAL_TECHNOLOGY_UNLAWFUL,
+      formSections.LEGAL_ASSOCIATIONS,
+      formSections.LEGAL_ASSOCIATIONS_TERRORIST_ORGANIZATION,
+      formSections.LEGAL_ASSOCIATIONS_ENGAGED_IN_TERRORISM,
+      formSections.LEGAL_ASSOCIATIONS_ADVOCATING,
+      formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_OVERTHROW,
+      formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_VIOLENCE,
+      formSections.LEGAL_ASSOCIATIONS_ACTIVITIES_TO_OVERTHROW,
+      formSections.LEGAL_ASSOCIATIONS_TERRORISM_ASSOCIATION,
       formSections.LEGAL_REVIEW
     ]
   }
@@ -317,13 +271,9 @@ export const SF86 = [
     ...formSections.RELATIONSHIPS,
     subsections: [
       formSections.RELATIONSHIPS_INTRO,
-      {
-        ...formSections.RELATIONSHIPS_STATUS,
-        subsections: [
-          formSections.RELATIONSHIPS_STATUS_MARITAL,
-          formSections.RELATIONSHIPS_STATUS_COHABITANTS
-        ]
-      },
+      formSections.RELATIONSHIPS_STATUS,
+      formSections.RELATIONSHIPS_STATUS_MARITAL,
+      formSections.RELATIONSHIPS_STATUS_COHABITANTS,
       formSections.RELATIONSHIPS_PEOPLE,
       formSections.RELATIONSHIPS_RELATIVES,
       formSections.RELATIONSHIPS_REVIEW
@@ -356,30 +306,22 @@ export const SF86 = [
       formSections.FOREIGN_INTRO,
       formSections.FOREIGN_PASSPORT,
       formSections.FOREIGN_CONTACTS,
-      {
-        ...formSections.FOREIGN_ACTIVITIES,
-        subsections: [
-          formSections.FOREIGN_ACTIVITIES_DIRECT,
-          formSections.FOREIGN_ACTIVITIES_INDIRECT,
-          formSections.FOREIGN_ACTIVITIES_REAL_ESTATE,
-          formSections.FOREIGN_ACTIVITIES_BENEFITS,
-          formSections.FOREIGN_ACTIVITIES_SUPPORT
-        ]
-      },
-      {
-        ...formSections.FOREIGN_BUSINESS,
-        susections: [
-          formSections.FOREIGN_BUSINESS_ADVICE,
-          formSections.FOREIGN_BUSINESS_FAMILY,
-          formSections.FOREIGN_BUSINESS_EMPLOYMENT,
-          formSections.FOREIGN_BUSINESS_VENTURES,
-          formSections.FOREIGN_BUSINESS_CONFERENCES,
-          formSections.FOREIGN_BUSINESS_CONTACT,
-          formSections.FOREIGN_BUSINESS_SPONSORSHIP,
-          formSections.FOREIGN_BUSINESS_POLITICAL,
-          formSections.FOREIGN_BUSINESS_VOTING
-        ]
-      },
+      formSections.FOREIGN_ACTIVITIES,
+      formSections.FOREIGN_ACTIVITIES_DIRECT,
+      formSections.FOREIGN_ACTIVITIES_INDIRECT,
+      formSections.FOREIGN_ACTIVITIES_REAL_ESTATE,
+      formSections.FOREIGN_ACTIVITIES_BENEFITS,
+      formSections.FOREIGN_ACTIVITIES_SUPPORT,
+      formSections.FOREIGN_BUSINESS,
+      formSections.FOREIGN_BUSINESS_ADVICE,
+      formSections.FOREIGN_BUSINESS_FAMILY,
+      formSections.FOREIGN_BUSINESS_EMPLOYMENT,
+      formSections.FOREIGN_BUSINESS_VENTURES,
+      formSections.FOREIGN_BUSINESS_CONFERENCES,
+      formSections.FOREIGN_BUSINESS_CONTACT,
+      formSections.FOREIGN_BUSINESS_SPONSORSHIP,
+      formSections.FOREIGN_BUSINESS_POLITICAL,
+      formSections.FOREIGN_BUSINESS_VOTING,
       formSections.FOREIGN_TRAVEL,
       formSections.FOREIGN_REVIEW
     ]
@@ -402,28 +344,20 @@ export const SF86 = [
     ...formSections.SUBSTANCE_USE,
     subsections: [
       formSections.SUBSTANCE_USE_INTRO,
-      {
-        ...formSections.SUBSTANCE_USE_DRUGS,
-        subsections: [
-          formSections.SUBSTANCE_USE_DRUGS_USAGE,
-          formSections.SUBSTANCE_USE_DRUGS_PURCHASE,
-          formSections.SUBSTANCE_USE_DRUGS_CLEARANCE,
-          formSections.SUBSTANCE_USE_DRUGS_PUBLIC_SAFETY,
-          formSections.SUBSTANCE_USE_DRUGS_MISUSE,
-          formSections.SUBSTANCE_USE_DRUGS_ORDERED,
-          formSections.SUBSTANCE_USE_DRUGS_VOLUNTARY
-        ]
-      },
-      {
-        ...formSections.SUBSTANCE_USE_ALCOHOL,
-        subsections: [
-          formSections.SUBSTANCE_USE_ALCOHOL,
-          formSections.SUBSTANCE_USE_ALCOHOL_NEGATIVE,
-          formSections.SUBSTANCE_USE_ALCOHOL_ORDERED,
-          formSections.SUBSTANCE_USE_ALCOHOL_VOLUNTARY,
-          formSections.SUBSTANCE_USE_ALCOHOL_ADDITIONAL
-        ]
-      },
+      formSections.SUBSTANCE_USE_DRUGS,
+      formSections.SUBSTANCE_USE_DRUGS_USAGE,
+      formSections.SUBSTANCE_USE_DRUGS_PURCHASE,
+      formSections.SUBSTANCE_USE_DRUGS_CLEARANCE,
+      formSections.SUBSTANCE_USE_DRUGS_PUBLIC_SAFETY,
+      formSections.SUBSTANCE_USE_DRUGS_MISUSE,
+      formSections.SUBSTANCE_USE_DRUGS_ORDERED,
+      formSections.SUBSTANCE_USE_DRUGS_VOLUNTARY,
+      formSections.SUBSTANCE_USE_ALCOHOL,
+      formSections.SUBSTANCE_USE_ALCOHOL,
+      formSections.SUBSTANCE_USE_ALCOHOL_NEGATIVE,
+      formSections.SUBSTANCE_USE_ALCOHOL_ORDERED,
+      formSections.SUBSTANCE_USE_ALCOHOL_VOLUNTARY,
+      formSections.SUBSTANCE_USE_ALCOHOL_ADDITIONAL,
       formSections.SUBSTANCE_USE_REVIEW
     ]
   },
@@ -431,44 +365,28 @@ export const SF86 = [
     ...formSections.LEGAL,
     subsections: [
       formSections.LEGAL_INTRO,
-      {
-        ...formSections.LEGAL_POLICE,
-        subsections: [
-          formSections.LEGAL_POLICE_INTRO,
-          formSections.LEGAL_POLICE_OFFENSES,
-          formSections.LEGAL_POLICE_ADDITIONAL_OFFENSES,
-          formSections.LEGAL_POLICE_DOMESTIC_VIOLENCE
-        ]
-      },
-      {
-        ...formSections.LEGAL_INVESTIGATIONS,
-        subsections: [
-          formSections.LEGAL_INVESTIGATIONS_HISTORY,
-          formSections.LEGAL_INVESTIGATIONS_REVOKED,
-          formSections.LEGAL_INVESTIGATIONS_DEBARRED
-        ]
-      },
+      formSections.LEGAL_POLICE,
+      formSections.LEGAL_POLICE_INTRO,
+      formSections.LEGAL_POLICE_OFFENSES,
+      formSections.LEGAL_POLICE_ADDITIONAL_OFFENSES,
+      formSections.LEGAL_POLICE_DOMESTIC_VIOLENCE,
+      formSections.LEGAL_INVESTIGATIONS,
+      formSections.LEGAL_INVESTIGATIONS_HISTORY,
+      formSections.LEGAL_INVESTIGATIONS_REVOKED,
+      formSections.LEGAL_INVESTIGATIONS_DEBARRED,
       formSections.LEGAL_COURT,
-      {
-        ...formSections.LEGAL_TECHNOLOGY,
-        subsections: [
-          formSections.LEGAL_TECHNOLOGY_UNAUTHORIZED,
-          formSections.LEGAL_TECHNOLOGY_MANIPULATING,
-          formSections.LEGAL_TECHNOLOGY_UNLAWFUL
-        ]
-      },
-      {
-        ...formSections.LEGAL_ASSOCIATIONS,
-        subsections: [
-          formSections.LEGAL_ASSOCIATIONS_TERRORIST_ORGANIZATION,
-          formSections.LEGAL_ASSOCIATIONS_ENGAGED_IN_TERRORISM,
-          formSections.LEGAL_ASSOCIATIONS_ADVOCATING,
-          formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_OVERTHROW,
-          formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_VIOLENCE,
-          formSections.LEGAL_ASSOCIATIONS_ACTIVITIES_TO_OVERTHROW,
-          formSections.LEGAL_ASSOCIATIONS_TERRORISM_ASSOCIATION
-        ]
-      },
+      formSections.LEGAL_TECHNOLOGY,
+      formSections.LEGAL_TECHNOLOGY_UNAUTHORIZED,
+      formSections.LEGAL_TECHNOLOGY_MANIPULATING,
+      formSections.LEGAL_TECHNOLOGY_UNLAWFUL,
+      formSections.LEGAL_ASSOCIATIONS,
+      formSections.LEGAL_ASSOCIATIONS_TERRORIST_ORGANIZATION,
+      formSections.LEGAL_ASSOCIATIONS_ENGAGED_IN_TERRORISM,
+      formSections.LEGAL_ASSOCIATIONS_ADVOCATING,
+      formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_OVERTHROW,
+      formSections.LEGAL_ASSOCIATIONS_MEMBERSHIP_VIOLENCE,
+      formSections.LEGAL_ASSOCIATIONS_ACTIVITIES_TO_OVERTHROW,
+      formSections.LEGAL_ASSOCIATIONS_TERRORISM_ASSOCIATION,
       formSections.LEGAL_REVIEW
     ]
   },


### PR DESCRIPTION
## Description

I had a ton of trouble getting nested subsections to play nicely with the back/next buttons. I also thought about how the sidebar navigation is going to be generated from the form type config.

example subsection
```
const SUBSTANCE_USE_DRUGS_ORDERED = {
  key: sections.SUBSTANCE_USE_DRUGS_ORDERED,
  name: 'ordered',
  path: {
    section: SUBSTANCE_USE.path.section,
    subsection: 'drugs/misuse',
  },
  storeKey: 'OrderedTreatments',
  label: i18n.t('substance.subsection.drugs.ordered'),
  parentKey: SUBSTANCE_USE_DRUGS.key,
}
```

1. Flattened out the form type data structure. instead of having a nested `subsections` array. the nested subsections are mapped to its parent by a `parentKey`
2. extracted out the subsection `path` key to be an object instead of a string
    - the `subsection` prop in `SectionNavigation` comes from a react router param. previously, there was nothing in the config to be able to map the `subsection` prop to the config file. now the path is restructured to have the keys `section` and `subsection`. we ca construct the path with those object key values.

## Checklist for Reveiwer

- [ ] Review code changes

More details about this can be found in [docs/review.md](docs/review.md)