### PR TITLE
Don't encode country if FS240 issued in US

### DIFF
--- a/api/templates/citizenship-status.xml
+++ b/api/templates/citizenship-status.xml
@@ -81,7 +81,7 @@
         <DocumentType>{{radio $citizenship.AbroadDocumentation | selfAbroadDocType}}</DocumentType>
         <IssuedName>{{name $citizenship.DocumentName}}</IssuedName>
         <OtherExplanation>{{textarea $citizenship.Explanation}}</OtherExplanation>
-        <Place>{{location $citizenship.PlaceIssued}}</Place>
+        <Place>{{locationOverrideLayout $citizenship.PlaceIssued "Birthplace without County CountriesNoUS"}}</Place>
       </StateDeptForm240>
       {{end}}
       {{if radio $citizenship.CitizenshipStatus | eq "Naturalized"}}

--- a/api/testdata/complete-scenarios/test6.json
+++ b/api/testdata/complete-scenarios/test6.json
@@ -314,8 +314,9 @@
           "type": "location",
           "props": {
             "layout": "Birthplace without County",
-            "city": "Victoria",
-            "country": "Canada"
+            "city": "San Jose",
+            "state": "CA",
+            "country": "United States"
           }
         },
         "CertificateNumber": {

--- a/api/testdata/complete-scenarios/test6.xml
+++ b/api/testdata/complete-scenarios/test6.xml
@@ -597,8 +597,8 @@
                       <Middle Type="NMN"/>
                     </IssuedName>
                     <Place>
-                      <City>Victoria</City>
-                      <Country>Canada</Country>
+                      <City>San Jose</City>
+                      <State>CA</State>
                     </Place>
                   </StateDeptForm240>
                 </ProofOfUSCitizenship>


### PR DESCRIPTION
Addresses the "SF86_5_S09-Citizenship" data exception in #1521 – SF-86 XSD does not permit the country value of "United States" when the FS-240 was issued in the US. It only wants city and state.