### PR TITLE
[EN-3711] Fix babel config for IE11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,6 @@
 {
     "presets": [
-        [
-            "@babel/preset-env",
-            {
-                "targets": {
-                    "node": "current",
-                },
-            },
-        ],
+        "@babel/preset-env",
         "@babel/preset-react",
     ],
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     ],
     "globals": {
       "EAPP_VERSION": "MAJOR.MINOR.PATCH-IDENTIFIER"
-    }
+    },
+    "setupFiles": ["<rootDir>/node_modules/regenerator-runtime/runtime"]
   },
   "scripts": {
     "test": "NODE_ENV=test jest",


### PR DESCRIPTION
## Description

This change to the babel config file (https://github.com/18F/e-QIP-prototype/pull/1642/commits/9c6b407e07721593407ca7ae1d61706f10a62301) overwrote supporting the target browser IE11, resulting in JS breaking when loading the app in IE11. This PR fixes that, and also addresses the original reason for the change which was in order to be able to run Jest, the regenerator runtime needs to be included.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] **Verify change works in IE browser**

More details about this can be found in [docs/review.md](docs/review.md)
