### PR TITLE
Fix NotApplicable default prop

### DIFF
--- a/src/components/Section/History/Education/EducationItem.jsx
+++ b/src/components/Section/History/Education/EducationItem.jsx
@@ -396,7 +396,7 @@ export default class EducationItem extends ValidationElement {
                 <Field
                   title={i18n.t('reference.heading.address')}
                   titleSize="h4"
-                  optiona
+                  optional
                   help="reference.help.address"
                   adjustFor="address"
                   scrollIntoView={this.props.scrollIntoView}

--- a/src/components/Section/History/Education/EducationItem.jsx
+++ b/src/components/Section/History/Education/EducationItem.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { i18n } from '../../../../config'
-import { nameIsEmpty } from '../../../../validators'
+
+import i18n from 'util/i18n'
+import { nameIsEmpty } from 'validators'
 import {
   ValidationElement,
   BranchCollection,
@@ -14,18 +15,17 @@ import {
   Name,
   Telephone,
   Show,
-  Email
-} from '../../../Form'
+  Email,
+} from 'components/Form'
+
 import { DiplomaItem } from './Diploma'
 import { today, daysAgo, extractDate } from '../dateranges'
 
 // We need to determine how far back 3 years ago was
 const threeYearsAgo = daysAgo(today, 365 * 3)
-const withinThreeYears = (from, to, present) => {
-  return (
-    present || (from && from >= threeYearsAgo) || (to && to >= threeYearsAgo)
-  )
-}
+const withinThreeYears = (from, to, present) => (
+  present || (from && from >= threeYearsAgo) || (to && to >= threeYearsAgo)
+)
 
 /**
  * Education item in a collection
@@ -34,29 +34,7 @@ const withinThreeYears = (from, to, present) => {
  * when particular portions of this should be rendered.
  */
 export default class EducationItem extends ValidationElement {
-  constructor(props) {
-    super(props)
-
-    this.update = this.update.bind(this)
-    this.updateDates = this.updateDates.bind(this)
-    this.updateType = this.updateType.bind(this)
-    this.updateName = this.updateName.bind(this)
-    this.updateAddress = this.updateAddress.bind(this)
-    this.updateComments = this.updateComments.bind(this)
-    this.updateReferenceName = this.updateReferenceName.bind(this)
-    this.updateReferenceNameNotApplicable = this.updateReferenceNameNotApplicable.bind(
-      this
-    )
-    this.updateReferencePhone = this.updateReferencePhone.bind(this)
-    this.updateReferenceEmail = this.updateReferenceEmail.bind(this)
-    this.updateReferenceEmailNotApplicable = this.updateReferenceEmailNotApplicable.bind(
-      this
-    )
-    this.updateReferenceAddress = this.updateReferenceAddress.bind(this)
-    this.updateDiplomas = this.updateDiplomas.bind(this)
-  }
-
-  update(queue) {
+  update = (queue) => {
     this.props.onUpdate({
       Dates: this.props.Dates,
       Type: this.props.Type,
@@ -70,15 +48,15 @@ export default class EducationItem extends ValidationElement {
       ReferenceEmailNotApplicable: this.props.ReferenceEmailNotApplicable,
       ReferenceAddress: this.props.ReferenceAddress,
       Diplomas: this.props.Diplomas,
-      ...queue
+      ...queue,
     })
   }
 
-  updateDates(values) {
+  updateDates = (values) => {
     const dates = values || {}
-    const from = dates.from
-    const to = dates.to
+    const { from, to } = dates
     const zeroReference = !withinThreeYears(from, to, dates.present)
+
     this.update({
       Dates: values,
       ReferenceName: zeroReference ? {} : this.props.ReferenceName,
@@ -90,91 +68,92 @@ export default class EducationItem extends ValidationElement {
       ReferenceEmailNotApplicable: zeroReference
         ? {}
         : this.props.ReferenceEmailNotApplicable,
-      ReferenceAddress: zeroReference ? {} : this.props.ReferenceAddress
+      ReferenceAddress: zeroReference ? {} : this.props.ReferenceAddress,
     })
   }
 
-  updateType(values) {
+  updateType = (values) => {
     this.update({
-      Type: values
+      Type: values,
     })
   }
 
-  updateName(values) {
+  updateName = (values) => {
     this.update({
-      Name: values
+      Name: values,
     })
   }
 
-  updateAddress(values) {
+  updateAddress = (values) => {
     this.update({
-      Address: values
+      Address: values,
     })
   }
 
-  updateComments(values) {
+  updateComments = (values) => {
     this.update({
-      Comments: values
+      Comments: values,
     })
   }
 
-  updateReferenceName(values) {
+  updateReferenceName = (values) => {
     this.update({
-      ReferenceName: values
+      ReferenceName: values,
     })
   }
 
-  updateReferenceNameNotApplicable(values) {
+  updateReferenceNameNotApplicable = (values) => {
     this.update({
-      ReferenceNameNotApplicable: values
+      ReferenceNameNotApplicable: values,
     })
   }
 
-  updateReferencePhone(values) {
+  updateReferencePhone = (values) => {
     this.update({
-      ReferencePhone: values
+      ReferencePhone: values,
     })
   }
 
-  updateReferenceEmail(values) {
+  updateReferenceEmail = (values) => {
     this.update({
-      ReferenceEmail: values
+      ReferenceEmail: values,
     })
   }
 
-  updateReferenceEmailNotApplicable(values) {
+  updateReferenceEmailNotApplicable = (values) => {
     this.update({
       ReferenceEmailNotApplicable: values,
-      ReferenceEmail: values.applicable ? this.props.ReferenceEmail : {}
+      ReferenceEmail: values.applicable ? this.props.ReferenceEmail : {},
     })
   }
 
-  updateReferenceAddress(values) {
+  updateReferenceAddress = (values) => {
     this.update({
-      ReferenceAddress: values
+      ReferenceAddress: values,
     })
   }
 
-  updateDiplomas(values) {
+  updateDiplomas = (values) => {
     this.update({
-      Diplomas: values
+      Diplomas: values,
     })
   }
 
-  diplomaSummary(item, index) {
+  diplomaSummary = (item, index) => {
     const unk = i18n.t('history.education.collection.diploma.summary.unknown')
     const diploma = item.Diploma || {}
     const d = diploma.Date || {}
-    const text =
-      (diploma.Diploma === 'Other' ? diploma.DiplomaOther : diploma.Diploma) ||
-      unk
+    const text = (
+      diploma.Diploma === 'Other'
+        ? diploma.DiplomaOther
+        : diploma.Diploma
+    ) || unk
     const dd = d ? `${d.month}/${d.year}` : unk
 
     return (
       <span>
         <span className="index">
-          {i18n.t('history.education.collection.diploma.summary.item')}{' '}
-          {index + 1}:
+          {`${i18n.t('history.education.collection.diploma.summary.item')} ${index + 1}:`}
         </span>
         <span className="">
           <strong>{text}</strong>
@@ -200,7 +179,8 @@ export default class EducationItem extends ValidationElement {
             title={i18n.t('history.education.heading.name')}
             titleSize="h4"
             adjustFor="labels"
-            scrollIntoView={this.props.scrollIntoView}>
+            scrollIntoView={this.props.scrollIntoView}
+          >
             <Text
               name="Name"
               {...this.props.Name}
@@ -217,8 +197,11 @@ export default class EducationItem extends ValidationElement {
             titleSize="h4"
             help="history.education.help.dates"
             adjustFor="daterange"
-            shrink={true}
-            scrollIntoView={this.props.scrollIntoView}>
+            shrink
+            scrollIntoView={this.props.scrollIntoView}
+          >
+            {/* eslint jsx-a11y/label-has-associated-control: 0 */}
+            {/* eslint jsx-a11y/label-has-for: 0 */}
             <label className="info-label">
               {i18n.t('history.education.label.dates')}
             </label>
@@ -226,7 +209,7 @@ export default class EducationItem extends ValidationElement {
               name="Dates"
               {...this.props.Dates}
               label={i18n.t('history.education.label.dates')}
-              minDateEqualTo={true}
+              minDateEqualTo
               onUpdate={this.updateDates}
               onError={this.props.onError}
               required={this.props.required}
@@ -236,16 +219,17 @@ export default class EducationItem extends ValidationElement {
           <Field
             title={i18n.t('history.education.heading.address')}
             titleSize="h4"
-            optional={true}
+            optional
             help="history.education.help.address"
-            comments={true}
+            comments
             commentsName="Comments"
             commentsValue={this.props.Comments}
             onUpdate={this.updateComments}
             onError={this.props.onError}
             adjustFor="address"
-            shrink={true}
-            scrollIntoView={this.props.scrollIntoView}>
+            shrink
+            scrollIntoView={this.props.scrollIntoView}
+          >
             <label className="into-label">
               {i18n.m('history.education.label.addressLink')}
             </label>
@@ -257,8 +241,8 @@ export default class EducationItem extends ValidationElement {
               dispatch={this.props.dispatch}
               addressBooks={this.props.addressBooks}
               addressBook="Education"
-              geocode={true}
-              showPostOffice={true}
+              geocode
+              showPostOffice
               onUpdate={this.updateAddress}
               onError={this.props.onError}
               required={this.props.required}
@@ -269,13 +253,15 @@ export default class EducationItem extends ValidationElement {
             title={i18n.t('history.education.heading.type')}
             titleSize="h4"
             adjustFor="big-buttons"
-            shrink={true}
-            scrollIntoView={this.props.scrollIntoView}>
+            shrink
+            scrollIntoView={this.props.scrollIntoView}
+          >
             <RadioGroup
               className="type option-list option-list-vertical"
               required={this.props.required}
               onError={this.props.onError}
-              selectedValue={(this.props.Type || {}).value}>
+              selectedValue={(this.props.Type || {}).value}
+            >
               <Radio
                 name="type-highschool"
                 className="type-highschool"
@@ -317,30 +303,33 @@ export default class EducationItem extends ValidationElement {
                 title={i18n.t('history.education.heading.reference')}
                 titleSize="h3"
                 className="no-margin-bottom"
-                scrollIntoView={this.props.scrollIntoView}>
+                scrollIntoView={this.props.scrollIntoView}
+              >
                 {i18n.m('history.education.para.reference')}
               </Field>
 
               <Field
                 title={i18n.t('reference.heading.name')}
                 titleSize="h4"
-                optional={true}
+                optional
                 filterErrors={Name.requiredErrorsOnly}
-                scrollIntoView={this.props.scrollIntoView}>
+                scrollIntoView={this.props.scrollIntoView}
+              >
                 <NotApplicable
                   name="ReferenceNameNotApplicable"
                   {...this.props.ReferenceNameNotApplicable}
                   label={i18n.t('reference.label.idk')}
                   or={i18n.m('reference.para.or')}
                   onUpdate={this.updateReferenceNameNotApplicable}
-                  onError={this.props.onError}>
+                  onError={this.props.onError}
+                >
                   <Name
                     name="ReferenceName"
-                    prefix={'name'}
+                    prefix="name"
                     className="reference-name"
                     {...this.props.ReferenceName}
                     scrollIntoView={this.props.scrollIntoView}
-                    hideMiddleName={true}
+                    hideMiddleName
                     onUpdate={this.updateReferenceName}
                     onError={this.props.onError}
                     required={this.props.required}
@@ -352,9 +341,10 @@ export default class EducationItem extends ValidationElement {
                 <Field
                   title={i18n.t('reference.heading.correspondence')}
                   titleSize="h4"
-                  optional={true}
+                  optional
                   className="no-margin-bottom"
-                  scrollIntoView={this.props.scrollIntoView}>
+                  scrollIntoView={this.props.scrollIntoView}
+                >
                   {i18n.m('reference.para.correspondence')}
                 </Field>
 
@@ -362,9 +352,10 @@ export default class EducationItem extends ValidationElement {
                   title={i18n.t('reference.heading.phone.default')}
                   titleSize="h4"
                   className="override-required"
-                  help={'reference.help.phone'}
+                  help="reference.help.phone"
                   adjustFor="telephone"
-                  scrollIntoView={this.props.scrollIntoView}>
+                  scrollIntoView={this.props.scrollIntoView}
+                >
                   <Telephone
                     name="ReferencePhone"
                     className="reference-phone"
@@ -379,16 +370,18 @@ export default class EducationItem extends ValidationElement {
                 <Field
                   title={i18n.t('reference.heading.email')}
                   titleSize="h4"
-                  help={'reference.help.email'}
+                  help="reference.help.email"
                   adjustFor="label"
-                  scrollIntoView={this.props.scrollIntoView}>
+                  scrollIntoView={this.props.scrollIntoView}
+                >
                   <NotApplicable
                     name="ReferenceEmailNotApplicable"
                     {...this.props.ReferenceEmailNotApplicable}
                     label={i18n.t('reference.label.idk')}
                     or={i18n.m('reference.para.or')}
                     onUpdate={this.updateReferenceEmailNotApplicable}
-                    onError={this.props.onError}>
+                    onError={this.props.onError}
+                  >
                     <Email
                       name="ReferenceEmail"
                       {...this.props.ReferenceEmail}
@@ -403,10 +396,11 @@ export default class EducationItem extends ValidationElement {
                 <Field
                   title={i18n.t('reference.heading.address')}
                   titleSize="h4"
-                  optional={true}
-                  help={'reference.help.address'}
+                  optiona
+                  help="reference.help.address"
                   adjustFor="address"
-                  scrollIntoView={this.props.scrollIntoView}>
+                  scrollIntoView={this.props.scrollIntoView}
+                >
                   <p>{i18n.t('reference.para.address')}</p>
                   <Location
                     name="ReferenceAddress"
@@ -414,10 +408,10 @@ export default class EducationItem extends ValidationElement {
                     {...this.props.ReferenceAddress}
                     label={i18n.t('reference.label.address')}
                     layout={Location.ADDRESS}
-                    geocode={true}
+                    geocode
                     addressBooks={this.props.addressBooks}
                     addressBook="Reference"
-                    showPostOffice={true}
+                    showPostOffice
                     dispatch={this.props.dispatch}
                     onUpdate={this.updateReferenceAddress}
                     onError={this.props.onError}
@@ -436,10 +430,11 @@ export default class EducationItem extends ValidationElement {
             onUpdate={this.updateDiplomas}
             onError={this.props.onError}
             required={this.props.required}
-            scrollIntoView={this.props.scrollIntoView}>
+            scrollIntoView={this.props.scrollIntoView}
+          >
             <DiplomaItem
               name="Item"
-              bind={true}
+              bind
               required={this.props.required}
               scrollIntoView={this.props.scrollIntoView}
             />
@@ -457,14 +452,12 @@ EducationItem.defaultProps = {
   Address: {},
   Comments: {},
   ReferenceName: {},
-  ReferenceNameNotApplicable: {},
+  ReferenceNameNotApplicable: { applicable: true },
   ReferencePhone: {},
   ReferenceEmail: {},
-  ReferenceEmailNotApplicable: {},
+  ReferenceEmailNotApplicable: { applicable: true },
   ReferenceAddress: {},
   Diplomas: { items: [] },
-  onUpdate: queue => {},
-  onError: (value, arr) => {
-    return arr
-  }
+  onUpdate: () => {},
+  onError: (value, arr) => arr,
 }

--- a/src/components/Section/History/Education/EducationItem.jsx
+++ b/src/components/Section/History/Education/EducationItem.jsx
@@ -99,6 +99,7 @@ export default class EducationItem extends ValidationElement {
   updateReferenceName = (values) => {
     this.update({
       ReferenceName: values,
+      ReferenceNameNotApplicable: { applicable: true },
     })
   }
 
@@ -117,6 +118,7 @@ export default class EducationItem extends ValidationElement {
   updateReferenceEmail = (values) => {
     this.update({
       ReferenceEmail: values,
+      ReferenceEmailNotApplicable: { applicable: true },
     })
   }
 

--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
-import { i18n } from '../../../../config'
+
+import i18n from 'util/i18n'
+
 import {
   ValidationElement,
   DateRange,
@@ -13,21 +15,18 @@ import {
   DateControl,
   CheckboxGroup,
   Checkbox,
-  Svg,
   Telephone,
   NotApplicable,
-  Email
-} from '../../../Form'
-import AlternateAddress from '../../../Form/Location/AlternateAddress'
+  Email,
+} from 'components/Form'
+import ConnectedAlternateAddress from 'components/Form/Location/AlternateAddress'
 import { today, daysAgo, extractDate } from '../dateranges'
 
 // We need to determine how far back 3 years ago was
 const threeYearsAgo = daysAgo(today, 365 * 3)
-const withinThreeYears = (from, to, present) => {
-  return (
-    present || (from && from >= threeYearsAgo) || (to && to >= threeYearsAgo)
-  )
-}
+const withinThreeYears = (from, to, present) => (
+  present || (from && from >= threeYearsAgo) || (to && to >= threeYearsAgo)
+)
 
 /**
  * Residence item in a collection
@@ -36,145 +35,110 @@ const withinThreeYears = (from, to, present) => {
  * when particular portions of this should be rendered.
  */
 export default class ResidenceItem extends ValidationElement {
-  constructor(props) {
-    super(props)
-
-    this.update = this.update.bind(this)
-    this.updateReferenceName = this.updateReferenceName.bind(this)
-    this.updateReferenceLastContact = this.updateReferenceLastContact.bind(this)
-    this.updateReferenceRelationshipComments = this.updateReferenceRelationshipComments.bind(
-      this
-    )
-    this.updateReferenceRelationship = this.updateReferenceRelationship.bind(
-      this
-    )
-    this.updateReferenceRelationshipOther = this.updateReferenceRelationshipOther.bind(
-      this
-    )
-    this.updateReferencePhoneEvening = this.updateReferencePhoneEvening.bind(
-      this
-    )
-    this.updateReferencePhoneDay = this.updateReferencePhoneDay.bind(this)
-    this.updateReferencePhoneMobile = this.updateReferencePhoneMobile.bind(this)
-    this.updateReferenceEmailNotApplicable = this.updateReferenceEmailNotApplicable.bind(
-      this
-    )
-    this.updateReferenceEmail = this.updateReferenceEmail.bind(this)
-    this.updateReferenceAddress = this.updateReferenceAddress.bind(this)
-    this.updateComments = this.updateComments.bind(this)
-    this.updateAddress = this.updateAddress.bind(this)
-    this.updateDates = this.updateDates.bind(this)
-    this.updateRole = this.updateRole.bind(this)
-    this.updateRoleOther = this.updateRoleOther.bind(this)
-  }
-
   /**
    * Handle any updates and bubble them up.
    */
-  update(queue) {
+  update = (queue) => {
     this.props.onUpdate({
       ...this.props,
-      ...queue
+      ...queue,
     })
   }
 
-  updateReferenceName(values) {
+  updateReferenceName = (values) => {
     this.update({
-      ReferenceName: values
+      ReferenceName: values,
     })
   }
 
-  updateReferenceLastContact(values) {
+  updateReferenceLastContact = (values) => {
     this.update({
-      ReferenceLastContact: values
+      ReferenceLastContact: values,
     })
   }
 
-  updateReferenceRelationshipComments(values) {
+  updateReferenceRelationshipComments = (values) => {
     this.update({
-      ReferenceRelationshipComments: values
+      ReferenceRelationshipComments: values,
     })
   }
 
-  updateReferenceRelationship(values) {
-    let selected = [...((this.props.ReferenceRelationship || {}).values || [])]
+  updateReferenceRelationship = (values) => {
+    const selected = [...((this.props.ReferenceRelationship || {}).values || [])]
 
     if (values.checked) {
       // Add the new relationship
       selected.push(values.value)
-    } else {
-      if (selected.includes(values.value)) {
-        // Remove the relationship if it was previously selected
-        selected.splice(selected.indexOf(values.value), 1)
-      }
+    } else if (selected.includes(values.value)) {
+      // Remove the relationship if it was previously selected
+      selected.splice(selected.indexOf(values.value), 1)
     }
 
     this.update({
       ReferenceRelationship: {
-        values: selected
-      }
+        values: selected,
+      },
     })
   }
 
-  updateReferenceRelationshipOther(values) {
+  updateReferenceRelationshipOther = (values) => {
     this.update({
-      ReferenceRelationshipOther: values
+      ReferenceRelationshipOther: values,
     })
   }
 
-  updateReferencePhoneEvening(values) {
+  updateReferencePhoneEvening = (values) => {
     this.update({
-      ReferencePhoneEvening: values
+      ReferencePhoneEvening: values,
     })
   }
 
-  updateReferencePhoneDay(values) {
+  updateReferencePhoneDay = (values) => {
     this.update({
-      ReferencePhoneDay: values
+      ReferencePhoneDay: values,
     })
   }
 
-  updateReferencePhoneMobile(values) {
+  updateReferencePhoneMobile = (values) => {
     this.update({
-      ReferencePhoneMobile: values
+      ReferencePhoneMobile: values,
     })
   }
 
-  updateReferenceEmailNotApplicable(values) {
+  updateReferenceEmailNotApplicable = (values) => {
     this.update({
       ReferenceEmailNotApplicable: values,
-      ReferenceEmail: values.applicable ? this.props.ReferenceEmail : {}
+      ReferenceEmail: values.applicable ? this.props.ReferenceEmail : {},
     })
   }
 
-  updateReferenceEmail(values) {
+  updateReferenceEmail = (values) => {
     this.update({
-      ReferenceEmail: values
+      ReferenceEmail: values,
     })
   }
 
-  updateReferenceAddress(values) {
+  updateReferenceAddress = (values) => {
     this.update({
-      ReferenceAddress: values
+      ReferenceAddress: values,
     })
   }
 
-  updateComments(values) {
+  updateComments = (values) => {
     this.update({
-      Comments: values
+      Comments: values,
     })
   }
 
-  updateAddress(values) {
+  updateAddress = (values) => {
     this.update({
-      Address: values
+      Address: values,
     })
   }
 
-  updateDates(values) {
+  updateDates = (values) => {
     const dates = this.props.Dates || {}
-    const from = dates.from
-    const to = dates.to
+    const { from, to } = dates
     const zeroReference = !withinThreeYears(from, to, dates.present)
     this.update({
       Dates: values,
@@ -202,19 +166,19 @@ export default class ResidenceItem extends ValidationElement {
         ? {}
         : this.props.ReferenceEmailNotApplicable,
       ReferenceEmail: zeroReference ? {} : this.props.ReferenceEmail,
-      ReferenceAddress: zeroReference ? {} : this.props.ReferenceAddress
+      ReferenceAddress: zeroReference ? {} : this.props.ReferenceAddress,
     })
   }
 
-  updateRole(values) {
+  updateRole = (values) => {
     this.update({
-      Role: values
+      Role: values,
     })
   }
 
-  updateRoleOther(values) {
+  updateRoleOther = (values) => {
     this.update({
-      RoleOther: values
+      RoleOther: values,
     })
   }
 
@@ -240,7 +204,8 @@ export default class ResidenceItem extends ValidationElement {
           onError={this.props.onError}
           adjustFor="address"
           shrink
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <Location
             name="Address"
             {...this.props.Address}
@@ -256,7 +221,7 @@ export default class ResidenceItem extends ValidationElement {
             required={this.props.required}
           />
         </Field>
-        <AlternateAddress
+        <ConnectedAlternateAddress
           address={this.props.AlternateAddress}
           belongingTo="AlternateAddress"
           country={this.props.Address.country}
@@ -267,7 +232,10 @@ export default class ResidenceItem extends ValidationElement {
           title={i18n.t('history.residence.heading.dates')}
           titleSize="h4"
           help="history.residence.help.dates"
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
+          {/* eslint jsx-a11y/label-has-associated-control: 0 */}
+          {/* eslint jsx-a11y/label-has-for: 0 */}
           <label className="info-label">
             {i18n.t('history.residence.label.dates')}
           </label>
@@ -275,7 +243,7 @@ export default class ResidenceItem extends ValidationElement {
             name="Dates"
             {...this.props.Dates}
             label={i18n.t('history.residence.label.dates')}
-            minDateEqualTo={true}
+            minDateEqualTo
             onUpdate={this.updateDates}
             onError={this.props.onError}
             required={this.props.required}
@@ -288,12 +256,14 @@ export default class ResidenceItem extends ValidationElement {
           className={
             (this.props.Role || {}).value === 'Other' ? 'no-margin-bottom' : ''
           }
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <RadioGroup
             className="role option-list option-list-vertical"
             required={this.props.required}
             onError={this.props.onError}
-            selectedValue={(this.props.Role || {}).value}>
+            selectedValue={(this.props.Role || {}).value}
+          >
             <Radio
               name="role-owned"
               label={i18n.m('history.residence.label.role.owned')}
@@ -329,7 +299,8 @@ export default class ResidenceItem extends ValidationElement {
             title={i18n.t('history.residence.label.role.explanation')}
             titleSize="h4"
             adjustFor="text"
-            scrollIntoView={this.props.scrollIntoView}>
+            scrollIntoView={this.props.scrollIntoView}
+          >
             <Text
               name="RoleOther"
               {...this.props.RoleOther}
@@ -349,7 +320,8 @@ export default class ResidenceItem extends ValidationElement {
               titleSize="h3"
               optional
               className="no-margin-bottom"
-              scrollIntoView={this.props.scrollIntoView}>
+              scrollIntoView={this.props.scrollIntoView}
+            >
               {i18n.m('history.residence.para.reference')}
             </Field>
 
@@ -359,10 +331,11 @@ export default class ResidenceItem extends ValidationElement {
                 titleSize="h4"
                 optional
                 filterErrors={Name.requiredErrorsOnly}
-                scrollIntoView={this.props.scrollIntoView}>
+                scrollIntoView={this.props.scrollIntoView}
+              >
                 <Name
                   name="ReferenceName"
-                  prefix={'name'}
+                  prefix="name"
                   className="reference-name"
                   {...this.props.ReferenceName}
                   scrollIntoView={this.props.scrollIntoView}
@@ -375,15 +348,16 @@ export default class ResidenceItem extends ValidationElement {
               <Field
                 title={i18n.t('reference.heading.contact')}
                 titleSize="h4"
-                help={'reference.help.contact'}
+                help="reference.help.contact"
                 adjustFor="labels"
                 shrink
-                scrollIntoView={this.props.scrollIntoView}>
+                scrollIntoView={this.props.scrollIntoView}
+              >
                 <DateControl
                   name="ReferenceLastContact"
                   className="reference-last-contact"
                   {...this.props.ReferenceLastContact}
-                  minDateEqualTo={true}
+                  minDateEqualTo
                   onUpdate={this.updateReferenceLastContact}
                   onError={this.props.onError}
                   required={this.props.required}
@@ -396,11 +370,12 @@ export default class ResidenceItem extends ValidationElement {
                 comments
                 commentsName="ReferenceRelationshipComments"
                 commentsValue={this.props.ReferenceRelationshipComments}
-                commentsAdd={'reference.label.relationship.comments'}
+                commentsAdd="reference.label.relationship.comments"
                 onUpdate={this.updateReferenceRelationshipComments}
                 adjustFor="labels"
                 shrink
-                scrollIntoView={this.props.scrollIntoView}>
+                scrollIntoView={this.props.scrollIntoView}
+              >
                 <label>{i18n.t('reference.label.relationship.title')}</label>
                 <CheckboxGroup
                   className="relationship option-list eapp-extend-labels option-list-vertical"
@@ -408,7 +383,8 @@ export default class ResidenceItem extends ValidationElement {
                   onError={this.props.onError}
                   selectedValues={
                     (this.props.ReferenceRelationship || {}).values || []
-                  }>
+                  }
+                >
                   <Checkbox
                     name="relationship-neighbor"
                     className="reference-relationship-neighbor"
@@ -448,9 +424,8 @@ export default class ResidenceItem extends ValidationElement {
                 <Show
                   when={(
                     (this.props.ReferenceRelationship || {}).values || []
-                  ).some(x => {
-                    return x === 'Other'
-                  })}>
+                  ).some(x => x === 'Other')}
+                >
                   <Text
                     name="ReferenceRelationshipOther"
                     label={i18n.t('reference.label.relationship.explanation')}
@@ -469,7 +444,8 @@ export default class ResidenceItem extends ValidationElement {
                 titleSize="h3"
                 optional
                 className="no-margin-bottom"
-                scrollIntoView={this.props.scrollIntoView}>
+                scrollIntoView={this.props.scrollIntoView}
+              >
                 {i18n.m('reference.para.correspondence')}
               </Field>
 
@@ -477,9 +453,10 @@ export default class ResidenceItem extends ValidationElement {
                 title={i18n.t('reference.heading.phone.evening')}
                 titleSize="h4"
                 className="override-required"
-                help={'reference.help.phone'}
+                help="reference.help.phone"
                 adjustFor="telephone"
-                scrollIntoView={this.props.scrollIntoView}>
+                scrollIntoView={this.props.scrollIntoView}
+              >
                 <Telephone
                   name="ReferencePhoneEvening"
                   className="reference-phone-evening"
@@ -495,9 +472,10 @@ export default class ResidenceItem extends ValidationElement {
                 title={i18n.t('reference.heading.phone.day')}
                 titleSize="h4"
                 className="override-required"
-                help={'reference.help.phone'}
+                help="reference.help.phone"
                 adjustFor="telephone"
-                scrollIntoView={this.props.scrollIntoView}>
+                scrollIntoView={this.props.scrollIntoView}
+              >
                 <Telephone
                   name="ReferencePhoneDay"
                   className="reference-phone-day"
@@ -513,9 +491,10 @@ export default class ResidenceItem extends ValidationElement {
                 title={i18n.t('reference.heading.phone.mobile')}
                 titleSize="h4"
                 className="override-required"
-                help={'reference.help.phone'}
+                help="reference.help.phone"
                 adjustFor="telephone"
-                scrollIntoView={this.props.scrollIntoView}>
+                scrollIntoView={this.props.scrollIntoView}
+              >
                 <Telephone
                   name="ReferencePhoneMobile"
                   className="reference-phone-mobile"
@@ -530,16 +509,18 @@ export default class ResidenceItem extends ValidationElement {
               <Field
                 title={i18n.t('reference.heading.email')}
                 titleSize="h4"
-                help={'reference.help.email'}
+                help="reference.help.email"
                 adjustFor="label"
-                scrollIntoView={this.props.scrollIntoView}>
+                scrollIntoView={this.props.scrollIntoView}
+              >
                 <NotApplicable
                   name="ReferenceEmailNotApplicable"
                   {...this.props.ReferenceEmailNotApplicable}
                   label={i18n.t('reference.label.idk')}
                   or={i18n.m('reference.para.or')}
                   onUpdate={this.updateReferenceEmailNotApplicable}
-                  onError={this.props.onError}>
+                  onError={this.props.onError}
+                >
                   <Email
                     name="ReferenceEmail"
                     {...this.props.ReferenceEmail}
@@ -555,9 +536,10 @@ export default class ResidenceItem extends ValidationElement {
                 title={i18n.t('reference.heading.address')}
                 titleSize="h4"
                 optional
-                help={'reference.help.address'}
+                help="reference.help.address"
                 adjustFor="address"
-                scrollIntoView={this.props.scrollIntoView}>
+                scrollIntoView={this.props.scrollIntoView}
+              >
                 <p>{i18n.t('reference.para.address')}</p>
                 <Location
                   name="ReferenceAddress"
@@ -574,7 +556,7 @@ export default class ResidenceItem extends ValidationElement {
                   onError={this.props.onError}
                 />
               </Field>
-              <AlternateAddress
+              <ConnectedAlternateAddress
                 belongingTo="ReferenceAlternateAddress"
                 address={this.props.ReferenceAlternateAddress}
                 country={this.props.ReferenceAddress.country}
@@ -605,13 +587,11 @@ ResidenceItem.defaultProps = {
   ReferencePhoneEvening: {},
   ReferencePhoneDay: {},
   ReferencePhoneMobile: {},
-  ReferenceEmailNotApplicable: {},
+  ReferenceEmailNotApplicable: { applicable: true },
   ReferenceEmail: {},
   ReferenceAddress: {},
   addressBooks: {},
-  dispatch: action => {},
-  onUpdate: queue => {},
-  onError: (value, arr) => {
-    return arr
-  }
+  dispatch: () => {},
+  onUpdate: () => {},
+  onError: (value, arr) => arr,
 }

--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -115,6 +115,7 @@ export default class ResidenceItem extends ValidationElement {
   updateReferenceEmail = (values) => {
     this.update({
       ReferenceEmail: values,
+      ReferenceEmailNotApplicable: { applicable: true },
     })
   }
 

--- a/src/components/Section/Package/Errors/__snapshots__/index.test.jsx.snap
+++ b/src/components/Section/Package/Errors/__snapshots__/index.test.jsx.snap
@@ -20,6 +20,7 @@ ShallowWrapper {
         }
       }
       source="# Some required fields are incomplete
+
 Please fix the errors listed below."
     />
     <FormStatus
@@ -40,6 +41,7 @@ Please fix the errors listed below."
           }
         }
         source="### List of incomplete sections
+
 Use the list below to complete all incomplete sections or sections with errors."
       />
     </div>
@@ -57,6 +59,7 @@ Use the list below to complete all incomplete sections or sections with errors."
           }
         }
         source="# Some required fields are incomplete
+
 Please fix the errors listed below."
       />
       <FormStatus
@@ -77,6 +80,7 @@ Please fix the errors listed below."
             }
           }
           source="### List of incomplete sections
+
 Use the list below to complete all incomplete sections or sections with errors."
         />
       </div>
@@ -132,6 +136,7 @@ Use the list below to complete all incomplete sections or sections with errors."
               }
             }
             source="# Some required fields are incomplete
+
 Please fix the errors listed below."
           />
           <FormStatus
@@ -152,6 +157,7 @@ Please fix the errors listed below."
                 }
               }
               source="### List of incomplete sections
+
 Use the list below to complete all incomplete sections or sections with errors."
             />
           </div>
@@ -169,6 +175,7 @@ Use the list below to complete all incomplete sections or sections with errors."
               }
             }
             source="# Some required fields are incomplete
+
 Please fix the errors listed below."
           />
           <FormStatus
@@ -189,6 +196,7 @@ Please fix the errors listed below."
                 }
               }
               source="### List of incomplete sections
+
 Use the list below to complete all incomplete sections or sections with errors."
             />
           </div>

--- a/src/components/Section/Package/Review/__snapshots__/index.test.jsx.snap
+++ b/src/components/Section/Package/Review/__snapshots__/index.test.jsx.snap
@@ -20,6 +20,7 @@ ShallowWrapper {
         }
       }
       source="# Verifying your information is complete
+
 Checking your form..."
     />
     <FormStatus
@@ -42,6 +43,7 @@ Checking your form..."
           }
         }
         source="# Verifying your information is complete
+
 Checking your form..."
       />
       <FormStatus
@@ -105,6 +107,7 @@ Checking your form..."
               }
             }
             source="# Verifying your information is complete
+
 Checking your form..."
           />
           <FormStatus
@@ -127,6 +130,7 @@ Checking your form..."
               }
             }
             source="# Verifying your information is complete
+
 Checking your form..."
           />
           <FormStatus

--- a/src/components/Section/Package/Submit/__snapshots__/index.test.jsx.snap
+++ b/src/components/Section/Package/Submit/__snapshots__/index.test.jsx.snap
@@ -20,6 +20,7 @@ ShallowWrapper {
         }
       }
       source="# All required fields are complete
+
 Not a guarantee of acceptance, but all required fields are complete."
     />
     <FormStatus
@@ -112,6 +113,7 @@ Not a guarantee of acceptance, but all required fields are complete."
           }
         }
         source="# All required fields are complete
+
 Not a guarantee of acceptance, but all required fields are complete."
       />
       <FormStatus
@@ -263,6 +265,7 @@ Not a guarantee of acceptance, but all required fields are complete."
               }
             }
             source="# All required fields are complete
+
 Not a guarantee of acceptance, but all required fields are complete."
           />
           <FormStatus
@@ -355,6 +358,7 @@ Not a guarantee of acceptance, but all required fields are complete."
               }
             }
             source="# All required fields are complete
+
 Not a guarantee of acceptance, but all required fields are complete."
           />
           <FormStatus

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -1048,7 +1048,7 @@ Relative.defaultProps = {
   MethodsComments: {},
   Frequency: '',
   FrequencyComments: {},
-  EmployerNotApplicable: {},
+  EmployerNotApplicable: { applicable: true },
   EmployerAddressNotApplicable: { applicable: true },
   EmployerRelationshipNotApplicable: { applicable: true },
   Employer: {},

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -1,3 +1,6 @@
+/* eslint jsx-a11y/label-has-associated-control: 0 */
+/* eslint jsx-a11y/label-has-for: 0 */
+
 import React from 'react'
 import { i18n } from 'config'
 import { pickDate, alphaNumericRegEx } from 'validators/helpers'
@@ -19,7 +22,7 @@ import {
   NotApplicable,
   Location,
 } from 'components/Form'
-import AlternateAddress from 'components/Form/Location/AlternateAddress'
+import ConnectedAlternateAddress from 'components/Form/Location/AlternateAddress'
 import { RelativeValidator } from 'validators'
 import { countryString } from 'validators/location'
 import Alias from './Alias'
@@ -255,6 +258,13 @@ export default class Relative extends ValidationElement {
     }
   }
 
+  updateEmployer = (values) => {
+    this.update({
+      Employer: values,
+      EmployerNotApplicable: { applicable: true },
+    })
+  }
+
   updateEmployerNotApplicable = (values) => {
     this.update({
       EmployerNotApplicable: values,
@@ -262,10 +272,24 @@ export default class Relative extends ValidationElement {
     })
   }
 
+  updateEmployerAddress = (values) => {
+    this.update({
+      EmployerAddress: values,
+      EmployerAddressNotApplicable: { applicable: true },
+    })
+  }
+
   updateEmployerAddressNotApplicable = (values) => {
     this.update({
       EmployerAddressNotApplicable: values,
       EmployerAddress: {},
+    })
+  }
+
+  updateEmployerRelationship = (values) => {
+    this.update({
+      EmployerRelationship: values,
+      EmployerRelationshipNotApplicable: { applicable: true },
     })
   }
 
@@ -498,7 +522,7 @@ export default class Relative extends ValidationElement {
               required={this.props.required}
             />
           </Field>
-          <AlternateAddress
+          <ConnectedAlternateAddress
             address={this.props.AlternateAddress}
             addressBook={this.props.addressBook}
             belongingTo="AlternateAddress"
@@ -945,7 +969,7 @@ export default class Relative extends ValidationElement {
                   className="relative-employer"
                   {...this.props.Employer}
                   onError={this.props.onError}
-                  onUpdate={(value) => { this.updateField('Employer', value) }}
+                  onUpdate={(value) => { this.updateEmployer(value) }}
                   required={this.props.required}
                 />
               </NotApplicable>
@@ -973,7 +997,7 @@ export default class Relative extends ValidationElement {
                   className="relative-employer-address"
                   showPostOffice
                   onError={this.props.onError}
-                  onUpdate={(value) => { this.updateField('EmployerAddress', value) }}
+                  onUpdate={(value) => { this.updateEmployerAddress(value) }}
                   required={this.props.required}
                 />
               </NotApplicable>
@@ -1012,7 +1036,7 @@ export default class Relative extends ValidationElement {
                   {...this.props.EmployerRelationship}
                   disabled={!this.props.EmployerRelationshipNotApplicable.applicable}
                   onError={this.props.onError}
-                  onUpdate={(value) => { this.updateField('EmployerRelationship', value) }}
+                  onUpdate={(value) => { this.updateEmployerRelationship(value) }}
                   required={this.props.required}
                 />
               </Field>


### PR DESCRIPTION
## Description

- Fixes #1613 
- Fixes bug where for certain NotApplicable fields, even if you entered data after reloading it would display as "I don't know". The bug was because apparently NotApplicable components should have `applicable: true` set by default in order to indicate there is data.
- I also found and resolved the same bug on the Residence reference email and Relative employer name fields.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
