### PR TITLE
[EN-3782] Update broken complete test scenarios

### DIFF
--- a/api/testdata/complete-scenarios/test7.json
+++ b/api/testdata/complete-scenarios/test7.json
@@ -7796,7 +7796,7 @@
                     "props": {
                       "first": "UNEMPL REFEXXXXXXXXOO",
                       "firstInitialOnly": false,
-                      "middle": "UNEMPL REFE MIDDLEXXXXXXXXOO",
+                      "middle": "",
                       "middleInitialOnly": false,
                       "noMiddleName": false,
                       "last": "UNEMPL REFE LASTXXXXXXXXOO",
@@ -8148,7 +8148,7 @@
                     "props": {
                       "first": "SELF EMPL VERI FIRSTXXXXXXXXOO",
                       "firstInitialOnly": false,
-                      "middle": "SELF EMPL VERY MIDDLEXXXXXXXXOO",
+                      "middle": "",
                       "middleInitialOnly": false,
                       "noMiddleName": false,
                       "last": "SELF EMPL VERI LASTXXXXXXXXOO",

--- a/api/testdata/complete-scenarios/test7.json
+++ b/api/testdata/complete-scenarios/test7.json
@@ -9416,7 +9416,7 @@
         "HomeEmail": {
           "type": "email",
           "props": {
-            "value": ""
+            "value": "test@test.com"
           }
         },
         "WorkEmail": {

--- a/api/testdata/complete-scenarios/test7.xml
+++ b/api/testdata/complete-scenarios/test7.xml
@@ -163,6 +163,9 @@ are now called - nay!</Reason>
               </Weight>
             </IdentifyingInformation>
             <ContactInformation Version="1" Type="Pooled">
+              <HomeEmail>
+                <Email>test@test.com</Email>
+              </HomeEmail>
               <WorkTelephone>
                 <Telephone>
                   <Number>5555555555</Number>

--- a/api/testdata/complete-scenarios/test8.json
+++ b/api/testdata/complete-scenarios/test8.json
@@ -1542,7 +1542,7 @@
         "WorkEmail": {
           "type": "email",
           "props": {
-            "value": ""
+            "value": "test@test.com"
           }
         },
         "PhoneNumbers": {

--- a/api/testdata/complete-scenarios/test8.xml
+++ b/api/testdata/complete-scenarios/test8.xml
@@ -69,6 +69,9 @@
               </Weight>
             </IdentifyingInformation>
             <ContactInformation Version="1" Type="Pooled">
+              <WorkEmail>
+                <Email>test@test.com</Email>
+              </WorkEmail>
               <MobileTelephone>
                 <Telephone>
                   <Number>8312131212</Number>

--- a/src/constants/enums/nameSuffixOptions.js
+++ b/src/constants/enums/nameSuffixOptions.js
@@ -2,6 +2,7 @@ export default [
   '',
   'Jr',
   'Sr',
+  'I',
   'II',
   'III',
   'IV',

--- a/src/models/__tests__/employment.test.js
+++ b/src/models/__tests__/employment.test.js
@@ -1077,7 +1077,6 @@ describe('The employment model', () => {
         }
 
         const expectedErrors = ['Additional.branchCollection']
-        console.log('helo, there!')
         expect(validateModel(testData, employment))
           .toEqual(expect.arrayContaining(expectedErrors))
       })

--- a/src/models/__tests__/employment.test.js
+++ b/src/models/__tests__/employment.test.js
@@ -1068,6 +1068,7 @@ describe('The employment model', () => {
     describe('if additional activities are included', () => {
       it('additional activities must be valid', () => {
         const testData = {
+          EmploymentActivity: { value: 'StateGovernment' },
           Additional: {
             items: [
               { test: 'invalid' },
@@ -1076,7 +1077,7 @@ describe('The employment model', () => {
         }
 
         const expectedErrors = ['Additional.branchCollection']
-
+        console.log('helo, there!')
         expect(validateModel(testData, employment))
           .toEqual(expect.arrayContaining(expectedErrors))
       })

--- a/src/models/education.js
+++ b/src/models/education.js
@@ -60,7 +60,10 @@ const education = {
 
     return {
       presence: true,
-      model: { validator: name },
+      model: {
+        validator: name,
+        hideMiddleName: true,
+      },
     }
   },
   ReferenceNameNotApplicable: {},

--- a/src/models/employment.js
+++ b/src/models/employment.js
@@ -243,10 +243,15 @@ const employment = {
   },
 
   // Applies to other employment
-  Additional: {
-    branchCollection: {
-      validator: additional,
-    },
+  Additional: (value, attributes = {}) => {
+    if (matchEmploymentActivity(attributes, otherEmploymentOptions)) {
+      return {
+        branchCollection: {
+          validator: additional,
+        },
+      }
+    }
+    return {}
   },
 }
 

--- a/src/models/validators/branchCollection.js
+++ b/src/models/validators/branchCollection.js
@@ -7,7 +7,7 @@ const branchCollectionValidator = (value, options = {}) => {
   const { items } = value
   const { validator } = options
 
-  if (!items || !items.length) return 'Collection is empty'
+  if (!items || !items.length) return null
   if (!validator) return 'Invalid validator'
 
   const hasNo = items.some(i => i.Item && i.Item.Has && i.Item.Has.value === 'No')

--- a/src/models/validators/branchCollection.js
+++ b/src/models/validators/branchCollection.js
@@ -7,7 +7,7 @@ const branchCollectionValidator = (value, options = {}) => {
   const { items } = value
   const { validator } = options
 
-  if (!items || !items.length) return null
+  if (!items || !items.length) return 'Collection is empty'
   if (!validator) return 'Invalid validator'
 
   const hasNo = items.some(i => i.Item && i.Item.Has && i.Item.Has.value === 'No')

--- a/src/validators/employment.test.js
+++ b/src/validators/employment.test.js
@@ -701,7 +701,7 @@ describe('Employment component validation', () => {
       {
         data: {
           EmploymentActivity: {
-            value: 'SelfEmployed',
+            value: 'StateGovernment',
           },
           Additional: null,
         },
@@ -710,7 +710,7 @@ describe('Employment component validation', () => {
       {
         data: {
           EmploymentActivity: {
-            value: 'SelfEmployed',
+            value: 'StateGovernment',
           },
           Additional: { items: [{ Item: { Has: { value: 'Yes' } } }] },
         },
@@ -719,7 +719,7 @@ describe('Employment component validation', () => {
       {
         data: {
           EmploymentActivity: {
-            value: 'SelfEmployed',
+            value: 'StateGovernment',
           },
           Additional: {
             items: [
@@ -758,7 +758,7 @@ describe('Employment component validation', () => {
       {
         data: {
           EmploymentActivity: {
-            value: 'SelfEmployed',
+            value: 'StateGovernment',
           },
           Additional: {
             items: [
@@ -794,7 +794,7 @@ describe('Employment component validation', () => {
       {
         data: {
           EmploymentActivity: {
-            value: 'SelfEmployed',
+            value: 'StateGovernment',
           },
           Additional: {
             items: [


### PR DESCRIPTION
## Description
This PR fixes the following test cases. They all validate now.

1. test03
2. test04
3. test05
4. test07 
5. test09

- Fixed employment model/validator for `Additional` employments. It was executing for all employment activity types, but it should only be executed for "Other" employment activity types.
- Removed middle name from education verifier to align with validation matrix, eApp backend/XML, and e-QIP
- Updated test case 7 by removing employment reference middle name and adding a required contact email.
- Added missing name suffix option.
- Fix relevant tests.


## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
