### PR TITLE
Sets CORS Access-Control-Max-Age header

### DIFF
--- a/api/http/cors.go
+++ b/api/http/cors.go
@@ -3,10 +3,13 @@ package http
 import (
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/18F/e-QIP-prototype/api"
 )
+
+const defaultMaxAge = 600
 
 // CORSHandler is the handler for CORS.
 type CORSHandler struct {
@@ -35,6 +38,12 @@ func (service CORSHandler) Middleware(next http.Handler) http.Handler {
 			w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
 			w.Header().Set("Access-Control-Allow-Headers",
 				"Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+
+			maxAge := defaultMaxAge
+			if service.Env.Has(api.CORSMaxAge) {
+				maxAge = service.Env.Int(api.CORSMaxAge)
+			}
+			w.Header().Set("Access-Control-Max-Age", strconv.Itoa(maxAge))
 		} else {
 			service.Log.Info(api.CORSDenied, api.LogFields{"origin": origin})
 			RespondWithStructuredError(w, api.CORSDenied, http.StatusBadRequest)

--- a/api/http/cors.go
+++ b/api/http/cors.go
@@ -9,6 +9,11 @@ import (
 	"github.com/18F/e-QIP-prototype/api"
 )
 
+// Default to a preflight cache of 10 minutes, chosen to match the value
+// that Chrome caps its max age to (ostensibly to minimize risk of poisoned
+// cache). As the intent of a preflight is to protect old, non-CORS-aware
+// servers, and the CORS Origin is just our own frontend, and we are using TLS,
+// it's not an applicable risk here.
 const defaultMaxAge = 600
 
 // CORSHandler is the handler for CORS.

--- a/api/settings.go
+++ b/api/settings.go
@@ -164,6 +164,12 @@ const (
 	// Default: *empty*
 	CORSAllowed = "CORS_ALLOWED"
 
+	// CORSMaxAge The number of seconds browsers should cache preflight requests.
+	//
+	// Target: Back-end (api)
+	// Default: `600`
+	CORSMaxAge = "CORS_MAX_AGE"
+
 	// FlushStorage Flag to enable flushing of persisted information for an account during the logon process.
 	//
 	// Target: Back-end (api)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -33,6 +33,7 @@ When running the application using the provided [docker-compose.yml](docker-comp
 | [`TEST_DATABASE_NAME`](#database_name)                       |                 |                        | X                     |
 | [`DATABASE_HOST`](#database_host)                       |                 |                        | X                     |
 | [`CORS_ALLOWED`](#cors_allowed)                        | X               |                        | X                     |
+| [`CORS_MAX_AGE`](#cors_max_age)                    |                 |                        | X                     |
 | [`FLUSH_STORAGE`](#flush_storage)                       |                 |                        | X                     |
 | [`USPS_API_API_KEY`](#usps_api_api_key)                    |                 |                        | X                     |
 | [`JWT_SECRET`](#jwt_secret)                          | X               |                        | X                     |
@@ -224,6 +225,23 @@ Whitelist of address(es) for cross-origin resource sharing (CORS). CORS restrict
 
 **Target** - Back-end (api)<br>
 **Default** - *empty*<br>
+
+## `CORS_MAX_AGE`
+
+Sets the `Access-Control-Max-Age` header in the response to a cross-origin
+resources sharing (CORS) preflight request (i.e., `HTTP OPTIONS`).
+
+The value indicates the number of seconds the preflight results should be
+cached by the browser. Chrome caps maximum age to 10 minutes. FireFox caps
+it to 24 hours. Safari caps it to 5 minutes.
+
+Preflight caching is done against the host/URL/headers. Setting this to zero
+will disable the browser preflight cache and result in every CORS call being
+preceeded by a preflight HTTP OPTIONS request.
+
+**Target** - Back-end (api)<br>
+**Default** - `600`<br>
+
 
 ## `FLUSH_STORAGE`
 


### PR DESCRIPTION
Closes EN-3143

Sets CORS Access-Control-Max-Age header via the CORS_MAX_AGE environment variable. Defaults to 10 minutes, which was influenced by the Chrome team's decision to cap max age in their browser to
that duration.
