### PR TITLE
Make Address element serialization more defensive

### DIFF
--- a/api/templates/address.xml
+++ b/api/templates/address.xml
@@ -1,0 +1,6 @@
+{{$dnk := notApplicable .DoNotKnow}}
+<Address DoNotKnow="{{$dnk}}">
+  {{if $dnk | ne "True"}}
+    {{location .Location}}
+  {{end}}
+</Address>

--- a/api/templates/foreign-contacts.xml
+++ b/api/templates/foreign-contacts.xml
@@ -8,9 +8,7 @@
     {{with $Item := $item.Item}}
     <Contact ID="{{inc $index}}">
       {{ $doNotKnowAddr := notApplicable $Item.AddressNotApplicable }}
-      <Address DoNotKnow="{{$doNotKnowAddr}}">
-        {{location $Item.Address}}
-      </Address>
+      {{address $Item.Address $Item.AddressNotApplicable}}
       <!-- These conditionals are not consistent with SF-86 form or validation matrix, but are consistent with e-QIP -->
       {{if and (isInternational $Item.Address) ($doNotKnowAddr | eq "False")}}
       {{apoFpo $Item.Address $Item.AlternateAddress}}
@@ -81,9 +79,7 @@
         </To>
       </DateRange>
       <Employer>
-        <Address DoNotKnow="{{notApplicable $Item.EmployerAddressNotApplicable}}">
-          {{location $Item.EmployerAddress}}
-        </Address>
+        {{address $Item.EmployerAddress $Item.EmployerAddressNotApplicable}}
         <Comment></Comment>
         <Name DoNotKnow="{{notApplicable $Item.EmployerNotApplicable}}">{{text $Item.Employer}}</Name>
       </Employer>

--- a/api/templates/relatives-and-associates.xml
+++ b/api/templates/relatives-and-associates.xml
@@ -123,9 +123,7 @@
         </AffiliatedWithForeignGovernment>
         <Comment></Comment>
         <Employer>
-          <Address DoNotKnow="{{notApplicable $Item.EmployerAddressNotApplicable}}">
-            {{location $Item.EmployerAddress}}
-          </Address>
+          {{address $Item.EmployerAddress $Item.EmployerAddressNotApplicable}}
           <Comment></Comment>
           <Name DoNotKnow="{{notApplicable $Item.EmployerNotApplicable}}">
             {{text $Item.Employer}}

--- a/api/templates/spouse-former.xml
+++ b/api/templates/spouse-former.xml
@@ -3,9 +3,7 @@
   {{with $Item := $item.Item}}
   <FormerSpouse ID="{{inc $index}}">
     {{if branch $Item.Deceased | eq "No" }}
-    <Address DoNotKnow="{{notApplicable $Item.DeceasedAddressNotApplicable}}">
-      {{location $Item.DeceasedAddress}}
-    </Address>
+    {{address $Item.DeceasedAddress $Item.DeceasedAddressNotApplicable}}
     {{end}}
     <Birth>
       <Date Type="{{dateEstimated $Item.Birthdate}}">

--- a/api/testdata/complete-scenarios/test5.xml
+++ b/api/testdata/complete-scenarios/test5.xml
@@ -2579,8 +2579,8 @@
               <Contacts>
                 <Contact ID="1">
                   <Address DoNotKnow="True">
-                    <Street> </Street>
-                  </Address>
+  
+</Address>
                   <Birth>
                     <Date DoNotKnow="True">
           

--- a/api/testdata/complete-scenarios/test9.xml
+++ b/api/testdata/complete-scenarios/test9.xml
@@ -1017,8 +1017,8 @@
                   </DateRange>
                   <Employer>
                     <Address DoNotKnow="True">
-                      <Street> </Street>
-                    </Address>
+  
+</Address>
                     <Name DoNotKnow="True"/>
                   </Employer>
                   <ForeignAffiliation>

--- a/api/xml/xml.go
+++ b/api/xml/xml.go
@@ -34,6 +34,7 @@ func (service Service) DefaultTemplate(templateName string, data map[string]inte
 	// These can be helper functions for formatting or even to process complex structure
 	// types.
 	fmap := template.FuncMap{
+		"address":                address,
 		"addressIn":              addressIn,
 		"agencyType":             agencyType,
 		"apoFpo":                 apoFpo,
@@ -203,6 +204,19 @@ func selectBenefit(freqType string, benefitItem map[string]interface{}) (map[str
 		}
 	}
 	return nil, errors.New(selector + " not found in benefit item")
+}
+
+func address(loc map[string]interface{}, dnk map[string]interface{}) (template.HTML, error) {
+	view := make(map[string]interface{})
+	view["Location"] = loc
+	view["DoNotKnow"] = dnk
+
+	fmap := template.FuncMap{
+		"notApplicable": notApplicable,
+		"location":      location,
+	}
+
+	return xmlTemplateWithFuncs("address.xml", view, fmap)
 }
 
 // Put simple structures here where they only output a string


### PR DESCRIPTION
Based on stack traces in pre-prod, eApp was producing JSON where address country was set to "United States", but address was marked as not applicable. Could not replicate via UI, but in case of data inconsistency, use the not applicable flag as source of truth.

Has a side-benefit of cleaning up some extraneous empty `Street` elements (e-QIP ignores these, so wasn't a blocking issue).