### PR TITLE
Remove I don't know from spouse phone number

### DIFF
--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -370,6 +370,7 @@ class CivilUnion extends ValidationElement {
               })}
               onError={this.props.onError}
               required={this.props.required}
+              allowNotApplicable={false}
             />
           </Field>
 


### PR DESCRIPTION
## Description

- Fixes #1529 
- Removes "I don't know" from spouse phone number field
- Does *not* add "Use my current telephone number" since that will need some additional requirements (i.e., a user can enter multiple phone numbers, how do we decide which one is their "current" number?)

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
