### PR TITLE
[EN-3433] Clear out state field when place issued branch changes

### DIFF
--- a/src/components/Section/Citizenship/Status/Status.jsx
+++ b/src/components/Section/Citizenship/Status/Status.jsx
@@ -18,6 +18,8 @@ import {
   Location,
 } from 'components/Form'
 
+import { countryString } from 'validators/location'
+
 import {
   CITIZENSHIP,
   CITIZENSHIP_STATUS,
@@ -81,6 +83,24 @@ export class Status extends Subsection {
     this.update({
       [field]: values,
     })
+  }
+
+  updatePlaceIssued = (values) => {
+    const { PlaceIssued } = this.props
+    // If country changes, it means the branch changed.
+    // This means we need to clear out the state value
+    if (countryString(PlaceIssued.country) !== values.country.value) {
+      this.update({
+        PlaceIssued: {
+          ...values,
+          state: undefined,
+        },
+      })
+    } else {
+      this.update({
+        PlaceIssued: values,
+      })
+    }
   }
 
   derivedAlienRegistrationNumberRequired = () => (
@@ -310,7 +330,7 @@ export class Status extends Subsection {
                   {...this.props.PlaceIssued}
                   layout={Location.BIRTHPLACE_WITHOUT_COUNTY}
                   className="place-issued"
-                  onUpdate={(value) => { this.updateField('PlaceIssued', value) }}
+                  onUpdate={this.updatePlaceIssued}
                   onError={this.handleError}
                   required={resultIsDocumentRequired && this.props.required}
                 />


### PR DESCRIPTION
## Description
This PR fixes unwanted data persisting in Citizenship Status -> Place Issued field.

In `Provide the place of issuance`, when an applicant toggles the branch between `In the U.S.` and `Outside the U.S.`, the state field should clear. Currently, the city field does not clear because it is a common field between both branches. 

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)