### PR TITLE
Breakout syscalls based on build target so app can be built cross platform

### DIFF
--- a/api/cmd/syscalls_bsd.go
+++ b/api/cmd/syscalls_bsd.go
@@ -1,0 +1,8 @@
+// +build darwin freebsd netbsd openbsd solaris dragonfly
+
+package cmd
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TIOCGETA
+const ioctlWriteTermios = syscall.TIOCSETA

--- a/api/cmd/syscalls_linux.go
+++ b/api/cmd/syscalls_linux.go
@@ -1,0 +1,8 @@
+// +build linux
+
+package cmd
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TCGETS
+const ioctlWriteTermios = syscall.TCSETS

--- a/api/cmd/webclient.go
+++ b/api/cmd/webclient.go
@@ -188,7 +188,7 @@ func echo(visible bool) {
 	var termios = &syscall.Termios{}
 	var fd = os.Stdout.Fd()
 
-	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, syscall.TCGETS, uintptr(unsafe.Pointer(termios))); err != 0 {
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(termios))); err != 0 {
 		return
 	}
 
@@ -198,7 +198,7 @@ func echo(visible bool) {
 		termios.Lflag &^= syscall.ECHO
 	}
 
-	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, syscall.TCSETS, uintptr(unsafe.Pointer(termios))); err != 0 {
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, ioctlWriteTermios, uintptr(unsafe.Pointer(termios))); err != 0 {
 		return
 	}
 }


### PR DESCRIPTION
## Description

It has been impossible to build any of our commands that used web client.go on MacOS because the echo implementation there used two syscalls that only exist on linux. This change uses files that are conditionally built for specific platforms to set the correct syscall as a variable. 

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)