### PR TITLE
Before running cf, change working dir

### DIFF
--- a/bin/deploy-cloudgov
+++ b/bin/deploy-cloudgov
@@ -52,6 +52,7 @@ cf_run() {
 					 --rm \
 					 -v $HOME/.cf:/root/.cf \
 					 -v $PWD:/app \
+					 -w /app \
 					 governmentpaas/cf-cli \
 					 cf "$@"
 }


### PR DESCRIPTION
Perhaps adelevie/cf-cli started off in `/app`? Explicitly set working directory so `cf` can find our manifest files under the new cf-cli docker image.
