### PR TITLE
Add SSLMODE env to configure postgres sslmode

### DIFF
--- a/api/cmd/cmd.go
+++ b/api/cmd/cmd.go
@@ -25,6 +25,7 @@ func Command(log api.LogService, action func(api.DatabaseService, *api.Account))
 		Password: settings.String(api.DatabasePassword),
 		Address:  settings.String(api.DatabaseHost),
 		DBName:   settings.String(api.TestDatabaseName),
+		SSLMode:  settings.String(api.DatabaseSSLMode),
 	}
 	database := postgresql.NewPostgresService(dbConf, log)
 

--- a/api/cmd/cmd.go
+++ b/api/cmd/cmd.go
@@ -24,7 +24,7 @@ func Command(log api.LogService, action func(api.DatabaseService, *api.Account))
 		User:     settings.String(api.DatabaseUser),
 		Password: settings.String(api.DatabasePassword),
 		Address:  settings.String(api.DatabaseHost),
-		DBName:   settings.String(api.TestDatabaseName),
+		DBName:   settings.String(api.DatabaseName),
 		SSLMode:  settings.String(api.DatabaseSSLMode),
 	}
 	database := postgresql.NewPostgresService(dbConf, log)

--- a/api/cmd/dbmigrate/main.go
+++ b/api/cmd/dbmigrate/main.go
@@ -38,6 +38,7 @@ func runMigrations(dbName string, migrationsPath string) error {
 		Password: settings.String(api.DatabasePassword),
 		Address:  settings.String(api.DatabaseHost),
 		DBName:   dbName,
+		SSLMode:  settings.String(api.DatabaseSSLMode),
 	}
 
 	connStr := postgresql.PostgresConnectURI(dbConf)

--- a/api/cmd/dbreset/main.go
+++ b/api/cmd/dbreset/main.go
@@ -40,6 +40,7 @@ func resetDB(dbName string, force bool) error {
 		Password: settings.String(api.DatabasePassword),
 		Address:  settings.String(api.DatabaseHost),
 		DBName:   "template1", // template1 exists on all default postgres instances.
+		SSLMode:  settings.String(api.DatabaseSSLMode),
 	}
 
 	connStr := postgresql.PostgresConnectURI(dbConf)
@@ -52,7 +53,7 @@ func resetDB(dbName string, force bool) error {
 
 	check, checkErr := db.Exec("SELECT 1 AS result FROM pg_database WHERE datname=$1", dbName)
 	if checkErr != nil {
-		return errors.Wrap(checkErr, fmt.Sprintf("ERROR Checking for existence of %s", dbName))
+		return errors.Wrap(checkErr, fmt.Sprintf("ERROR Checking for existence of %s", connStr))
 	}
 
 	checkCount, _ := check.RowsAffected()

--- a/api/cmd/sftype/main.go
+++ b/api/cmd/sftype/main.go
@@ -28,6 +28,7 @@ func configureDB() api.DatabaseService {
 		Password: os.Getenv(api.DatabasePassword),
 		Address:  os.Getenv(api.DatabaseHost),
 		DBName:   os.Getenv(api.DatabaseName),
+		SSLMode:  os.Getenv(api.DatabaseSSLMode),
 	}
 
 	db := postgresql.NewPostgresService(dbConf, logger)

--- a/api/integration/setup.go
+++ b/api/integration/setup.go
@@ -38,6 +38,7 @@ func cleanTestServices() serviceSet {
 		Password: env.String(api.DatabasePassword),
 		Address:  env.String(api.DatabaseHost),
 		DBName:   env.String(api.TestDatabaseName),
+		SSLMode:  env.String(api.DatabaseSSLMode),
 	}
 
 	db := postgresql.NewPostgresService(dbConf, log)

--- a/api/postgresql/db_test.go
+++ b/api/postgresql/db_test.go
@@ -42,6 +42,7 @@ func TestCollections(t *testing.T) {
 		Password: settings.String(api.DatabasePassword),
 		Address:  settings.String(api.DatabaseHost),
 		DBName:   settings.String(api.TestDatabaseName),
+		SSLMode:  settings.String(api.DatabaseSSLMode),
 	}
 
 	service := NewPostgresService(dbConf, logger)
@@ -290,6 +291,7 @@ func TestPayloadPersistence(t *testing.T) {
 		Password: settings.String(api.DatabasePassword),
 		Address:  settings.String(api.DatabaseHost),
 		DBName:   settings.String(api.TestDatabaseName),
+		SSLMode:  settings.String(api.DatabaseSSLMode),
 	}
 
 	service := NewPostgresService(dbConf, logger)

--- a/api/settings.go
+++ b/api/settings.go
@@ -137,6 +137,12 @@ const (
 	// Default: `postgres`
 	DatabaseName = "DATABASE_NAME"
 
+	// DatabaseSSLMode The PostgreSQL sslmode to use to connect to the db
+	//
+	// Target: Back-end (api)
+	// Default: `require`
+	DatabaseSSLMode = "DATABASE_SSLMODE"
+
 	// TestDatabaseName PostgreSQL database instance name for tests
 	//
 	// Target: Back-end (api)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -30,8 +30,9 @@ When running the application using the provided [docker-compose.yml](docker-comp
 | [`DATABASE_USER`](#database_user)                       |                 |                        | X                     |
 | [`DATABASE_PASSWORD`](#database_password)                   |                 |                        | X                     |
 | [`DATABASE_NAME`](#database_name)                       |                 |                        | X                     |
-| [`TEST_DATABASE_NAME`](#database_name)                       |                 |                        | X                     |
+| [`TEST_DATABASE_NAME`](#test_database_name)                       |                 |                        | X                     |
 | [`DATABASE_HOST`](#database_host)                       |                 |                        | X                     |
+| [`DATABASE_SSLMODE`](#database_sslmode)                       |                 |                        | X                     |
 | [`CORS_ALLOWED`](#cors_allowed)                        | X               |                        | X                     |
 | [`FLUSH_STORAGE`](#flush_storage)                       |                 |                        | X                     |
 | [`USPS_API_API_KEY`](#usps_api_api_key)                    |                 |                        | X                     |
@@ -208,6 +209,13 @@ PostgreSQL database host name and port.
 
 **Target** - Back-end (api)<br>
 **Default** - `localhost:5432`<br>
+
+## `DATABASE_SSLMODE`
+
+The PostgreSQL sslmode to use to connect to the db.
+
+**Target** - Back-end (api)<br>
+**Default** - `require`<br>
 
 ## `CORS_ALLOWED`
 


### PR DESCRIPTION
## Description

These changes got made as part of merging preview.4.1 in order to enable testing in CI there. This allows you to configure sslmode with an env var. 

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser
