### PR TITLE
disable comma dangle for functions

### DIFF
--- a/.eslintrc.dev.yml
+++ b/.eslintrc.dev.yml
@@ -23,6 +23,9 @@ rules:
   no-unused-vars: ['error', {
     argsIgnorePattern: '^_'
   }]
+  comma-dangle: ['error', {
+    functions: 'never'
+  }]
 settings:
   import/resolver:
     babel-module:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -30,6 +30,7 @@ rules:
   react/prop-types:
     - error
     - skipUndeclared: true
+  comma-dangle: ['error', { functions: 'never' }]
 settings:
   import/resolver:
     babel-module:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -30,7 +30,9 @@ rules:
   react/prop-types:
     - error
     - skipUndeclared: true
-  comma-dangle: ['error', { functions: 'never' }]
+  comma-dangle: ['error', {
+    functions: 'never'
+  }]
 settings:
   import/resolver:
     babel-module:


### PR DESCRIPTION
## Description

```
shallow(
  <Component />
)
```
Currently, the component above will trigger a comma-dangle ESLint error. It wants a comma after the component (see below).

```
shallow(
  <Component />,
)
```

This component will disallow commas trailing functions.

## Checklist for Reveiwer

- [ ] Review code changes

More details about this can be found in [docs/review.md](docs/review.md)