### PR TITLE
Fix bankruptcy discharge not applicably saving issue

### DIFF
--- a/src/components/Section/Citizenship/Status/Status.jsx
+++ b/src/components/Section/Citizenship/Status/Status.jsx
@@ -76,7 +76,7 @@ export class Status extends Subsection {
     })
   }
 
-  updateField = (field, values) =>  {
+  updateField = (field, values) => {
     this.update({
       [field]: values,
     })

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { i18n } from '../../../../config'
+import { i18n } from 'config'
 import {
   ValidationElement,
   Branch,
@@ -14,7 +14,7 @@ import {
   NotApplicable,
   RadioGroup,
   Radio,
-  Location
+  Location,
 } from '../../../Form'
 
 export default class Bankruptcy extends ValidationElement {
@@ -24,17 +24,13 @@ export default class Bankruptcy extends ValidationElement {
     this.updateCourtNumber = this.updateCourtNumber.bind(this)
     this.updateDateFiled = this.updateDateFiled.bind(this)
     this.updateDateDischarged = this.updateDateDischarged.bind(this)
-    this.updateDischargeDateNotApplicable = this.updateDischargeDateNotApplicable.bind(
-      this
-    )
+    this.updateDischargeDateNotApplicable = this.updateDischargeDateNotApplicable.bind(this)
     this.updateTotalAmount = this.updateTotalAmount.bind(this)
     this.updateTotalAmountEstimated = this.updateTotalAmountEstimated.bind(this)
     this.updateNameDebt = this.updateNameDebt.bind(this)
     this.updateCourtInvolved = this.updateCourtInvolved.bind(this)
     this.updateCourtAddress = this.updateCourtAddress.bind(this)
-    this.updateHasDischargeExplanation = this.updateHasDischargeExplanation.bind(
-      this
-    )
+    this.updateHasDischargeExplanation = this.updateHasDischargeExplanation.bind(this)
     this.updateDischargeExplanation = this.updateDischargeExplanation.bind(this)
     this.updateTrustee = this.updateTrustee.bind(this)
     this.updateTrusteeAddress = this.updateTrusteeAddress.bind(this)
@@ -56,92 +52,91 @@ export default class Bankruptcy extends ValidationElement {
       TrusteeAddress: this.props.TrusteeAddress,
       HasDischargeExplanation: this.props.HasDischargeExplanation,
       DischargeExplanation: this.props.DischargeExplanation,
-      ...queue
+      ...queue,
     })
   }
 
   updatePetitionType(values) {
     this.update({
-      PetitionType: values
+      PetitionType: values,
     })
   }
 
   updateCourtNumber(values) {
     this.update({
-      CourtNumber: values
+      CourtNumber: values,
     })
   }
 
   updateDateFiled(values) {
     this.update({
-      DateFiled: values
+      DateFiled: values,
     })
   }
 
   updateDateDischarged(values) {
     this.update({
-      DateDischarged: values
+      DateDischarged: values,
     })
   }
 
   updateDischargeDateNotApplicable(values) {
-    console.log(values)
     this.update({
-      DateDischargedNotApplicable: values
+      DateDischargedNotApplicable: values,
     })
   }
 
   updateTotalAmount(values) {
     this.update({
-      TotalAmount: values
+      TotalAmount: values,
     })
   }
 
   updateTotalAmountEstimated(values) {
     this.update({
-      TotalAmountEstimated: values
+      TotalAmountEstimated: values,
     })
   }
 
   updateNameDebt(values) {
     this.update({
-      NameDebt: values
+      NameDebt: values,
     })
   }
 
   updateCourtInvolved(values) {
     this.update({
-      CourtInvolved: values
+      CourtInvolved: values,
     })
   }
 
   updateCourtAddress(values) {
     this.update({
-      CourtAddress: values
+      CourtAddress: values,
     })
   }
 
   updateHasDischargeExplanation(values) {
     this.update({
-      HasDischargeExplanation: values
+      HasDischargeExplanation: values,
     })
   }
 
   updateDischargeExplanation(values) {
     this.update({
-      DischargeExplanation: values
+      DischargeExplanation: values,
     })
   }
 
   updateTrustee(values) {
     this.update({
-      Trustee: values
+      Trustee: values,
     })
   }
 
   updateTrusteeAddress(values) {
     this.update({
-      TrusteeAddress: values
+      TrusteeAddress: values,
     })
   }
 
@@ -153,12 +148,14 @@ export default class Bankruptcy extends ValidationElement {
           titleSize="h4"
           help="financial.bankruptcy.petitionType.help"
           scrollIntoView={this.props.scrollIntoView}
-          adjustFor="buttons">
+          adjustFor="buttons"
+        >
           <RadioGroup
             className="petition-chapters option-list option-list-vertical"
             selectedValue={(this.props.PetitionType || {}).value}
             required={this.props.required}
-            onError={this.props.onError}>
+            onError={this.props.onError}
+          >
             <Radio
               name="petition_type"
               label={i18n.t('financial.bankruptcy.petitionType.label.chapter7')}
@@ -169,9 +166,7 @@ export default class Bankruptcy extends ValidationElement {
             />
             <Radio
               name="petition_type"
-              label={i18n.t(
-                'financial.bankruptcy.petitionType.label.chapter11'
-              )}
+              label={i18n.t('financial.bankruptcy.petitionType.label.chapter11')}
               value="Chapter11"
               disabled={this.props.disabled}
               onUpdate={this.updatePetitionType}
@@ -179,9 +174,7 @@ export default class Bankruptcy extends ValidationElement {
             />
             <Radio
               name="petition_type"
-              label={i18n.t(
-                'financial.bankruptcy.petitionType.label.chapter12'
-              )}
+              label={i18n.t('financial.bankruptcy.petitionType.label.chapter12')}
               value="Chapter12"
               disabled={this.props.disabled}
               onUpdate={this.updatePetitionType}
@@ -189,9 +182,7 @@ export default class Bankruptcy extends ValidationElement {
             />
             <Radio
               name="petition_type"
-              label={i18n.t(
-                'financial.bankruptcy.petitionType.label.chapter13'
-              )}
+              label={i18n.t('financial.bankruptcy.petitionType.label.chapter13')}
               value="Chapter13"
               disabled={this.props.disabled}
               onUpdate={this.updatePetitionType}
@@ -202,7 +193,8 @@ export default class Bankruptcy extends ValidationElement {
 
         <Field
           title={i18n.t('financial.bankruptcy.heading.courtNumber')}
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <Text
             name="CourtNumber"
             onUpdate={this.updateCourtNumber}
@@ -217,45 +209,49 @@ export default class Bankruptcy extends ValidationElement {
         <Field
           title={i18n.t('financial.bankruptcy.heading.dateFiled')}
           scrollIntoView={this.props.scrollIntoView}
-          adjustFor="labels">
+          adjustFor="labels"
+        >
           <DateControl
             name="DateFiled"
             onUpdate={this.updateDateFiled}
-            minDateEqualTo={true}
+            minDateEqualTo
             onError={this.props.onError}
             {...this.props.DateFiled}
             className="datefiled"
             required={this.props.required}
-            hideDay={true}
+            hideDay
           />
         </Field>
 
         <Field
           title={i18n.t('financial.bankruptcy.heading.dateDischarged')}
           scrollIntoView={this.props.scrollIntoView}
-          adjustFor="label">
+          adjustFor="label"
+        >
           <NotApplicable
             name="DateDischargedNotApplicable"
             {...this.props.DateDischargedNotApplicable}
             onError={this.props.onError}
-            onUpdate={this.updateDischargeDateNotApplicable}>
+            onUpdate={this.updateDischargeDateNotApplicable}
+          >
             <DateControl
               name="DateDischarged"
               className="datedischarged"
               onUpdate={this.updateDateDischarged}
               onError={this.props.onError}
               minDate={this.props.DateFiled}
-              minDateEqualTo={true}
+              minDateEqualTo
               {...this.props.DateDischarged}
               required={this.props.required}
-              hideDay={true}
+              hideDay
             />
           </NotApplicable>
         </Field>
 
         <Field
           title={i18n.t('financial.bankruptcy.heading.totalAmount')}
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <Currency
             name="TotalAmount"
             onUpdate={this.updateTotalAmount}
@@ -283,7 +279,8 @@ export default class Bankruptcy extends ValidationElement {
           title={i18n.t('financial.bankruptcy.heading.nameDebt')}
           filterErrors={Name.requiredErrorsOnly}
           scrollIntoView={this.props.scrollIntoView}
-          optional={true}>
+          optional
+        >
           <Name
             name="NameDebt"
             className="namedebt"
@@ -297,7 +294,8 @@ export default class Bankruptcy extends ValidationElement {
 
         <Field
           title={i18n.t('financial.bankruptcy.heading.courtInvolved')}
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <Text
             name="CourtInvolved"
             {...this.props.CourtInvolved}
@@ -310,16 +308,17 @@ export default class Bankruptcy extends ValidationElement {
 
         <Field
           title={i18n.t('financial.bankruptcy.heading.courtAddress')}
-          optional={true}
+          optional
           help="financial.bankruptcy.courtAddress.help"
           scrollIntoView={this.props.scrollIntoView}
-          adjustFor="address">
+          adjustFor="address"
+        >
           <Location
             name="CourtAddress"
             label={i18n.t('financial.bankruptcy.courtAddress.label')}
             {...this.props.CourtAddress}
             layout={Location.ADDRESS}
-            geocode={true}
+            geocode
             dispatch={this.props.dispatch}
             addressBooks={this.props.addressBooks}
             addressBook="Court"
@@ -333,7 +332,8 @@ export default class Bankruptcy extends ValidationElement {
           <div className="chapter13">
             <Field
               title={i18n.t('financial.bankruptcy.trustee.title')}
-              scrollIntoView={this.props.scrollIntoView}>
+              scrollIntoView={this.props.scrollIntoView}
+            >
               <Text
                 name="chapter13Trustee"
                 className="trustee"
@@ -346,17 +346,18 @@ export default class Bankruptcy extends ValidationElement {
 
             <Field
               title={i18n.t('financial.bankruptcy.trustee.address.title')}
-              optional={true}
+              optional
               help="financial.bankruptcy.trustee.address.help"
               scrollIntoView={this.props.scrollIntoView}
-              adjustFor="address">
+              adjustFor="address"
+            >
               <Location
                 name="trusteeAddress"
                 className="trustee-address"
                 {...this.props.TrusteeAddress}
                 label={i18n.t('financial.bankruptcy.trustee.address.label')}
                 layout={Location.ADDRESS}
-                geocode={true}
+                geocode
                 dispatch={this.props.dispatch}
                 addressBooks={this.props.addressBooks}
                 addressBook="Court"
@@ -385,7 +386,8 @@ export default class Bankruptcy extends ValidationElement {
             title={i18n.t('financial.bankruptcy.label.dischargeExplanation')}
             titleSize="label"
             adjustFor="textarea"
-            scrollIntoView={this.props.scrollIntoView}>
+            scrollIntoView={this.props.scrollIntoView}
+          >
             <Textarea
               name="DischargeExplanation"
               {...this.props.DischargeExplanation}
@@ -404,9 +406,7 @@ export default class Bankruptcy extends ValidationElement {
 Bankruptcy.defaultProps = {
   DischargeDateNotApplicable: { applicable: true },
   addressBooks: {},
-  dispatch: action => {},
-  onUpdate: queue => {},
-  onError: (value, arr) => {
-    return arr
-  }
+  dispatch: () => {},
+  onUpdate: () => {},
+  onError: (value, arr) => arr,
 }

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
@@ -85,8 +85,9 @@ export default class Bankruptcy extends ValidationElement {
   }
 
   updateDischargeDateNotApplicable(values) {
+    console.log(values)
     this.update({
-      DischargeDateNotApplicable: values
+      DateDischargedNotApplicable: values
     })
   }
 
@@ -234,8 +235,8 @@ export default class Bankruptcy extends ValidationElement {
           scrollIntoView={this.props.scrollIntoView}
           adjustFor="label">
           <NotApplicable
-            name="DischargeDateNotApplicable"
-            {...this.props.DischargeDateNotApplicable}
+            name="DateDischargedNotApplicable"
+            {...this.props.DateDischargedNotApplicable}
             onError={this.props.onError}
             onUpdate={this.updateDischargeDateNotApplicable}>
             <DateControl

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
@@ -18,24 +18,6 @@ import {
 } from '../../../Form'
 
 export default class Bankruptcy extends ValidationElement {
-  constructor(props) {
-    super(props)
-    this.updatePetitionType = this.updatePetitionType.bind(this)
-    this.updateCourtNumber = this.updateCourtNumber.bind(this)
-    this.updateDateFiled = this.updateDateFiled.bind(this)
-    this.updateDateDischarged = this.updateDateDischarged.bind(this)
-    this.updateDischargeDateNotApplicable = this.updateDischargeDateNotApplicable.bind(this)
-    this.updateTotalAmount = this.updateTotalAmount.bind(this)
-    this.updateTotalAmountEstimated = this.updateTotalAmountEstimated.bind(this)
-    this.updateNameDebt = this.updateNameDebt.bind(this)
-    this.updateCourtInvolved = this.updateCourtInvolved.bind(this)
-    this.updateCourtAddress = this.updateCourtAddress.bind(this)
-    this.updateHasDischargeExplanation = this.updateHasDischargeExplanation.bind(this)
-    this.updateDischargeExplanation = this.updateDischargeExplanation.bind(this)
-    this.updateTrustee = this.updateTrustee.bind(this)
-    this.updateTrusteeAddress = this.updateTrusteeAddress.bind(this)
-  }
-
   update(queue) {
     this.props.onUpdate({
       PetitionType: this.props.PetitionType,
@@ -56,87 +38,9 @@ export default class Bankruptcy extends ValidationElement {
     })
   }
 
-  updatePetitionType(values) {
+  updateField = (field, values) => {
     this.update({
-      PetitionType: values,
-    })
-  }
-
-  updateCourtNumber(values) {
-    this.update({
-      CourtNumber: values,
-    })
-  }
-
-  updateDateFiled(values) {
-    this.update({
-      DateFiled: values,
-    })
-  }
-
-  updateDateDischarged(values) {
-    this.update({
-      DateDischarged: values,
-    })
-  }
-
-  updateDischargeDateNotApplicable(values) {
-    this.update({
-      DateDischargedNotApplicable: values,
-    })
-  }
-
-  updateTotalAmount(values) {
-    this.update({
-      TotalAmount: values,
-    })
-  }
-
-  updateTotalAmountEstimated(values) {
-    this.update({
-      TotalAmountEstimated: values,
-    })
-  }
-
-  updateNameDebt(values) {
-    this.update({
-      NameDebt: values,
-    })
-  }
-
-  updateCourtInvolved(values) {
-    this.update({
-      CourtInvolved: values,
-    })
-  }
-
-  updateCourtAddress(values) {
-    this.update({
-      CourtAddress: values,
-    })
-  }
-
-  updateHasDischargeExplanation(values) {
-    this.update({
-      HasDischargeExplanation: values,
-    })
-  }
-
-  updateDischargeExplanation(values) {
-    this.update({
-      DischargeExplanation: values,
-    })
-  }
-
-  updateTrustee(values) {
-    this.update({
-      Trustee: values,
-    })
-  }
-
-  updateTrusteeAddress(values) {
-    this.update({
-      TrusteeAddress: values,
+      [field]: values,
     })
   }
 
@@ -161,7 +65,7 @@ export default class Bankruptcy extends ValidationElement {
               label={i18n.t('financial.bankruptcy.petitionType.label.chapter7')}
               value="Chapter7"
               disabled={this.props.disabled}
-              onUpdate={this.updatePetitionType}
+              onUpdate={(value) => { this.updateField('PetitionType', value) }}
               onError={this.props.onError}
             />
             <Radio
@@ -169,7 +73,7 @@ export default class Bankruptcy extends ValidationElement {
               label={i18n.t('financial.bankruptcy.petitionType.label.chapter11')}
               value="Chapter11"
               disabled={this.props.disabled}
-              onUpdate={this.updatePetitionType}
+              onUpdate={(value) => { this.updateField('PetitionType', value) }}
               onError={this.props.onError}
             />
             <Radio
@@ -177,7 +81,7 @@ export default class Bankruptcy extends ValidationElement {
               label={i18n.t('financial.bankruptcy.petitionType.label.chapter12')}
               value="Chapter12"
               disabled={this.props.disabled}
-              onUpdate={this.updatePetitionType}
+              onUpdate={(value) => { this.updateField('PetitionType', value) }}
               onError={this.props.onError}
             />
             <Radio
@@ -185,7 +89,7 @@ export default class Bankruptcy extends ValidationElement {
               label={i18n.t('financial.bankruptcy.petitionType.label.chapter13')}
               value="Chapter13"
               disabled={this.props.disabled}
-              onUpdate={this.updatePetitionType}
+              onUpdate={(value) => { this.updateField('PetitionType', value) }}
               onError={this.props.onError}
             />
           </RadioGroup>
@@ -197,7 +101,7 @@ export default class Bankruptcy extends ValidationElement {
         >
           <Text
             name="CourtNumber"
-            onUpdate={this.updateCourtNumber}
+            onUpdate={(value) => { this.updateField('CourtNumber', value) }}
             onError={this.props.onError}
             {...this.props.CourtNumber}
             className="courtnumber"
@@ -213,7 +117,7 @@ export default class Bankruptcy extends ValidationElement {
         >
           <DateControl
             name="DateFiled"
-            onUpdate={this.updateDateFiled}
+            onUpdate={(value) => { this.updateField('DateFiled', value) }}
             minDateEqualTo
             onError={this.props.onError}
             {...this.props.DateFiled}
@@ -232,12 +136,12 @@ export default class Bankruptcy extends ValidationElement {
             name="DateDischargedNotApplicable"
             {...this.props.DateDischargedNotApplicable}
             onError={this.props.onError}
-            onUpdate={this.updateDischargeDateNotApplicable}
+            onUpdate={(value) => { this.updateField('DateDischargedNotApplicable', value) }}
           >
             <DateControl
               name="DateDischarged"
               className="datedischarged"
-              onUpdate={this.updateDateDischarged}
+              onUpdate={(value) => { this.updateField('DateDischarged', value) }}
               onError={this.props.onError}
               minDate={this.props.DateFiled}
               minDateEqualTo
@@ -254,7 +158,7 @@ export default class Bankruptcy extends ValidationElement {
         >
           <Currency
             name="TotalAmount"
-            onUpdate={this.updateTotalAmount}
+            onUpdate={(value) => { this.updateField('TotalAmount', value) }}
             onError={this.props.onError}
             {...this.props.TotalAmount}
             className="amount"
@@ -265,7 +169,7 @@ export default class Bankruptcy extends ValidationElement {
             <Checkbox
               name="TotalAmountEstimated"
               ref="estimated"
-              onUpdate={this.updateTotalAmountEstimated}
+              onUpdate={(value) => { this.updateField('TotalAmountEstimated', value) }}
               onError={this.props.onError}
               {...this.props.TotalAmountEstimated}
               label={i18n.t('financial.bankruptcy.totalAmount.estimated')}
@@ -285,7 +189,7 @@ export default class Bankruptcy extends ValidationElement {
             name="NameDebt"
             className="namedebt"
             {...this.props.NameDebt}
-            onUpdate={this.updateNameDebt}
+            onUpdate={(value) => { this.updateField('NameDebt', value) }}
             onError={this.props.onError}
             required={this.props.required}
             scrollIntoView={this.props.scrollIntoView}
@@ -300,7 +204,7 @@ export default class Bankruptcy extends ValidationElement {
             name="CourtInvolved"
             {...this.props.CourtInvolved}
             className="courtinvolved"
-            onUpdate={this.updateCourtInvolved}
+            onUpdate={(value) => { this.updateField('CourtInvolved', value) }}
             onError={this.props.onError}
             required={this.props.required}
           />
@@ -322,7 +226,7 @@ export default class Bankruptcy extends ValidationElement {
             dispatch={this.props.dispatch}
             addressBooks={this.props.addressBooks}
             addressBook="Court"
-            onUpdate={this.updateCourtAddress}
+            onUpdate={(value) => { this.updateField('CourtAddress', value) }}
             onError={this.props.onError}
             required={this.props.required}
           />
@@ -339,7 +243,7 @@ export default class Bankruptcy extends ValidationElement {
                 className="trustee"
                 {...this.props.Trustee}
                 onError={this.props.onError}
-                onUpdate={this.updateTrustee}
+                onUpdate={(value) => { this.updateField('Trustee', value) }}
                 required={this.props.required}
               />
             </Field>
@@ -362,7 +266,7 @@ export default class Bankruptcy extends ValidationElement {
                 addressBooks={this.props.addressBooks}
                 addressBook="Court"
                 onError={this.props.onError}
-                onUpdate={this.updateTrusteeAddress}
+                onUpdate={(value) => { this.updateField('TrusteeAddress', value) }}
                 required={this.props.required}
               />
             </Field>
@@ -375,7 +279,7 @@ export default class Bankruptcy extends ValidationElement {
           labelSize="h4"
           className="has-discharge-explanation no-margin-bottom"
           {...this.props.HasDischargeExplanation}
-          onUpdate={this.updateHasDischargeExplanation}
+          onUpdate={(value) => { this.updateField('HasDischargeExplanation', value) }}
           onError={this.props.onError}
           required={this.props.required}
           scrollIntoView={this.props.scrollIntoView}
@@ -392,7 +296,7 @@ export default class Bankruptcy extends ValidationElement {
               name="DischargeExplanation"
               {...this.props.DischargeExplanation}
               className="discharge-explanation"
-              onUpdate={this.updateDischargeExplanation}
+              onUpdate={(value) => { this.updateField('DischargeExplanation', value) }}
               onError={this.props.onError}
               required={this.props.required}
             />

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcy.test.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcy.test.jsx
@@ -10,12 +10,13 @@ describe('The Bankruptcy component', () => {
 
   beforeEach(() => {
     const store = mockStore()
-    createComponent = (expected = {}) =>
+    createComponent = (expected = {}) => (
       mount(
         <Provider store={store}>
           <Bankruptcy {...expected} />
         </Provider>
       )
+    )
   })
 
   it('Renders without errors', () => {
@@ -27,8 +28,8 @@ describe('The Bankruptcy component', () => {
     let updates = 0
     const expected = {
       onUpdate: () => {
-        updates++
-      }
+        updates += 1
+      },
     }
     const component = createComponent(expected)
     expect(component.find('.bankruptcy').length).toBe(1)
@@ -44,7 +45,7 @@ describe('The Bankruptcy component', () => {
       .find('.datedischarged input[name="month"]')
       .simulate('change', { target: { value: '1' } })
     component
-      .find('input[name="DischargeDateNotApplicable"]')
+      .find('input[name="DateDischargedNotApplicable"]')
       .simulate('change')
     component.find('.amount input[name="TotalAmount"]').simulate('change')
     component.find('.namedebt input[name="first"]').simulate('change')
@@ -61,9 +62,9 @@ describe('The Bankruptcy component', () => {
     let updates = 0
     const expected = {
       onUpdate: () => {
-        updates++
+        updates += 1
       },
-      HasDischargeExplanation: { value: 'Yes' }
+      HasDischargeExplanation: { value: 'Yes' },
     }
     const component = createComponent(expected)
     expect(component.find('.bankruptcy').length).toBe(1)
@@ -75,9 +76,9 @@ describe('The Bankruptcy component', () => {
     let updates = 0
     const expected = {
       onUpdate: () => {
-        updates++
+        updates += 1
       },
-      PetitionType: { value: 'Chapter13' }
+      PetitionType: { value: 'Chapter13' },
     }
     const component = createComponent(expected)
     component.find('input[name="chapter13Trustee"]').simulate('change')


### PR DESCRIPTION
## Description
Fixes #1465 

There was an inconsistent mapping between the field naming.
`DischargeDateNotApplicable` (wrong) versus `DateDischargedNotApplicable` (correct)

After updating the naming, the field updates and saves as expected. In addition to that, I did some cleanup around `src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx`.

## Checklist for Reveiwer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)