### PR TITLE
[EN-3704] Remove APO type for address of employment (Self Employment)

### DIFF
--- a/src/components/Form/Field/Field.jsx
+++ b/src/components/Form/Field/Field.jsx
@@ -447,7 +447,7 @@ export default class Field extends ValidationElement {
 
   render() {
     const {
-      optional, className, shrink, dataFieldName
+      optional, className, shrink, dataTestId,
     } = this.props
 
     const required = !optional
@@ -476,7 +476,7 @@ export default class Field extends ValidationElement {
         data-uuid={this.state.uuid}
         ref={(el) => { this.field = el }}
         aria-label={this.props.title}
-        {...(dataFieldName && { dataFieldName })}
+        {...(dataTestId && { 'data-test-id': dataTestId })}
       >
         <a
           id={this.state.uuid}
@@ -541,7 +541,7 @@ Field.defaultProps = {
   validate: true,
   shrink: false,
   scrollIntoView: true,
-  dataFieldName: '',
+  dataTestId: '',
   filterErrors: errors => errors,
   onUpdate: () => {},
 }

--- a/src/components/Form/Field/Field.jsx
+++ b/src/components/Form/Field/Field.jsx
@@ -446,7 +446,9 @@ export default class Field extends ValidationElement {
   }
 
   render() {
-    const { optional, className, shrink } = this.props
+    const {
+      optional, className, shrink, dataFieldName
+    } = this.props
 
     const required = !optional
 
@@ -474,7 +476,7 @@ export default class Field extends ValidationElement {
         data-uuid={this.state.uuid}
         ref={(el) => { this.field = el }}
         aria-label={this.props.title}
-        data-fieldName={this.props.dataFieldName}
+        {...(dataFieldName && { dataFieldName })}
       >
         <a
           id={this.state.uuid}

--- a/src/components/Form/Field/Field.jsx
+++ b/src/components/Form/Field/Field.jsx
@@ -474,6 +474,7 @@ export default class Field extends ValidationElement {
         data-uuid={this.state.uuid}
         ref={(el) => { this.field = el }}
         aria-label={this.props.title}
+        data-fieldName={this.props.dataFieldName}
       >
         <a
           id={this.state.uuid}
@@ -538,6 +539,7 @@ Field.defaultProps = {
   validate: true,
   shrink: false,
   scrollIntoView: true,
+  dataFieldName: '',
   filterErrors: errors => errors,
   onUpdate: () => {},
 }

--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -629,6 +629,7 @@ export default class Location extends ValidationElement {
             isEnabled={this.props.isEnabled}
             isPoBoxAllowed={this.props.isPoBoxAllowed}
             disableToggle={this.props.layout === Location.US_ADDRESS}
+            showPostOffice={this.props.showPostOffice}
             onBlur={this.handleBlur}
             onUpdate={this.updateAddress}
             onError={this.handleError}
@@ -868,6 +869,7 @@ Location.defaultProps = {
   addressBooks: {},
   addressBook: '',
   isPoBoxAllowed: true,
+  showPostOffice: true,
   onUpdate: queue => {},
   dispatch: action => {},
   onError: (value, arr) => {

--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -869,7 +869,7 @@ Location.defaultProps = {
   addressBooks: {},
   addressBook: '',
   isPoBoxAllowed: true,
-  showPostOffice: true,
+  showPostOffice: false,
   onUpdate: queue => {},
   dispatch: action => {},
   onError: (value, arr) => {

--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -346,6 +346,22 @@ export default class Location extends ValidationElement {
     })
   }
 
+  componentDidUpdate(prevProps) {
+    const { showPostOffice } = this.props
+    if (
+      prevProps.showPostOffice !== showPostOffice
+      && showPostOffice === false
+      && prevProps.country.value === 'POSTOFFICE'
+    ) {
+      this.update({
+        country: 'United States',
+        city: '',
+        state: '',
+        zipcode: '',
+      })
+    }
+  }
+
   componentWillUnmount() {
     this.geocodeCancel = true
   }

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -369,7 +369,7 @@ export default class EmploymentItem extends ValidationElement {
             help={`${prefix}.address.help`}
             adjustFor="address"
             shrink
-            dataFieldName="employmentAddress"
+            dataTestId="employmentAddress"
             scrollIntoView={this.props.scrollIntoView}
           >
             <Location

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -252,6 +252,7 @@ export default class EmploymentItem extends ValidationElement {
 
   render() {
     const { recordYears } = this.props
+    const activity = (this.props.EmploymentActivity || {}).value
     const prefix = `history.employment.${this.localizeByActivity()}`.trim()
 
     const hasDifferentPhysicalAddress = this.props.PhysicalAddress
@@ -368,6 +369,7 @@ export default class EmploymentItem extends ValidationElement {
             help={`${prefix}.address.help`}
             adjustFor="address"
             shrink
+            dataFieldName="employmentAddress"
             scrollIntoView={this.props.scrollIntoView}
           >
             <Location
@@ -377,7 +379,7 @@ export default class EmploymentItem extends ValidationElement {
               geocode
               addressBooks={this.props.addressBooks}
               addressBook="Employment"
-              showPostOffice
+              showPostOffice={activity !== 'SelfEmployment'}
               dispatch={this.props.dispatch}
               onUpdate={this.updateAddress}
               onError={this.props.onError}

--- a/src/components/Section/History/Employment/EmploymentItem.test.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.test.jsx
@@ -222,4 +222,14 @@ describe('The employment component', () => {
     expect(EmploymentItem.defaultProps.onUpdate()).toEqual(undefined)
     expect(EmploymentItem.defaultProps.onError(null, [])).toEqual([])
   })
+
+  it('hides APO for address of employment if self employed', () => {
+    const props = {
+      EmploymentActivity: { value: 'SelfEmployment' },
+    }
+
+    const component = createComponent(props)
+    const employmentAddressParent = component.find("[data-fieldName='employmentAddress']")
+    expect(employmentAddressParent.find('.apofpo').length).toBe(0)
+  })
 })

--- a/src/components/Section/History/Employment/EmploymentItem.test.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.test.jsx
@@ -229,7 +229,7 @@ describe('The employment component', () => {
     }
 
     const component = createComponent(props)
-    const employmentAddressParent = component.find("[data-fieldName='employmentAddress']")
+    const employmentAddressParent = component.find("[data-test-id='employmentAddress']")
     expect(employmentAddressParent.find('.apofpo').length).toBe(0)
   })
 })


### PR DESCRIPTION
## Description
This PR removes the radio button to select APO address for `Provide the address of employment` when an applicant selects `Self-employment`. This change reflects what is valid in the validation matrix and e-QIP.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)