### PR TITLE
Add AlternateAddress to employment item address

### DIFF
--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -385,15 +385,6 @@ export default class EmploymentItem extends ValidationElement {
               required={this.props.required}
             />
           </Field>
-          {!hasDifferentPhysicalAddress && (
-            <ConnectedAlternateAddress
-              address={this.props.AlternateAddress}
-              addressBook="Employment"
-              belongingTo="AlternateAddress"
-              country={this.props.Address.country}
-              onUpdate={this.update}
-            />
-          )}
         </Show>
 
         <Show when={this.showEmployed()}>
@@ -432,11 +423,25 @@ export default class EmploymentItem extends ValidationElement {
               address={this.props.PhysicalAlternateAddress}
               addressBook="Employment"
               belongingTo="PhysicalAlternateAddress"
-              country={this.props.PhysicalAddress.Address.country}
+              country={(
+                this.props.PhysicalAddress
+                && this.props.PhysicalAddress.Address
+                && this.props.PhysicalAddress.Address.country
+              )}
               onUpdate={this.update}
             />
           )}
         </Show>
+
+        {this.showEmployed() && !hasDifferentPhysicalAddress && (
+          <ConnectedAlternateAddress
+            address={this.props.AlternateAddress}
+            addressBook="Employment"
+            belongingTo="AlternateAddress"
+            country={this.props.Address.country}
+            onUpdate={this.update}
+          />
+        )}
 
         <Show when={this.showSupervisor()}>
           <Supervisor

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -253,6 +253,11 @@ export default class EmploymentItem extends ValidationElement {
   render() {
     const { recordYears } = this.props
     const prefix = `history.employment.${this.localizeByActivity()}`.trim()
+
+    const hasDifferentPhysicalAddress = this.props.PhysicalAddress
+      && this.props.PhysicalAddress.HasDifferentAddress
+      && this.props.PhysicalAddress.HasDifferentAddress.value === 'Yes'
+
     return (
       <div>
         <EmploymentActivity
@@ -380,6 +385,15 @@ export default class EmploymentItem extends ValidationElement {
               required={this.props.required}
             />
           </Field>
+          {!hasDifferentPhysicalAddress && (
+            <ConnectedAlternateAddress
+              address={this.props.AlternateAddress}
+              addressBook="Employment"
+              belongingTo="AlternateAddress"
+              country={this.props.Address.country}
+              onUpdate={this.update}
+            />
+          )}
         </Show>
 
         <Show when={this.showEmployed()}>
@@ -413,6 +427,15 @@ export default class EmploymentItem extends ValidationElement {
             required={this.props.required}
             scrollIntoView={this.props.scrollIntoView}
           />
+          {hasDifferentPhysicalAddress && (
+            <ConnectedAlternateAddress
+              address={this.props.PhysicalAlternateAddress}
+              addressBook="Employment"
+              belongingTo="PhysicalAlternateAddress"
+              country={this.props.PhysicalAddress.Address.country}
+              onUpdate={this.update}
+            />
+          )}
         </Show>
 
         <Show when={this.showSupervisor()}>

--- a/src/schema/section/history-employment.js
+++ b/src/schema/section/history-employment.js
@@ -1,7 +1,9 @@
+/* eslint import/prefer-default-export: 0  */
+
 import * as form from '../form'
 
 export const historyEmployment = (data = {}) => {
-  const items = ((data.List || {}).items || []).map(x => {
+  const items = ((data.List || {}).items || []).map((x) => {
     const xitem = x.Item || {}
     const reprimand = xitem.Reprimand || {}
     return {
@@ -13,30 +15,31 @@ export const historyEmployment = (data = {}) => {
         Title: form.text(xitem.Title),
         DutyStation: form.text(xitem.DutyStation),
         Address: form.location(xitem.Address),
+        AlternateAddress: form.physicaladdress(xitem.AlternateAddress),
         Additional: form.collection(
-          ((xitem.Additional || {}).items || []).map(y => {
+          ((xitem.Additional || {}).items || []).map((y) => {
             const yitem = y.Item || {}
             return {
               Item: {
                 Has: form.branch(yitem.Has),
                 Position: form.text(yitem.Position),
                 Supervisor: form.text(yitem.Supervisor),
-                DatesEmployed: form.daterange(yitem.DatesEmployed)
-              }
+                DatesEmployed: form.daterange(yitem.DatesEmployed),
+              },
             }
           })
         ),
         Telephone: form.telephone(xitem.Telephone),
         ReasonLeft: form.reasonleft(xitem.ReasonLeft),
         Reprimand: form.collection(
-          ((reprimand || {}).items || []).map(y => {
+          ((reprimand || {}).items || []).map((y) => {
             const yitem = y.Item || {}
             return {
               Item: {
                 Has: form.branch(yitem.Has),
                 Text: form.textarea(yitem.Text),
-                Date: form.datecontrol(yitem.Date)
-              }
+                Date: form.datecontrol(yitem.Date),
+              },
             }
           })
         ),
@@ -46,12 +49,14 @@ export const historyEmployment = (data = {}) => {
         ReferencePhone: form.telephone(xitem.ReferencePhone),
         ReferenceAddress: form.location(xitem.ReferenceAddress),
         ReferenceAlternateAddress: form.physicaladdress(xitem.ReferenceAlternateAddress),
-        PhysicalAddress: form.physicaladdress(xitem.PhysicalAddress)
-      }
+        PhysicalAddress: form.physicaladdress(xitem.PhysicalAddress),
+        PhysicalAlternateAddress: form.physicaladdress(xitem.PhysicalAlternateAddress),
+      },
     }
   })
+
   return {
     EmploymentRecord: form.branch(data.EmploymentRecord),
-    List: form.collection(items, (data.List || {}).branch)
+    List: form.collection(items, (data.List || {}).branch),
   }
 }

--- a/src/schema/section/history-employment.test.js
+++ b/src/schema/section/history-employment.test.js
@@ -1,7 +1,6 @@
 import { unschema } from '../schema'
 import { historyEmployment } from './history-employment'
 import alternateAddress from '../form/alternateaddress'
-import { physicaladdress } from '../form/physicaladdress'
 
 describe('Schema for financial taxes', () => {
   it('can wrap in schema', () => {
@@ -16,22 +15,36 @@ describe('Schema for financial taxes', () => {
               PhysicalAddress: {
                 Address: {
                   country: null,
-                  type: "location",
+                  type: 'location',
                 },
                 HasDifferentAddress: {},
-                Telephone: {}
+                Telephone: {},
+              },
+              PhysicalAlternateAddress: {
+                Address: {
+                  country: null,
+                },
+                HasDifferentAddress: {},
+                Telephone: {},
               },
               Dates: {
                 from: {},
                 to: {},
-                present: null
+                present: null,
               },
               Employment: {},
               Status: {},
               Title: {},
               DutyStation: {},
               Address: {
-                country: null
+                country: null,
+              },
+              AlternateAddress: {
+                Address: {
+                  country: null,
+                },
+                HasDifferentAddress: {},
+                Telephone: {},
               },
               Additional: {
                 branch: null,
@@ -44,11 +57,11 @@ describe('Schema for financial taxes', () => {
                       DatesEmployed: {
                         from: {},
                         to: {},
-                        present: null
-                      }
-                    }
-                  }
-                ]
+                        present: null,
+                      },
+                    },
+                  },
+                ],
               },
               Telephone: {},
               ReferenceAlternateAddress: alternateAddress(),
@@ -62,12 +75,12 @@ describe('Schema for financial taxes', () => {
                         Has: {},
                         Reason: {},
                         Text: {},
-                        Date: {}
-                      }
-                    }
-                  ]
+                        Date: {},
+                      },
+                    },
+                  ],
                 },
-                ReasonDescription: {}
+                ReasonDescription: {},
               },
               Reprimand: {
                 branch: null,
@@ -76,10 +89,10 @@ describe('Schema for financial taxes', () => {
                     Item: {
                       Has: {},
                       Text: {},
-                      Date: {}
-                    }
-                  }
-                ]
+                      Date: {},
+                    },
+                  },
+                ],
               },
               Supervisor: {
                 SupervisorName: {},
@@ -87,20 +100,20 @@ describe('Schema for financial taxes', () => {
                 Email: {},
                 EmailNotApplicable: {},
                 Address: {
-                  country: null
+                  country: null,
                 },
-                Telephone: {}
+                Telephone: {},
               },
               SupervisorAlternateAddress: alternateAddress(),
               ReferenceName: {},
               ReferencePhone: {},
               ReferenceAddress: {
-                country: null
-              }
-            }
-          }
-        ]
-      }
+                country: null,
+              },
+            },
+          },
+        ],
+      },
     }
 
     expect(unschema(historyEmployment(data))).toEqual(data)


