### PR TITLE
[EN-3786] Ask followup questions about Offense if WasCited is no

### DIFF
--- a/src/components/Section/Legal/Police/Offense.jsx
+++ b/src/components/Section/Legal/Police/Offense.jsx
@@ -334,19 +334,23 @@ export default class Offense extends ValidationElement {
                 required={this.props.required}
               />
             </Field>
-
-            <Branch
-              name="was_charged"
-              label={i18n.t('legal.police.heading.charged')}
-              labelSize="h4"
-              className="offense-charged"
-              {...this.props.WasCharged}
-              onUpdate={this.updateWasCharged}
-              required={this.props.required}
-              onError={this.props.onError}
-              scrollIntoView={this.props.scrollIntoView}
-            />
           </div>
+        </Show>
+
+        <Show when={(this.props.WasCited || {}).value === 'No'
+          || (this.props.WasCited || {}).value === 'Yes'}
+        >
+          <Branch
+            name="was_charged"
+            label={i18n.t('legal.police.heading.charged')}
+            labelSize="h4"
+            className="offense-charged"
+            {...this.props.WasCharged}
+            onUpdate={this.updateWasCharged}
+            required={this.props.required}
+            onError={this.props.onError}
+            scrollIntoView={this.props.scrollIntoView}
+          />
         </Show>
 
         <Show when={(this.props.WasCharged || {}).value === 'No'}>


### PR DESCRIPTION
## Description

- Offense followup questions (22.5-22.9) are already asked if the answer to 22.3.6 is "Yes".
- This PR modifies the logic so that the followup questions are also asked if the answer to 22.3.6 is "No".

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
