### PR TITLE
Encode various doc types correctly

### DIFF
--- a/api/templates/citizenship-status.xml
+++ b/api/templates/citizenship-status.xml
@@ -20,7 +20,7 @@
         <LegalName>{{name $citizenship.DocumentName}}</LegalName>
       </DocumentIssued>
       <DocumentNumber>{{text $citizenship.DocumentNumber}}</DocumentNumber>
-      <DocumentType>{{radio $citizenship.DocumentType}}</DocumentType>
+      <DocumentType>{{radio $citizenship.DocumentType | selfForeignDocType}}</DocumentType>
       <DocumentTypeExplanation>{{textarea $citizenship.Explanation}}</DocumentTypeExplanation>
       <ResidenceStatus>{{text $citizenship.ResidenceStatus}}</ResidenceStatus>
       <VisaExpiration>

--- a/api/templates/citizenship-status.xml
+++ b/api/templates/citizenship-status.xml
@@ -78,7 +78,7 @@
           <Date Type="{{dateEstimated $citizenship.DocumentIssued}}">{{date $citizenship.DocumentIssued}}</Date>
         </DatePrepared>
         <DocumentNumber>{{text $citizenship.DocumentNumber}}</DocumentNumber>
-        <DocumentType>{{radio $citizenship.AbroadDocumentation}}</DocumentType>
+        <DocumentType>{{radio $citizenship.AbroadDocumentation | selfAbroadDocType}}</DocumentType>
         <IssuedName>{{name $citizenship.DocumentName}}</IssuedName>
         <OtherExplanation>{{textarea $citizenship.Explanation}}</OtherExplanation>
         <Place>{{location $citizenship.PlaceIssued}}</Place>

--- a/api/templates/spouse-cohabitants.xml
+++ b/api/templates/spouse-cohabitants.xml
@@ -27,7 +27,7 @@
         <Comment></Comment>
         <DocumentExpiration Type="{{dateEstimated $doc.DocumentExpiration}}">{{date $doc.DocumentExpiration}}</DocumentExpiration>
         <DocumentNumber>{{text $doc.DocumentNumber}}</DocumentNumber>
-        <Type>{{text $doc.DocumentType | foreignDocType}}</Type>
+        <Type>{{text $doc.DocumentType | spouseForeignDocType}}</Type>
         <TypeOtherExplanation>{{text $doc.OtherExplanation}}</TypeOtherExplanation>
       </ProofOfStatus>
     </Citizenship>

--- a/api/templates/spouse-present-marriage.xml
+++ b/api/templates/spouse-present-marriage.xml
@@ -24,7 +24,7 @@
         <Comment></Comment>
         <DocumentExpiration Type="{{dateEstimated $doc.DocumentExpiration}}">{{date $doc.DocumentExpiration}}</DocumentExpiration>
         <DocumentNumber>{{text $doc.DocumentNumber}}</DocumentNumber>
-        <Type>{{text $doc.DocumentType | foreignDocType}}</Type>
+        <Type>{{text $doc.DocumentType | spouseForeignDocType}}</Type>
         <TypeOtherExplanation>{{text $doc.OtherExplanation}}</TypeOtherExplanation>
       </ProofOfStatus>
     </Citizenship>