### PR DESCRIPTION
## Description

- Fixes #1050 
- Adds the alternate address flow to Employment items based on the requirements described in the test cases below.
  - The alternate address flow displays follow-up fields if a given address is marked as `APO/FPO/DPO` or `Outside the U.S.`
  - If the address is marked `APO/FPO/DPO`, a secondary address block is displayed under the label `Provide physical location data with street address, base, post, embassy, unit, and country location or home port/fleet headquarter.`
  - If the address is marked `Outside the U.S.`, the follow up yes/no question is displayed: `Do you or did you have an APO/FPO address while at this location?`
    - If the answer is `Yes`, a secondary address block is displayed under the label `Provide APO/FPO address.`
    - If the answer is `No`, no secondary address block is displayed.
- TODO:
  - [x] Verify label copy
  - [ ] B/E / XML updates to persist new address keys? - need a new task for this
  - [x] UX question

## Test Cases
- [ ] **User is employed by the military**
  - The question `Is/was your physical work address different than your employer's address?` should NOT appear on the form
  - If the employer address (duty station) is `APO/FPO/DPO` or `Outside the U.S.`, the alternate address flow should appear underneath the employer address fields
- [ ] **User is not employed by the military and physical work address is not different**
  - The question `Is/was your physical work address different than your employer's address?` should appear on the form (mark "No")
  - If the employer address is `APO/FPO/DPO` or `Outside the U.S.`, the alternate address flow should appear underneath the physical work address question
- [ ] **User is not employed by the military and physical work address is different**
  - The question `Is/was your physical work address different than your employer's address?` should appear on the form (mark "Yes")
  - If the employer address is `APO/FPO/DPO` or `Outside the U.S.`, the alternate address flow should NOT appear underneath the physical work address question
  - If the physical work address is `APO/FPO/DPO` or `Outside the U.S.`, the alternate address flow should appear underneath the physical work address fields

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
