### PR TITLE
disable comma dangle func

### DIFF
--- a/.eslintrc.dev.yml
+++ b/.eslintrc.dev.yml
@@ -23,8 +23,12 @@ rules:
   no-unused-vars: ['error', {
     argsIgnorePattern: '^_'
   }]
-  comma-dangle: ['error', {
-    functions: 'never'
+  comma-dangle: [2, {
+    arrays: 'always-multiline',
+    objects: 'always-multiline',
+    imports: 'always-multiline',
+    exports: 'always-multiline',
+    functions: 'ignore'
   }]
 settings:
   import/resolver:

--- a/.eslintrc.dev.yml
+++ b/.eslintrc.dev.yml
@@ -23,6 +23,9 @@ rules:
   no-unused-vars: ['error', {
     argsIgnorePattern: '^_'
   }]
+  comma-dangle: ['error', {
+    functions: 'never'
+  }]
 settings:
   import/resolver:
     babel-module:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -30,13 +30,6 @@ rules:
   react/prop-types:
     - error
     - skipUndeclared: true
-  comma-dangle: [2, {
-    arrays: 'always-multiline',
-    objects: 'always-multiline',
-    imports: 'always-multiline',
-    exports: 'always-multiline',
-    functions: 'ignore'
-  }]
 settings:
   import/resolver:
     babel-module:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -30,6 +30,7 @@ rules:
   react/prop-types:
     - error
     - skipUndeclared: true
+  comma-dangle: ['error', { functions: 'never' }]
 settings:
   import/resolver:
     babel-module:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -30,7 +30,9 @@ rules:
   react/prop-types:
     - error
     - skipUndeclared: true
-  comma-dangle: ['error', { functions: 'never' }]
+  comma-dangle: ['error', {
+    functions: 'never'
+  }]
 settings:
   import/resolver:
     babel-module:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -30,8 +30,12 @@ rules:
   react/prop-types:
     - error
     - skipUndeclared: true
-  comma-dangle: ['error', {
-    functions: 'never'
+  comma-dangle: [2, {
+    arrays: 'always-multiline',
+    objects: 'always-multiline',
+    imports: 'always-multiline',
+    exports: 'always-multiline',
+    functions: 'ignore'
   }]
 settings:
   import/resolver:


### PR DESCRIPTION
## Description

This PR makes trailing commas optional for function arguments. We can disallow trailing commas, but that seemed too aggressive.

In my previous PR, I found strange issues where missing commas weren't triggering errors and some dangling commas were seen as extraneous.

This PR **SHOULD** enable dangling commas for everything, **EXCEPT** function arguments.

Please reference different file types throughout eApp before approving.


## Checklist for Reveiwer

- [ ] Review code changes

More details about this can be found in [docs/review.md](docs/review.md)