### PR TITLE
Fix issues with Substance Use

### DIFF
--- a/src/components/Section/Section.jsx
+++ b/src/components/Section/Section.jsx
@@ -25,7 +25,8 @@ const storeToComponentMap = {
   History,
   Legal,
   Psychological,
-  SubstanceUse,
+  // TODO: Redux, backend, XML, etc. all has Substance named as such instead of SubstanceUse
+  Substance: SubstanceUse,
   Package,
 }
 

--- a/src/components/Section/SubstanceUse/SubstanceUseConnector.jsx
+++ b/src/components/Section/SubstanceUse/SubstanceUseConnector.jsx
@@ -72,8 +72,8 @@ const connectSubstanceUseSection = (Component, {
         return { ...substance.OrderedTreatments, addressBooks } || {}
       case 'VoluntaryTreatments':
         return { ...substance.VoluntaryTreatments, addressBooks } || {}
-      case 'NegativeImpact':
-        return { ...substance.NegativeImpact } || {}
+      case 'NegativeImpacts':
+        return { ...substance.NegativeImpacts } || {}
       case 'OrderedCounselings':
         return { ...substance.OrderedCounselings, addressBooks } || {}
       case 'VoluntaryCounselings':

--- a/src/config/formSections/substanceUse.js
+++ b/src/config/formSections/substanceUse.js
@@ -90,7 +90,7 @@ export const SUBSTANCE_USE_ALCOHOL_NEGATIVE = {
   key: sections.SUBSTANCE_USE_ALCOHOL_NEGATIVE,
   name: 'alcohol/negative',
   path: 'negative',
-  storeKey: 'NegativeImpact',
+  storeKey: 'NegativeImpacts',
   label: i18n.t('substance.subsection.alcohol.negative'),
 }
 


### PR DESCRIPTION
## Description
Fixes #1564 
- Fixes issues with `Negative Impact` subsection not saving
  - Fix: The naming was wrong. `NegativeImpact` should be `NegativeImpacts` (plural)
## Checklist for Reveiwer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