--- a/api/testdata/complete-scenarios/test6.json
+++ b/api/testdata/complete-scenarios/test6.json
@@ -252,14 +252,13 @@
         "CitizenshipStatus": {
           "type": "radio",
           "props": {
-            "value": "Citizen",
-            "checked": true
+            "value": "ForeignBorn"
           }
         },
         "AbroadDocumentation": {
           "type": "radio",
           "props": {
-            "value": ""
+            "value": "FS-240"
           }
         },
         "Explanation": {
@@ -271,27 +270,27 @@
         "DocumentNumber": {
           "type": "text",
           "props": {
-            "value": ""
+            "value": "9732"
           }
         },
         "DocumentIssued": {
           "type": "datecontrol",
           "props": {
-            "month": "",
-            "day": "",
-            "year": "",
+            "month": "01",
+            "day": "02",
+            "year": "1984",
             "estimated": false
           }
         },
         "DocumentName": {
           "type": "name",
           "props": {
-            "first": "",
+            "first": "Ian",
             "firstInitialOnly": false,
             "middle": "",
             "middleInitialOnly": false,
-            "noMiddleName": false,
-            "last": "",
+            "noMiddleName": true,
+            "last": "Chris",
             "suffix": "",
             "suffixOther": ""
           }
@@ -314,34 +313,35 @@
         "PlaceIssued": {
           "type": "location",
           "props": {
-            "layout": "",
-            "country": ""
+            "layout": "Birthplace without County",
+            "city": "Victoria",
+            "country": "Canada"
           }
         },
         "CertificateNumber": {
           "type": "text",
           "props": {
-            "value": ""
+            "value": "7312"
           }
         },
         "CertificateIssued": {
           "type": "datecontrol",
           "props": {
-            "month": "",
-            "day": "",
-            "year": "",
+            "month": "01",
+            "day": "03",
+            "year": "1984",
             "estimated": false
           }
         },
         "CertificateName": {
           "type": "name",
           "props": {
-            "first": "",
+            "first": "Ian",
             "firstInitialOnly": false,
             "middle": "",
             "middleInitialOnly": false,
-            "noMiddleName": false,
-            "last": "",
+            "noMiddleName": true,
+            "last": "Chris",
             "suffix": "",
             "suffixOther": ""
           }
@@ -362,13 +362,13 @@
         "BornOnMilitaryInstallation": {
           "type": "branch",
           "props": {
-            "value": ""
+            "value": "Yes"
           }
         },
         "MilitaryBase": {
           "type": "text",
           "props": {
-            "value": ""
+            "value": "All Your Base"
           }
         },
         "EntryDate": {
@@ -2934,6 +2934,11 @@
         }
       }
     }
+  },
+  "Metadata": {
+    "form_type": "SF86",
+    "form_version": "2016-11",
+    "type": "metadata"
   },
   "Military": {
     "Disciplinary": {

--- a/api/testdata/complete-scenarios/test6.xml
+++ b/api/testdata/complete-scenarios/test6.xml
@@ -557,13 +557,51 @@
   </FederalServices>
             </FormerFederalServiceActivities>
             <Citizenship Version="1" Type="Pooled">
-              <Status>USByBirth</Status>
+              <Status>USByBirthOutsideUS</Status>
               <USCitizen>
                 <ProofOfUSCitizenship>
-      
-      
-      
-    </ProofOfUSCitizenship>
+                  <BornOnBase>
+                    <Answer>Yes</Answer>
+                  </BornOnBase>
+                  <CitizenshipCertificate>
+                    <CertificateNumber>7312</CertificateNumber>
+                    <DateIssued>
+                      <Date>
+                        <Month>01</Month>
+                        <Day>03</Day>
+                        <Year>1984</Year>
+                      </Date>
+                    </DateIssued>
+                    <IssuedName>
+                      <Last>Chris</Last>
+                      <First>Ian</First>
+                      <Middle Type="NMN"/>
+                    </IssuedName>
+                  </CitizenshipCertificate>
+                  <MilitaryBase>
+                    <Name>All Your Base</Name>
+                  </MilitaryBase>
+                  <StateDeptForm240>
+                    <DatePrepared>
+                      <Date>
+                        <Month>01</Month>
+                        <Day>02</Day>
+                        <Year>1984</Year>
+                      </Date>
+                    </DatePrepared>
+                    <DocumentNumber>9732</DocumentNumber>
+                    <DocumentType>FS240</DocumentType>
+                    <IssuedName>
+                      <Last>Chris</Last>
+                      <First>Ian</First>
+                      <Middle Type="NMN"/>
+                    </IssuedName>
+                    <Place>
+                      <City>Victoria</City>
+                      <Country>Canada</Country>
+                    </Place>
+                  </StateDeptForm240>
+                </ProofOfUSCitizenship>
               </USCitizen>
             </Citizenship>
             <DualCitizenship Version="1" Type="Pooled">

--- a/api/testdata/complete-scenarios/test8.json
+++ b/api/testdata/complete-scenarios/test8.json
@@ -13,7 +13,10 @@
           "type": "collection",
           "props": {
             "branch": {
-              "type": ""
+              "type": "branch",
+              "props": {
+                "value": ""
+              }
             },
             "items": []
           }
@@ -74,7 +77,8 @@
                   "Location": {
                     "type": "location",
                     "props": {
-                      "layout": ""
+                      "layout": "",
+                      "country": ""
                     }
                   },
                   "Name": {
@@ -115,8 +119,7 @@
         "CitizenshipStatus": {
           "type": "radio",
           "props": {
-            "value": "Citizen",
-            "checked": true
+            "value": "NotCitizen"
           }
         },
         "AbroadDocumentation": {
@@ -134,27 +137,27 @@
         "DocumentNumber": {
           "type": "text",
           "props": {
-            "value": ""
+            "value": "129456"
           }
         },
         "DocumentIssued": {
           "type": "datecontrol",
           "props": {
-            "month": "",
-            "day": "",
-            "year": "",
+            "month": "01",
+            "day": "02",
+            "year": "2017",
             "estimated": false
           }
         },
         "DocumentName": {
           "type": "name",
           "props": {
-            "first": "",
+            "first": "Alexander",
             "firstInitialOnly": false,
             "middle": "",
             "middleInitialOnly": false,
-            "noMiddleName": false,
-            "last": "",
+            "noMiddleName": true,
+            "last": "Hamilton",
             "suffix": "",
             "suffixOther": ""
           }
@@ -162,22 +165,23 @@
         "DocumentExpiration": {
           "type": "datecontrol",
           "props": {
-            "month": "",
-            "day": "",
-            "year": "",
+            "month": "01",
+            "day": "02",
+            "year": "2019",
             "estimated": false
           }
         },
         "DocumentType": {
           "type": "radio",
           "props": {
-            "value": ""
+            "value": "U.S. Visa"
           }
         },
         "PlaceIssued": {
           "type": "location",
           "props": {
-            "layout": ""
+            "layout": "",
+            "country": ""
           }
         },
         "CertificateNumber": {
@@ -217,7 +221,8 @@
         "CertificateCourtAddress": {
           "type": "location",
           "props": {
-            "layout": ""
+            "layout": "",
+            "country": ""
           }
         },
         "BornOnMilitaryInstallation": {
@@ -235,22 +240,27 @@
         "EntryDate": {
           "type": "datecontrol",
           "props": {
-            "month": "",
-            "day": "",
-            "year": "",
+            "month": "01",
+            "day": "02",
+            "year": "2017",
             "estimated": false
           }
         },
         "EntryLocation": {
           "type": "location",
           "props": {
-            "layout": ""
+            "layout": "City, State",
+            "city": "Portland",
+            "state": "OR",
+            "country": ""
           }
         },
         "PriorCitizenship": {
           "type": "country",
           "props": {
-            "value": null
+            "value": [
+              "Saint Kitts and Nevis"
+            ]
           }
         },
         "HasAlienRegistration": {
@@ -262,15 +272,15 @@
         "AlienRegistrationNumber": {
           "type": "text",
           "props": {
-            "value": ""
+            "value": "723456"
           }
         },
         "AlienRegistrationExpiration": {
           "type": "datecontrol",
           "props": {
-            "month": "",
-            "day": "",
-            "year": "",
+            "month": "01",
+            "day": "02",
+            "year": "2017",
             "estimated": false
           }
         },
@@ -289,7 +299,7 @@
         "ResidenceStatus": {
           "type": "text",
           "props": {
-            "value": ""
+            "value": "Landed"
           }
         }
       }
@@ -1021,7 +1031,8 @@
                       "Address": {
                         "type": "location",
                         "props": {
-                          "layout": ""
+                          "layout": "",
+                          "country": ""
                         }
                       },
                       "Telephone": {
@@ -2131,12 +2142,6 @@
             "value": "Yes"
           }
         },
-        "HasRegisteredNotApplicable": {
-          "type": "notapplicable",
-          "props": {
-            "applicable": true
-          }
-        },
         "RegistrationNumber": {
           "type": "text",
           "props": {
@@ -2147,6 +2152,12 @@
           "type": "textarea",
           "props": {
             "value": ""
+          }
+        },
+        "HasRegisteredNotApplicable": {
+          "type": "notapplicable",
+          "props": {
+            "applicable": true
           }
         }
       }
@@ -2568,13 +2579,15 @@
             "Address": {
               "type": "location",
               "props": {
-                "layout": ""
+                "layout": "",
+                "country": ""
               }
             },
             "AddressSeparated": {
               "type": "location",
               "props": {
-                "layout": ""
+                "layout": "",
+                "country": ""
               }
             },
             "AddressSeparatedNotApplicable": {
@@ -2615,7 +2628,8 @@
             "BirthPlace": {
               "type": "location",
               "props": {
-                "layout": ""
+                "layout": "",
+                "country": ""
               }
             },
             "Birthdate": {
@@ -2710,7 +2724,8 @@
             "Location": {
               "type": "location",
               "props": {
-                "layout": ""
+                "layout": "",
+                "country": ""
               }
             },
             "Name": {
@@ -3153,7 +3168,8 @@
                   "Address": {
                     "type": "location",
                     "props": {
-                      "layout": ""
+                      "layout": "",
+                      "country": ""
                     }
                   },
                   "Aliases": {
@@ -3260,7 +3276,8 @@
                   "CourtAddress": {
                     "type": "location",
                     "props": {
-                      "layout": ""
+                      "layout": "",
+                      "country": ""
                     }
                   },
                   "CourtName": {
@@ -3296,7 +3313,8 @@
                   "EmployerAddress": {
                     "type": "location",
                     "props": {
-                      "layout": ""
+                      "layout": "",
+                      "country": ""
                     }
                   },
                   "EmployerAddressNotApplicable": {
@@ -3438,7 +3456,8 @@
                   "Address": {
                     "type": "location",
                     "props": {
-                      "layout": ""
+                      "layout": "",
+                      "country": ""
                     }
                   },
                   "Aliases": {
@@ -3545,7 +3564,8 @@
                   "CourtAddress": {
                     "type": "location",
                     "props": {
-                      "layout": ""
+                      "layout": "",
+                      "country": ""
                     }
                   },
                   "CourtName": {
@@ -3581,7 +3601,8 @@
                   "EmployerAddress": {
                     "type": "location",
                     "props": {
-                      "layout": ""
+                      "layout": "",
+                      "country": ""
                     }
                   },
                   "EmployerAddressNotApplicable": {

--- a/api/testdata/complete-scenarios/test8.xml
+++ b/api/testdata/complete-scenarios/test8.xml
@@ -415,14 +415,58 @@
   </FederalServices>
             </FormerFederalServiceActivities>
             <Citizenship Version="1" Type="Pooled">
-              <Status>USByBirth</Status>
-              <USCitizen>
-                <ProofOfUSCitizenship>
+              <Status>Alien</Status>
+              <Alien>
+                <AlienRegistration>
+                  <DateEnteredUS>
+                    <Date>
+                      <Month>01</Month>
+                      <Day>02</Day>
+                      <Year>2017</Year>
+                    </Date>
+                  </DateEnteredUS>
+                  <Place>
+                    <City>Portland</City>
+                    <State>OR</State>
+                  </Place>
+                  <RegistrationNumber>723456</RegistrationNumber>
+                  <DocumentExpiration>
+                    <Month>01</Month>
+                    <Day>02</Day>
+                    <Year>2019</Year>
+                  </DocumentExpiration>
+                  <DocumentIssued>
+                    <Date>
+                      <Month>01</Month>
+                      <Day>02</Day>
+                      <Year>2017</Year>
+                    </Date>
+                    <LegalName>
+                      <Last>Hamilton</Last>
+                      <First>Alexander</First>
+                      <Middle Type="NMN"/>
+                    </LegalName>
+                  </DocumentIssued>
+                  <DocumentNumber>129456</DocumentNumber>
+                  <DocumentType>Visa</DocumentType>
+                  <ResidenceStatus>Landed</ResidenceStatus>
+                  <VisaExpiration>
+                    <Date>
+                      <Month>01</Month>
+                      <Day>02</Day>
+                      <Year>2017</Year>
+                    </Date>
+                  </VisaExpiration>
+                </AlienRegistration>
+                <Citizenships>
+                  <Citizenship ID="1">
+                    <Country>Saint Kitts and Nevis</Country>
+                  </Citizenship>
+                </Citizenships>
+                <HaveAlienRegistrationNumber>
       
-      
-      
-    </ProofOfUSCitizenship>
-              </USCitizen>
+    </HaveAlienRegistrationNumber>
+              </Alien>
             </Citizenship>
             <DualCitizenship Version="1" Type="Pooled">
               <DualCitizenships>

--- a/api/xml/xml.go
+++ b/api/xml/xml.go
@@ -91,6 +91,7 @@ func (service Service) DefaultTemplate(templateName string, data map[string]inte
 		"radio":                  radio,
 		"schoolType":             schoolType,
 		"selectBenefit":          selectBenefit,
+		"selfAbroadDocType":      selfAbroadDocType,
 		"selfForeignDocType":     selfForeignDocType,
 		"severanceType":          severanceType,
 		"suffixType":             suffixType,
@@ -537,6 +538,16 @@ func selfForeignDocType(docType string) string {
 		"I-20":      "I20",
 		"DS-2019":   "DS2019",
 		"Other":     "Other",
+	}
+	return alias[docType]
+}
+
+func selfAbroadDocType(docType string) string {
+	alias := map[string]string{
+		"FS-240":  "FS240",
+		"DS-1350": "DS1350",
+		"FS-545":  "FS545",
+		"Other":   "Other",
 	}
 	return alias[docType]
 }

--- a/api/xml/xml.go
+++ b/api/xml/xml.go
@@ -91,6 +91,7 @@ func (service Service) DefaultTemplate(templateName string, data map[string]inte
 		"radio":                  radio,
 		"schoolType":             schoolType,
 		"selectBenefit":          selectBenefit,
+		"selfForeignDocType":     selfForeignDocType,
 		"severanceType":          severanceType,
 		"suffixType":             suffixType,
 		"relationshipType":       relationshipType,
@@ -525,6 +526,17 @@ func spouseForeignDocType(docType string) string {
 		"NonImmigrantStudent": "NonCitizenI20",
 		"ExchangeVisitor":     "NonCitizenDS2019",
 		"Other":               "Other",
+	}
+	return alias[docType]
+}
+
+func selfForeignDocType(docType string) string {
+	alias := map[string]string{
+		"I-94":      "I94",
+		"U.S. Visa": "Visa",
+		"I-20":      "I20",
+		"DS-2019":   "DS2019",
+		"Other":     "Other",
 	}
 	return alias[docType]
 }

--- a/api/xml/xml.go
+++ b/api/xml/xml.go
@@ -64,7 +64,7 @@ func (service Service) DefaultTemplate(templateName string, data map[string]inte
 		"doctorFirstName":        doctorFirstName,
 		"doctorLastName":         doctorLastName,
 		"drugType":               drugType,
-		"foreignDocType":         foreignDocType,
+		"spouseForeignDocType":   spouseForeignDocType,
 		"foreignAffiliation":     foreignAffiliation,
 		"frequencyType":          frequencyType,
 		"email":                  email,
@@ -507,8 +507,8 @@ func relativeForeignDocType(docType string) string {
 	return alias[docType]
 }
 
-// foreignDocType translates our enums to eqip specific enums
-func foreignDocType(docType string) string {
+// spouseForeignDocType translates our enums to eqip specific enums
+func spouseForeignDocType(docType string) string {
 	alias := map[string]string{
 		"FS240":                              "FS240or545",
 		"DS1350":                             "DS1350",

--- a/api/xml/xml_test.go
+++ b/api/xml/xml_test.go
@@ -296,6 +296,7 @@ func TestScenario5(t *testing.T) {
 // application plus:
 // * Other Foreign Benefit with Other Frequency Type and received at Other interval
 // * Divorced and not currently married
+// * Having an applicant that is a U.S. Citizen board abroad
 func TestScenario6(t *testing.T) {
 	executeScenario(t, "test6")
 }

--- a/api/xml/xml_test.go
+++ b/api/xml/xml_test.go
@@ -305,7 +305,9 @@ func TestScenario7(t *testing.T) {
 	executeScenario(t, "test7")
 }
 
-// `test8` is for 21E, explicitly answering "No" to 21A, 21B, 21C, and 21D
+// `test8` is for:
+// * 21E, explicitly answering "No" to 21A, 21B, 21C, and 21D
+// * Having an applicant that is not a U.S. Citizen
 func TestScenario8(t *testing.T) {
 	executeScenario(t, "test8")
 }


### PR DESCRIPTION
Fixes #1514 - front end uses different values from 86 XML for different document types in different contexts, and in some cases no mapping existed in the backend.