### PR TITLE
Stop auto-provisioning accounts on WSO2 login success

### DIFF
--- a/api/http/saml.go
+++ b/api/http/saml.go
@@ -165,18 +165,7 @@ func (service SamlResponseHandler) serveAuthnResponse(encodedResponse string, w 
 	if _, err := account.Get(service.Database, account.ID); err != nil {
 		service.Log.WarnError(api.NoAccount, err, api.LogFields{"username": username})
 
-		// Attempt to create a new account if one is not
-		// found in the system but is verified to have
-		// access.
-		//
-		// NOTE: This may only be a pilot circumstance. If so
-		// make sure the final release does not allow the creation
-		// of a new account and returns an error in its place.
-		if _, err := account.Save(service.Database, account.ID); err != nil {
-			service.Log.WarnError(api.AccountUpdateError, err, api.LogFields{"username": username})
-			redirectAccessDenied(w, r)
-			return
-		}
+		redirectAccessDenied(w, r)
 	}
 
 	// Generate jwt token


### PR DESCRIPTION
## Description

For development purposes, eApp would provision an account if login via WSO2 succeeded but the corresponding account did not exist in eApp. This is sloppy, the upstream provisioner should provision accounts in eApp and WSO2 at the same time. This turns it into an error again. 

## Checklist for Reveiwer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
