### PR TITLE
[EN-3446] Fix AlternateAddress empty country bug

### DIFF
--- a/src/components/Form/Location/AlternateAddress.jsx
+++ b/src/components/Form/Location/AlternateAddress.jsx
@@ -1,16 +1,16 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux';
+import { connect } from 'react-redux'
 import { i18n } from '../../../config'
 import Field from '../Field'
 import Branch from '../Branch'
 import Show from '../Show'
 import Location from './Location'
-import LocationValidator, { countryString } from '../../../validators/location'
+import { countryString } from '../../../validators/location'
 import ValidationElement from '../ValidationElement'
-import alternateAddress from '../../../schema/form/alternateaddress'
+import { defaultAlternateAddress } from '../../../schema/form/alternateaddress'
 
-const alternateAddressDefaultState = alternateAddress
+const alternateAddressDefaultState = defaultAlternateAddress
 const propTypes = {
   address: PropTypes.object,
   addressBook: PropTypes.string,
@@ -19,14 +19,14 @@ const propTypes = {
   country: PropTypes.string,
   // XXX Rename this prop
   forceAPO: PropTypes.bool,
-  onUpdate: PropTypes.func
+  onUpdate: PropTypes.func,
 }
 
 class AlternateAddress extends ValidationElement {
   constructor(props) {
     super(props)
 
-    this.handleUpdate = this.handleUpdate.bind(this);
+    this.handleUpdate = this.handleUpdate.bind(this)
     this.setAlternateAddress = this.setAlternateAddress.bind(this)
   }
 
@@ -40,15 +40,15 @@ class AlternateAddress extends ValidationElement {
     return {
       [this.props.belongingTo]: {
         ...this.props.address,
-        ...toUpdate
-      }
+        ...toUpdate,
+      },
     }
   }
 
   handleUpdate(values) {
     this.props.onUpdate(
       this.prepareUpdate({
-        Address: values
+        Address: values,
       })
     )
   }
@@ -56,7 +56,7 @@ class AlternateAddress extends ValidationElement {
   setAlternateAddress(values) {
     this.props.onUpdate(
       this.prepareUpdate({
-        HasDifferentAddress: values
+        HasDifferentAddress: values,
       })
     )
   }
@@ -75,15 +75,15 @@ class AlternateAddress extends ValidationElement {
 
   isForeignAddress() {
     if (this.props.forceAPO) {
-      return true;
+      return true
     }
 
-    const country = countryString(this.props.country);
+    const country = countryString(this.props.country)
 
-    return country !== null &&
-      country !== undefined &&
-      country !== 'POSTOFFICE' &&
-      country !== 'United States'
+    return country !== null
+      && country !== undefined
+      && country !== 'POSTOFFICE'
+      && country !== 'United States'
   }
 
   isSameCountry(comparedCountry) {
@@ -96,12 +96,12 @@ class AlternateAddress extends ValidationElement {
       ...this.props.address.Address,
       label: i18n.t('address.label'),
       onUpdate: this.handleUpdate,
-      required: true
+      required: true,
     }
 
     return {
       ...defaults,
-      ...extraProps
+      ...extraProps,
     }
   }
 
@@ -136,7 +136,8 @@ class AlternateAddress extends ValidationElement {
         <Show when={this.isMilitaryAddress()}>
           <Field
             title={i18n.t('address.physicalLocationRequired')}
-            titleSize="h4">
+            titleSize="h4"
+          >
             <Location
               {...this.prepareProps({
                 addressBook: this.props.addressBook,

--- a/src/components/Form/Location/AlternateAddress.test.jsx
+++ b/src/components/Form/Location/AlternateAddress.test.jsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { shallow, mount } from 'enzyme'
-import { fn } from 'jest'
 import { AlternateAddress } from './AlternateAddress'
 import { address } from '../../../config/locales/en/address'
-import alternateAddress from '../../../schema/form/alternateaddress'
 
 describe('<AlternateAddress />', () => {
   describe('when a user indicates a foreign address', () => {
@@ -12,13 +10,13 @@ describe('<AlternateAddress />', () => {
         country: '',
         address: {
           HasDifferentAddress: '',
-          Address: { country: '' }
-        }
+          Address: { country: '' },
+        },
       }
-     
+
       const component = mount(<AlternateAddress {...props} />)
       const branch = component.find('Branch')
-  
+
       expect(branch.length).toEqual(1)
       expect(branch.prop('label')).toEqual(address.militaryAddress.meEmployment)
     })
@@ -27,8 +25,8 @@ describe('<AlternateAddress />', () => {
       const props = {
         country: '',
         address: {
-          HasDifferentAddress: { value: 'Yes' }
-        }
+          HasDifferentAddress: { value: 'Yes' },
+        },
       }
 
       const component = mount(<AlternateAddress {...props} />)
@@ -41,8 +39,8 @@ describe('<AlternateAddress />', () => {
       const props = {
         country: '',
         address: {
-          HasDifferentAddress: { value: 'No' }
-        }
+          HasDifferentAddress: { value: 'No' },
+        },
       }
       const component = mount(<AlternateAddress {...props} />)
 
@@ -55,12 +53,12 @@ describe('<AlternateAddress />', () => {
           onUpdate: () => ({}),
           country: 'Spain',
           address: {
-            HasDifferentAddress: { value: 'Yes' }
-          }
+            HasDifferentAddress: { value: 'Yes' },
+          },
         }
         const component = mount(<AlternateAddress {...props} />)
         expect(component.find('Branch').length).toBe(1)
-        component.setProps({ country: { value: 'POSTOFFICE' } });
+        component.setProps({ country: { value: 'POSTOFFICE' } })
 
         expect(component.find('Branch').length).toBe(0)
 
@@ -77,8 +75,8 @@ describe('<AlternateAddress />', () => {
       country: 'POSTOFFICE',
       address: {
         HasDifferentAddress: { value: '' },
-        Address: {}
-      }
+        Address: {},
+      },
     }
     const component = mount(<AlternateAddress {...props} />)
     const field = component.find('Field')
@@ -95,24 +93,24 @@ describe('<AlternateAddress />', () => {
       address: {
         Address: {
           country: 'POSTOFFICE',
-          state: 'AA'
+          state: 'AA',
         },
-        HasDifferentAddress: { value: 'Yes' }
-      }
+        HasDifferentAddress: { value: 'Yes' },
+      },
     }
 
     const component = mount(<AlternateAddress {...props} />)
-    expect(component.prop('address').Address.country).toEqual(props.address.Address.country);
+    expect(component.prop('address').Address.country).toEqual(props.address.Address.country)
 
     component.setProps({ country: 'United States' })
 
     expect(props.onUpdate.mock.calls.length).toBe(1)
     expect(props.onUpdate.mock.calls[0][0]).toEqual({
       Address: {
-        Address: { country: null },
+        Address: {},
         HasDifferentAddress: { value: '' },
-        Telephone: {}
-      }
+        Telephone: {},
+      },
     })
   })
 
@@ -123,8 +121,8 @@ describe('<AlternateAddress />', () => {
       country: 'United States',
       address: {
         Address: {},
-        HasDifferentAddress: { value: '' }
-      }
+        HasDifferentAddress: { value: '' },
+      },
     }
 
     const component = shallow(<AlternateAddress {...props} />)
@@ -137,16 +135,16 @@ describe('<AlternateAddress />', () => {
         country: 'POSTOFFICE',
         address: {
           Address: {
-            country: ''
+            country: '',
           },
-          HasDifferentAddress: { value: '' }
-        }
+          HasDifferentAddress: { value: '' },
+        },
       }
       const component = mount(<AlternateAddress {...props} />)
-      const location = component.find('Location');
+      const location = component.find('Location')
 
-      expect(location.prop('disableToggle')).toEqual(undefined);
-      expect(location.prop('geocode')).toEqual(true);
+      expect(location.prop('disableToggle')).toEqual(undefined)
+      expect(location.prop('geocode')).toEqual(true)
       expect(location.prop('country')).toEqual(props.address.Address.country)
     })
   })

--- a/src/schema/form/alternateaddress.js
+++ b/src/schema/form/alternateaddress.js
@@ -1,13 +1,22 @@
 import { general } from './general'
 
-const defaultState = (options = {}) => ({
+const defaultAlternateAddress = (options = {}) => ({
   Address: {},
   HasDifferentAddress: { value: '' },
   Telephone: {},
   ...options,
 })
 
-const alternateaddress = (data = {}) => general('alternateaddress', defaultState(data))
+const emptyState = (options = {}) => ({
+  Address: {
+    country: null,
+  },
+  HasDifferentAddress: { value: '' },
+  Telephone: {},
+  ...options,
+})
 
-export { alternateaddress }
-export default defaultState
+const alternateaddress = (data = {}) => general('alternateaddress', emptyState(data))
+
+export { alternateaddress, defaultAlternateAddress }
+export default emptyState

--- a/src/schema/form/alternateaddress.js
+++ b/src/schema/form/alternateaddress.js
@@ -1,16 +1,13 @@
 import { general } from './general'
 
 const defaultState = (options = {}) => ({
-  Address: {
-    country: null
-  },
+  Address: {},
   HasDifferentAddress: { value: '' },
   Telephone: {},
-  ...options
+  ...options,
 })
 
-const alternateaddress = (data = {}) =>
-  general('alternateaddress', defaultState(data))
+const alternateaddress = (data = {}) => general('alternateaddress', defaultState(data))
 
 export { alternateaddress }
 export default defaultState


### PR DESCRIPTION
## Description
The `AlternateAddress` component renders the `Location` component and passes an address object as a prop. `Location` and `Address` are designed to default to have a country value of `United States`. However, a pristine `AlternateAddress` passed in a "default" address object with `country` set explicitly to `null`, which over-wrote the default value of `United States`. This led to the UI showing that the address was "In the U.S.", however the actual value of the country attribute was `null`, causing a "phantom error".

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser
- [ ] To verify the fix, try filling out an AlternateAddress fieldset *without* changing the country toggle from "In the U.S.", and ensure the country value is set to "United States". Alternate Address fieldsets appear on the following sections:
  - History / Residence
  - History / Employment
  - Relationships / Marital
  - Relationships / Relative
  - Foreign / Contacts

More details about this can be found in [docs/review.md](docs/review.md)
