### PR TITLE
Make Date element serialization more defensive

### DIFF
--- a/api/templates/date-month-year-optional.xml
+++ b/api/templates/date-month-year-optional.xml
@@ -1,0 +1,6 @@
+{{$dnk := notApplicable .DoNotKnow}}
+<Date Type="{{dateEstimated .Date}}" DoNotKnow="{{$dnk}}">
+  {{if $dnk | ne "True"}}
+    <Month>{{padDigits .Date.props.month}}</Month><Year>{{.Date.props.year}}</Year>
+  {{end}}
+</Date>

--- a/api/templates/foreign-business-sponsored-visits.xml
+++ b/api/templates/foreign-business-sponsored-visits.xml
@@ -11,13 +11,7 @@
       </Address>
     </AddressWhileInUS>
     <Birth>
-      {{if notApplicable $Item.BirthdateNotApplicable | eq "True"}}
-      <Date DoNotKnow="True" />
-      {{else}}
-      <Date Type="{{dateEstimated $Item.Birthdate}}">
-        {{monthYear $Item.Birthdate}}
-      </Date>
-      {{end}}
+      {{monthYearOptional $Item.Birthdate $Item.BirthdateNotApplicable}}
       <Place>
         {{location $Item.Birthplace}}
         {{if $Item.Birthplace.props.country | eq "United States"}}

--- a/api/templates/legal-investigations-investigated.xml
+++ b/api/templates/legal-investigations-investigated.xml
@@ -17,14 +17,10 @@
     <ClearanceLevel>{{radio $Item.ClearanceLevel.props.Level | clearanceType}}</ClearanceLevel>
     <EntryComment></EntryComment>
     <GrantedDate>
-      <Date Type="{{dateEstimated $Item.Granted}}" DoNotKnow="{{notApplicable $Item.GrantedNotApplicable}}">
-        {{monthYear $Item.Granted}}
-      </Date>
+      {{monthYearOptional $Item.Granted $Item.GrantedNotApplicable}}
     </GrantedDate>
     <InvestigationDate>
-      <Date Type="{{dateEstimated $Item.Completed}}" DoNotKnow="{{notApplicable $Item.CompletedNotApplicable}}">
-        {{monthYear $Item.Completed}}
-      </Date>
+      {{monthYearOptional $Item.Completed $Item.CompletedNotApplicable}}
     </InvestigationDate>
     <IssuingAgency>
       <Name>{{text $Item.Issued}}</Name>

--- a/api/templates/legal-investigations-investigated.xml
+++ b/api/templates/legal-investigations-investigated.xml
@@ -13,6 +13,7 @@
     <OtherAgency>{{text $Item.AgencyExplanation}}</OtherAgency>
     {{end}}
     {{end}}
+    <!-- XXX https://github.com/18F/e-QIP-prototype/issues/1489 -->
     <ClearanceLevel>{{radio $Item.ClearanceLevel.props.Level | clearanceType}}</ClearanceLevel>
     <EntryComment></EntryComment>
     <GrantedDate>

--- a/api/testdata/complete-scenarios/test6.json
+++ b/api/testdata/complete-scenarios/test6.json
@@ -2595,16 +2595,101 @@
         "HasHistory": {
           "type": "branch",
           "props": {
-            "value": "No"
+            "value": "Yes"
           }
         },
         "List": {
           "type": "collection",
           "props": {
             "branch": {
-              "type": ""
+              "type": "branch",
+              "props": {
+                "value": "No"
+              }
             },
-            "items": []
+            "items": [
+              {
+                "Item": {
+                  "Agency": {
+                    "type": "radio",
+                    "props": {
+                      "value": ""
+                    }
+                  },
+                  "AgencyExplanation": {
+                    "type": "textarea",
+                    "props": {
+                      "value": ""
+                    }
+                  },
+                  "AgencyNotApplicable": {
+                    "type": "notapplicable",
+                    "props": {
+                      "applicable": false
+                    }
+                  },
+                  "ClearanceLevel": {
+                    "type": "clearancelevel",
+                    "props": {
+                      "Level": {
+                        "type": "radio",
+                        "props": {
+                          "value": "None"
+                        }
+                      },
+                      "Explanation": {
+                        "type": "textarea",
+                        "props": {
+                          "value": ""
+                        }
+                      }
+                    }
+                  },
+                  "ClearanceLevelNotApplicable": {
+                    "type": "notapplicable",
+                    "props": {
+                      "applicable": true
+                    }
+                  },
+                  "Completed": {
+                    "type": "datecontrol",
+                    "props": {
+                      "month": "",
+                      "day": "",
+                      "year": "",
+                      "estimated": false
+                    }
+                  },
+                  "CompletedNotApplicable": {
+                    "type": "notapplicable",
+                    "props": {
+                      "applicable": false
+                    }
+                  },
+                  "Granted": {
+                    "type": "datecontrol",
+                    "props": {
+                      "month": "",
+                      "day": "",
+                      "year": "",
+                      "estimated": false
+                    }
+                  },
+                  "GrantedNotApplicable": {
+                    "type": "notapplicable",
+                    "props": {
+                      "applicable": false
+                    }
+                  },
+                  "Issued": {
+                    "type": "text",
+                    "props": {
+                      "value": ""
+                    }
+                  }
+                }
+              }
+            ]
           }
         }
       }

