### PR TITLE
Make code more defensive where date can be unknown

### DIFF
--- a/api/templates/date-month-day-year-optional.xml
+++ b/api/templates/date-month-day-year-optional.xml
@@ -1,0 +1,6 @@
+{{$dnk := notApplicable .DoNotKnow}}
+<Date Type="{{dateEstimated .Date}}" DoNotKnow="{{$dnk}}">
+  {{if $dnk | ne "True"}}
+    <Month>{{padDigits .Date.props.month}}</Month><Day>{{padDigits .Date.props.day}}</Day><Year>{{.Date.props.year}}</Year>
+  {{end}}
+</Date>

--- a/api/templates/foreign-contacts.xml
+++ b/api/templates/foreign-contacts.xml
@@ -14,9 +14,7 @@
       {{apoFpo $Item.Address $Item.AlternateAddress}}
       {{end}}
       <Birth>
-        <Date Type="{{dateEstimated $Item.Birthdate}}" DoNotKnow="{{notApplicable $Item.BirthdateNotApplicable}}">
-          {{date $Item.Birthdate}}
-        </Date>
+        {{dateOptional $Item.Birthdate $Item.BirthdateNotApplicable}}
         <Place DoNotKnow="{{notApplicable $Item.BirthplaceNotApplicable}}">
           {{location $Item.Birthplace}}
         </Place>

--- a/api/testdata/complete-scenarios/test3.xml
+++ b/api/testdata/complete-scenarios/test3.xml
@@ -786,8 +786,8 @@
                   </Address>
                   <Birth>
                     <Date DoNotKnow="True">
-          
-        </Date>
+  
+</Date>
                     <Place>
                       <City>New York</City>
                       <Country>France</Country>

--- a/api/testdata/complete-scenarios/test5.xml
+++ b/api/testdata/complete-scenarios/test5.xml
@@ -2583,8 +2583,8 @@
 </Address>
                   <Birth>
                     <Date DoNotKnow="True">
-          
-        </Date>
+  
+</Date>
                     <Place DoNotKnow="True">
           
 

--- a/api/testdata/complete-scenarios/test9.xml
+++ b/api/testdata/complete-scenarios/test9.xml
@@ -984,8 +984,8 @@
                   </APOFPO>
                   <Birth>
                     <Date DoNotKnow="True">
-          
-        </Date>
+  
+</Date>
                     <Place>
                       <City>Belfast</City>
                       <Country>United Kingdom</Country>

--- a/api/xml/xml.go
+++ b/api/xml/xml.go
@@ -52,6 +52,7 @@ func (service Service) DefaultTemplate(templateName string, data map[string]inte
 		"citizenshipHas":         citizenshipHas,
 		"clearanceType":          clearanceType,
 		"date":                   date,
+		"dateOptional":           dateOptional,
 		"dateEstimated":          dateEstimated,
 		"daterange":              daterange,
 		"daysInRange":            daysInRange,
@@ -799,6 +800,19 @@ func monthYearDaterange(data map[string]interface{}) (template.HTML, error) {
 		"dateEstimated": dateEstimated,
 	}
 	return xmlTemplateWithFuncs("date-range.xml", data, fmap)
+}
+
+func dateOptional(d, dnk map[string]interface{}) (template.HTML, error) {
+	view := make(map[string]interface{})
+	view["Date"] = d
+	view["DoNotKnow"] = dnk
+
+	fmap := template.FuncMap{
+		"dateEstimated": dateEstimated,
+		"notApplicable": notApplicable,
+		"padDigits":     padDigits,
+	}
+	return xmlTemplateWithFuncs("date-month-day-year-optional.xml", view, fmap)
 }
 
 func date(data map[string]interface{}) (template.HTML, error) {


### PR DESCRIPTION
Fixes #1510. Similar to #1490. 

It seems possible to serialize form data in such a way that the `month` property is not set on date. This PR makes the code more defensive in that the month/day/year properties are not dereferenced if `I don't know` is specified for a date in the UI.
