### PR TITLE
Update FutureBenefit to use key Began so it saves and validates

### DIFF
--- a/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.jsx
+++ b/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.jsx
@@ -66,7 +66,7 @@ export class BenefitActivity extends Subsection {
         case 'Future':
           b = o.FutureBenefit || {}
           benefit.Country = (b.Country || {}).value
-          benefit.Date = DateSummary(b.Begin)
+          benefit.Date = DateSummary(b.Began)
           break
         case 'Continuing':
           b = o.ContinuingBenefit || {}

--- a/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.jsx
+++ b/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.jsx
@@ -56,25 +56,29 @@ export class BenefitActivity extends Subsection {
     const who = ((o.InterestTypes || {}).values || []).join(', ')
 
     let b = null
-    switch (o.BenefitFrequency) {
-      case 'OneTime':
-        b = o.OneTimeBenefit || {}
-        benefit.Country = (b.Country || {}).value
-        benefit.Date = DateSummary(b.Received)
-        break
-      case 'Future':
-        b = o.FutureBenefit || {}
-        benefit.Country = (b.Country || {}).value
-        benefit.Date = DateSummary(b.Begin)
-        break
-      case 'Continuing':
-        b = o.ContinuingBenefit || {}
-        benefit.Country = (b.Country || {}).value
-        benefit.Date = DateSummary(b.Began)
-        break
-      default:
-        console.warn(' There is no such benefit type')
-        break
+    if (o.BenefitFrequency) {
+      switch (o.BenefitFrequency.value) {
+        case 'OneTime':
+          b = o.OneTimeBenefit || {}
+          benefit.Country = (b.Country || {}).value
+          benefit.Date = DateSummary(b.Received)
+          break
+        case 'Future':
+          b = o.FutureBenefit || {}
+          benefit.Country = (b.Country || {}).value
+          benefit.Date = DateSummary(b.Begin)
+          break
+        case 'Continuing':
+          b = o.ContinuingBenefit || {}
+          benefit.Country = (b.Country || {}).value
+          benefit.Date = DateSummary(b.Began)
+          break
+        case 'Other':
+          break
+        default:
+          console.warn(' There is no such benefit type')
+          break
+      }
     }
 
     const summary = [who, benefit.Country].reduce((prev, next) => {

--- a/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.test.jsx
+++ b/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
+import configureMockStore from 'redux-mock-store'
+import { Provider } from 'react-redux'
 import { BenefitActivity } from './BenefitActivity'
 
 describe('The BenefitActivity component', () => {
@@ -72,7 +74,7 @@ describe('The BenefitActivity component', () => {
   it('Renders summary based on benefit', () => {
     const tests = [
       {
-        expected: 'Yourself - Germany',
+        expected: 'Yourself - Cambodia',
         HasBenefits: { value: 'Yes' },
         List: {
           items: [
@@ -81,7 +83,7 @@ describe('The BenefitActivity component', () => {
                 InterestTypes: {
                   values: ['Yourself'],
                 },
-                BenefitFrequency: 'OneTime',
+                BenefitFrequency: { value: 'OneTime' },
                 OneTimeBenefit: {
                   Received: {
                     month: '1',
@@ -89,7 +91,7 @@ describe('The BenefitActivity component', () => {
                     year: '2010',
                   },
                   Country: {
-                    value: 'Germany',
+                    value: 'Cambodia',
                   },
                 },
               },
@@ -107,7 +109,7 @@ describe('The BenefitActivity component', () => {
                 InterestTypes: {
                   values: ['Yourself'],
                 },
-                BenefitFrequency: 'Future',
+                BenefitFrequency: { value: 'Future' },
                 FutureBenefit: {
                   Received: {
                     month: '1',
@@ -133,7 +135,7 @@ describe('The BenefitActivity component', () => {
                 InterestTypes: {
                   values: ['Yourself'],
                 },
-                BenefitFrequency: 'Continuing',
+                BenefitFrequency: { value: 'Continuing' },
                 ContinuingBenefit: {
                   Received: {
                     month: '1',
@@ -148,8 +150,14 @@ describe('The BenefitActivity component', () => {
       },
     ]
 
+    const mockStore = configureMockStore()
     tests.forEach((test) => {
-      const component = mount(<BenefitActivity {...test} />)
+      const store = mockStore(test)
+      const component = mount(
+        <Provider store={store}>
+          <BenefitActivity {...test} />
+        </Provider>
+      )
       expect(component.find('.context').text()).toContain(test.expected)
     })
   })

--- a/src/components/Section/Foreign/Activities/BenefitActivity/FutureBenefit.jsx
+++ b/src/components/Section/Foreign/Activities/BenefitActivity/FutureBenefit.jsx
@@ -5,7 +5,6 @@ import {
   Currency,
   Branch,
   Field,
-  Text,
   DateControl,
   Textarea,
   Radio,
@@ -13,7 +12,6 @@ import {
   RadioGroup,
   Show,
   Checkbox,
-  CheckboxGroup
 } from '../../../../Form'
 
 export default class FutureBenefit extends ValidationElement {
@@ -21,7 +19,7 @@ export default class FutureBenefit extends ValidationElement {
     super(props)
 
     this.update = this.update.bind(this)
-    this.updateBegin = this.updateBegin.bind(this)
+    this.updateBegan = this.updateBegan.bind(this)
     this.updateFrequency = this.updateFrequency.bind(this)
     this.updateOtherFrequency = this.updateOtherFrequency.bind(this)
     this.updateCountry = this.updateCountry.bind(this)
@@ -34,7 +32,7 @@ export default class FutureBenefit extends ValidationElement {
 
   update(queue) {
     this.props.onUpdate({
-      Begin: this.props.Begin,
+      Began: this.props.Began,
       Frequency: this.props.Frequency,
       OtherFrequency: this.props.OtherFrequency,
       Country: this.props.Country,
@@ -43,79 +41,84 @@ export default class FutureBenefit extends ValidationElement {
       Reason: this.props.Reason,
       Obligated: this.props.Obligated,
       ObligatedExplanation: this.props.ObligatedExplanation,
-      ...queue
+      ...queue,
     })
   }
 
-  updateBegin(values) {
+  updateBegan(values) {
     this.update({
-      Begin: values
+      Began: values,
     })
   }
 
   updateFrequency(values) {
     this.update({
-      Frequency: values
+      Frequency: values,
     })
   }
 
   updateOtherFrequency(values) {
     this.update({
-      OtherFrequency: values
+      OtherFrequency: values,
     })
   }
 
   updateCountry(values) {
     this.update({
-      Country: values
+      Country: values,
     })
   }
 
   updateValue(values) {
     this.update({
-      Value: values
+      Value: values,
     })
   }
 
   updateValueEstimated(values) {
     this.update({
-      ValueEstimated: values
+      ValueEstimated: values,
     })
   }
 
   updateReason(values) {
     this.update({
-      Reason: values
+      Reason: values,
     })
   }
 
   updateObligated(values) {
     this.update({
-      Obligated: values
+      Obligated: values,
     })
   }
 
   updateObligatedExplanation(values) {
     this.update({
-      ObligatedExplanation: values
+      ObligatedExplanation: values,
     })
   }
 
   render() {
+    // TODO
+    // One of the things to go back and fix is the grammar.
+    // The backend is expecting Began, which is past tense
+    // Future should be Begin
     return (
       <div className="future-benefit">
         <Field
           title={i18n.t('foreign.activities.benefit.future.heading.begin')}
-          help={'foreign.activities.benefit.future.help.begin'}
+          help="foreign.activities.benefit.future.help.begin"
           adjustFor="labels"
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <DateControl
-            name="Begin"
-            className="begin"
-            {...this.props.Begin}
-            onUpdate={this.updateBegin}
+            name="Began"
+            className="began"
+            {...this.props.Began}
+            onUpdate={this.updateBegan}
             onError={this.props.onError}
-            noMaxDate={true}
+            noMaxDate
             required={this.props.required}
           />
         </Field>
@@ -123,12 +126,14 @@ export default class FutureBenefit extends ValidationElement {
         <Field
           title={i18n.t('foreign.activities.benefit.future.heading.frequency')}
           adjustFor="big-buttons"
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <RadioGroup
             className="frequency option-list option-list-vertical"
             selectedValue={(this.props.Frequency || {}).value}
             onError={this.props.onError}
-            required={this.props.required}>
+            required={this.props.required}
+          >
             <Radio
               name="benefit_frequency"
               label={i18n.m(
@@ -192,7 +197,8 @@ export default class FutureBenefit extends ValidationElement {
 
         <Field
           title={i18n.t('foreign.activities.benefit.future.heading.country')}
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <Country
             name="Country"
             {...this.props.Country}
@@ -204,7 +210,8 @@ export default class FutureBenefit extends ValidationElement {
 
         <Field
           title={i18n.t('foreign.activities.benefit.future.heading.value')}
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <Currency
             name="Value"
             className="value"
@@ -230,7 +237,8 @@ export default class FutureBenefit extends ValidationElement {
 
         <Field
           title={i18n.t('foreign.activities.benefit.future.heading.reason')}
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <Textarea
             name="Reason"
             className="reason"
@@ -259,7 +267,8 @@ export default class FutureBenefit extends ValidationElement {
               'foreign.activities.benefit.future.label.obligatedExplanation'
             )}
             titleSize="label"
-            adjustFor="textarea">
+            adjustFor="textarea"
+          >
             <Textarea
               name="Explanation"
               className="explanation"
@@ -277,8 +286,6 @@ export default class FutureBenefit extends ValidationElement {
 
 FutureBenefit.defaultProps = {
   Obligated: {},
-  onUpdate: queue => {},
-  onError: (value, arr) => {
-    return arr
-  }
+  onUpdate: () => {},
+  onError: (value, arr) => arr,
 }

--- a/src/components/Section/Foreign/Activities/BenefitActivity/FutureBenefit.test.jsx
+++ b/src/components/Section/Foreign/Activities/BenefitActivity/FutureBenefit.test.jsx
@@ -33,7 +33,7 @@ describe('The FutureBenefit component', () => {
     const component = createComponent(expected)
     expect(component.find('.future-benefit').length).toBe(1)
     component
-      .find('.begin input[name="month"]')
+      .find('.began input[name="month"]')
       .simulate('change', { target: { value: '1' } })
     component
       .find('.frequency input')


### PR DESCRIPTION
## Description
Fixes #1525 

While figuring out the validation bug, I learned that the question `Provide the date the benefit will begin` does not save when `Future benefit` is selected.

Previously, this component used the key `Begin` whereas it looks like the backend is expecting `Began`. The other components also follow the same key.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