--- a/api/testdata/complete-scenarios/test6.xml
+++ b/api/testdata/complete-scenarios/test6.xml
@@ -951,8 +951,28 @@
               <GovernmentDebarment>
                 <Answer>No</Answer>
               </GovernmentDebarment>
+              <Investigations>
+                <Investigation ID="1">
+                  <Agency>Unknown</Agency>
+                  <ClearanceLevel>None</ClearanceLevel>
+                  <GrantedDate>
+                    <Date DoNotKnow="True">
+        
+      </Date>
+                  </GrantedDate>
+                  <InvestigationDate>
+                    <Date DoNotKnow="True">
+        
+      </Date>
+                  </InvestigationDate>
+                  <IssuingAgency>
+      
+    </IssuingAgency>
+                </Investigation>
+              </Investigations>
               <PriorInvestigation>
-                <Answer>No</Answer>
+                <Answer>Yes</Answer>
+                <HaveAdditionalEntryAnswer>No</HaveAdditionalEntryAnswer>
               </PriorInvestigation>
             </InvestigationRecord>
             <MedicalRecord2 Version="1" Type="Pooled">

--- a/api/testdata/complete-scenarios/test6.xml
+++ b/api/testdata/complete-scenarios/test6.xml
@@ -957,13 +957,13 @@
                   <ClearanceLevel>None</ClearanceLevel>
                   <GrantedDate>
                     <Date DoNotKnow="True">
-        
-      </Date>
+  
+</Date>
                   </GrantedDate>
                   <InvestigationDate>
                     <Date DoNotKnow="True">
-        
-      </Date>
+  
+</Date>
                   </InvestigationDate>
                   <IssuingAgency>
       

--- a/api/xml/xml.go
+++ b/api/xml/xml.go
@@ -991,6 +991,7 @@ func agencyType(v string) string {
 
 func clearanceType(v string) string {
 	basis := map[string]string{
+		"None":                                "None",
 		"Confidential":                        "Confidential",
 		"Secret":                              "Secret",
 		"Top Secret":                          "TopSecret",

--- a/api/xml/xml.go
+++ b/api/xml/xml.go
@@ -67,7 +67,6 @@ func (service Service) DefaultTemplate(templateName string, data map[string]inte
 		"foreignDocType":         foreignDocType,
 		"foreignAffiliation":     foreignAffiliation,
 		"frequencyType":          frequencyType,
-		"monthYearDaterange":     monthYearDaterange,
 		"email":                  email,
 		"employmentType":         employmentType,
 		"hairType":               hairType,
@@ -81,6 +80,8 @@ func (service Service) DefaultTemplate(templateName string, data map[string]inte
 		"militaryAddress":        militaryAddress,
 		"militaryStatus":         militaryStatus,
 		"monthYear":              monthYear,
+		"monthYearOptional":      monthYearOptional,
+		"monthYearDaterange":     monthYearDaterange,
 		"name":                   name,
 		"nameLastFirst":          nameLastFirst,
 		"notApplicable":          notApplicable,
@@ -782,6 +783,19 @@ func date(data map[string]interface{}) (template.HTML, error) {
 		"padDigits": padDigits,
 	}
 	return xmlTemplateWithFuncs("date-month-day-year.xml", data, fmap)
+}
+
+func monthYearOptional(d, dnk map[string]interface{}) (template.HTML, error) {
+	view := make(map[string]interface{})
+	view["Date"] = d
+	view["DoNotKnow"] = dnk
+
+	fmap := template.FuncMap{
+		"dateEstimated": dateEstimated,
+		"notApplicable": notApplicable,
+		"padDigits":     padDigits,
+	}
+	return xmlTemplateWithFuncs("date-month-year-optional.xml", view, fmap)
 }
 
 func monthYear(data map[string]interface{}) (template.HTML, error) {


### PR DESCRIPTION
Similar to #1487. 

It seems to be possible to serialize form data in such a way where `month` property is not set on a date in the JSON serialization, but I have not been able to replicate this using the UI. 

The previous "lazy" version of the code relied on `month` being set to empty string if `not applicable` was indicated for the granted/investigation dates. This PR makes the code more defensive and makes less assumptions.

It also makes a fix to an adjacent investigation element – a clearance level of `None` was not correctly serialized.