### PR TITLE
Update cloud.gov deployment for cflinuxfs3 and more

### DIFF
--- a/bin/deploy-cloudgov
+++ b/bin/deploy-cloudgov
@@ -43,7 +43,7 @@ mkdir -p $HOME/.cf
 
 # This wonderful image pulls the `cf` tool along with the
 # `autopilot` plugin
-docker pull governmentpaas/cf-cli
+docker pull governmentpaas/cf-cli:latest
 
 # For some reason, aliases aren't working here
 # so we're using this function instead

--- a/bin/deploy-cloudgov
+++ b/bin/deploy-cloudgov
@@ -43,7 +43,7 @@ mkdir -p $HOME/.cf
 
 # This wonderful image pulls the `cf` tool along with the
 # `autopilot` plugin
-docker pull adelevie/cf-cli:latest
+docker pull governmentpaas/cf-cli
 
 # For some reason, aliases aren't working here
 # so we're using this function instead
@@ -52,10 +52,10 @@ cf_run() {
 					 --rm \
 					 -v $HOME/.cf:/root/.cf \
 					 -v $PWD:/app \
-					 adelevie/cf-cli \
+					 governmentpaas/cf-cli \
 					 cf "$@"
 }
 
 cf_run login -a $API -u $CF_USERNAME -p $CF_PASSWORD -o $ORG -s $SPACE
-cf_run zero-downtime-push $API_NAME -f $API_MANIFEST
-cf_run zero-downtime-push $FRONTEND_NAME -f $FRONTEND_MANIFEST
+cf_run push $API_NAME -f $API_MANIFEST -s cflinuxfs3
+cf_run push $FRONTEND_NAME -f $FRONTEND_MANIFEST -s cflinuxfs3


### PR DESCRIPTION
cloud.gov is requiring cflinuxfs3 vice cflinuxfs2, so update that.

Also, adelevie/cf-cli hasn't been updated in 2 years on DockerHub. The UK GDS docker image for cf-cli offers same capabilities and is regularly updated. Use that until Cloud Foundry has an official image.

Finally, remove zero down time push, since that seems to be the source of recurring issues on cloud.gov (https://github.com/18F/e-QIP-prototype/blob/develop/docs/advanced.md#failed-deployments) where a deploy will fail, and we're not sensitive to downtime for these test instances. 