### PR TITLE
[EN-3692] Audit use of DoNotKnow in XML

### DIFF
--- a/api/templates/address.xml
+++ b/api/templates/address.xml
@@ -1,6 +1,7 @@
-{{$dnk := notApplicable .DoNotKnow}}
-<Address DoNotKnow="{{$dnk}}">
-  {{if $dnk | ne "True"}}
-    {{location .Location}}
-  {{end}}
+{{if notApplicable .DoNotKnow | eq "True"}}
+<Address DoNotKnow="True"></Address>
+{{else}}
+<Address>
+  {{location .Location}}
 </Address>
+{{end}}

--- a/api/templates/date-month-day-year-optional.xml
+++ b/api/templates/date-month-day-year-optional.xml
@@ -1,6 +1,7 @@
-{{$dnk := notApplicable .DoNotKnow}}
-<Date Type="{{dateEstimated .Date}}" DoNotKnow="{{$dnk}}">
-  {{if $dnk | ne "True"}}
-    <Month>{{padDigits .Date.props.month}}</Month><Day>{{padDigits .Date.props.day}}</Day><Year>{{.Date.props.year}}</Year>
-  {{end}}
+{{if notApplicable .DoNotKnow | eq "True"}}
+<Date Type="{{dateEstimated .Date}}" DoNotKnow="True"></Date>
+{{else}}
+<Date Type="{{dateEstimated .Date}}">
+  <Month>{{padDigits .Date.props.month}}</Month><Day>{{padDigits .Date.props.day}}</Day><Year>{{.Date.props.year}}</Year>
 </Date>
+{{end}}

--- a/api/templates/date-month-year-optional.xml
+++ b/api/templates/date-month-year-optional.xml
@@ -1,6 +1,7 @@
-{{$dnk := notApplicable .DoNotKnow}}
-<Date Type="{{dateEstimated .Date}}" DoNotKnow="{{$dnk}}">
-  {{if $dnk | ne "True"}}
-    <Month>{{padDigits .Date.props.month}}</Month><Year>{{.Date.props.year}}</Year>
-  {{end}}
+{{if notApplicable .DoNotKnow | eq "True"}}
+<Date Type="{{dateEstimated .Date}}" DoNotKnow="True"></Date>
+{{else}}
+<Date Type="{{dateEstimated .Date}}">
+  <Month>{{padDigits .Date.props.month}}</Month><Year>{{.Date.props.year}}</Year>
 </Date>
+{{end}}

--- a/api/templates/email-optional.xml
+++ b/api/templates/email-optional.xml
@@ -1,0 +1,6 @@
+{{$dnk := notApplicable .DoNotKnow}}
+{{if $dnk | ne "True"}}
+<Email>{{email .Email}}</Email>
+{{else}}
+<Email DoNotKnow="{{$dnk}}"></Email>
+{{end}}

--- a/api/templates/email-optional.xml
+++ b/api/templates/email-optional.xml
@@ -1,6 +1,5 @@
-{{$dnk := notApplicable .DoNotKnow}}
-{{if $dnk | ne "True"}}
-<Email>{{email .Email}}</Email>
+{{if notApplicable .DoNotKnow | eq "True"}}
+<Email DoNotKnow="True"></Email>
 {{else}}
-<Email DoNotKnow="{{$dnk}}"></Email>
+<Email>{{email .Email}}</Email>
 {{end}}

--- a/api/templates/foreign-contacts.xml
+++ b/api/templates/foreign-contacts.xml
@@ -15,11 +15,13 @@
       {{end}}
       <Birth>
         {{dateOptional $Item.Birthdate $Item.BirthdateNotApplicable}}
-        <Place DoNotKnow="{{notApplicable $Item.BirthplaceNotApplicable}}">
-          {{if notApplicable $Item.BirthplaceNotApplicable | ne "True"}}
-            {{location $Item.Birthplace}}
-          {{end}}
+        {{if notApplicable $Item.BirthplaceNotApplicable | eq "True"}}
+        <Place DoNotKnow="True"></Place>
+        {{else}}
+        <Place>
+          {{location $Item.Birthplace}}
         </Place>
+        {{end}}
       </Birth>
       <Citizenships>
         {{range $index, $country := $Item.Citizenship.props.value}}
@@ -81,7 +83,11 @@
       <Employer>
         {{address $Item.EmployerAddress $Item.EmployerAddressNotApplicable}}
         <Comment></Comment>
-        <Name DoNotKnow="{{notApplicable $Item.EmployerNotApplicable}}">{{text $Item.Employer}}</Name>
+        {{if notApplicable $Item.EmployerNotApplicable | eq "True"}}
+        <Name DoNotKnow="True"></Name>
+        {{else}}
+        <Name>{{text $Item.Employer}}</Name>
+        {{end}}
       </Employer>
       <EntryComment></EntryComment>
       <ForeignAffiliation>
@@ -91,9 +97,11 @@
         <Relationship>{{text $Item.Affiliations}}</Relationship>
       </ForeignAffiliation>
       <FullName>
-        <LegalName DoNotKnow="{{notApplicable $Item.NameNotApplicable}}">
-          {{name $Item.Name}}
-        </LegalName>
+        {{if notApplicable $Item.NameNotApplicable | eq "True"}}
+        <LegalName DoNotKnow="True"></LegalName>
+        {{else}}
+        <LegalName>{{name $Item.Name}}</LegalName>
+        {{end}}
       </FullName>
       {{if branchcollectionHas $Item.Aliases | eq "Yes"}}
       <OtherNamesUsed>

--- a/api/templates/history-education.xml
+++ b/api/templates/history-education.xml
@@ -56,13 +56,7 @@
         <LegalName DoNotKnow="False">{{nameLastFirst $Item.ReferenceName}}</LegalName>
         {{end}}
 
-        {{$doNotKnowEmail := notApplicable $Item.ReferenceEmailNotApplicable}}
-        {{if $doNotKnowEmail | eq "True"}}
-        <Email DoNotKnow="True"></Email>
-        {{else}}
-        <Email DoNotKnow="False">{{email $Item.ReferenceEmail}}</Email>
-        {{end}}
-
+        {{emailOptional $Item.ReferenceEmail $Item.ReferenceEmailNotApplicable}}
         <Telephone>{{telephone $Item.ReferencePhone}}</Telephone>
         <Address>{{location $Item.ReferenceAddress}}</Address>
         <Comment></Comment>

--- a/api/templates/history-education.xml
+++ b/api/templates/history-education.xml
@@ -49,11 +49,10 @@
       {{if $Item.ReferenceName}}
       {{if $Item.ReferenceName.props.first}}
       <Verifier>
-        {{$doNotKnowPerson := notApplicable $Item.ReferenceNameNotApplicable}}
-        {{if $doNotKnowPerson | eq "True"}}
+        {{if notApplicable $Item.ReferenceNameNotApplicable | eq "True"}}
         <LegalName DoNotKnow="True"></LegalName>
         {{else}}
-        <LegalName DoNotKnow="False">{{nameLastFirst $Item.ReferenceName}}</LegalName>
+        <LegalName>{{nameLastFirst $Item.ReferenceName}}</LegalName>
         {{end}}
 
         {{emailOptional $Item.ReferenceEmail $Item.ReferenceEmailNotApplicable}}

--- a/api/templates/history-employment.xml
+++ b/api/templates/history-employment.xml
@@ -170,7 +170,7 @@
         <Address>{{location $supervisor.Address}}</Address>
         {{apoFpo $supervisor.Address $Item.SupervisorAlternateAddress}}
         <Comment></Comment>
-        <Email DoNotKnow="{{notApplicable $supervisor.EmailNotApplicable}}">{{email $supervisor.Email}}</Email>
+        {{emailOptional $supervisor.Email $supervisor.EmailNotApplicable}}
         <Telephone>{{telephone $supervisor.Telephone}}</Telephone>
       </Supervisor>
       {{end}}

--- a/api/templates/history-residence.xml
+++ b/api/templates/history-residence.xml
@@ -15,11 +15,7 @@
         <Address>{{location $Item.ReferenceAddress}}</Address>
         {{apoFpo $Item.ReferenceAddress $Item.ReferenceAlternateAddress}}
         <Comment>{{textarea $Item.ReferenceComments}}</Comment>
-        {{- if notApplicable $Item.ReferenceEmailNotApplicable | eq "True"}}
-        <Email DoNotKnow="True"></Email>
-        {{else}}
-        <Email>{{email $Item.ReferenceEmail}}</Email>
-        {{end}}
+        {{emailOptional $Item.ReferenceEmail $Item.ReferenceEmailNotApplicable}}
         <LastContact>
           <Date Type="{{dateEstimated $Item.ReferenceLastContact}}">{{monthYear $Item.ReferenceLastContact}}</Date>
         </LastContact>

--- a/api/templates/history-residence.xml
+++ b/api/templates/history-residence.xml
@@ -39,9 +39,21 @@
           {{end}}
           />
         <Telephone>
-          <Day DoNotKnow="{{telephoneNoNumber $Item.ReferencePhoneDay}}">{{telephoneNoTimeOfDay $Item.ReferencePhoneDay}}</Day>
-          <Evening DoNotKnow="{{telephoneNoNumber $Item.ReferencePhoneEvening}}">{{telephoneNoTimeOfDay $Item.ReferencePhoneEvening}}</Evening>
-          <Mobile DoNotKnow="{{telephoneNoNumber $Item.ReferencePhoneMobile}}">{{telephoneNoTimeOfDay $Item.ReferencePhoneMobile}}</Mobile>
+          {{if telephoneNoNumber $Item.ReferencePhoneDay | eq "True"}}
+          <Day DoNotKnow="True"></Day>
+          {{else}}
+          <Day>{{telephoneNoTimeOfDay $Item.ReferencePhoneDay}}</Day>
+          {{end}}
+          {{if telephoneNoNumber $Item.ReferencePhoneEvening | eq "True"}}
+          <Evening DoNotKnow="True"></Evening>
+          {{else}}
+          <Evening>{{telephoneNoTimeOfDay $Item.ReferencePhoneEvening}}</Evening>
+          {{end}}
+          {{if telephoneNoNumber $Item.ReferencePhoneMobile | eq "True"}}
+          <Mobile DoNotKnow="True"></Mobile>
+          {{else}}
+          <Mobile>{{telephoneNoTimeOfDay $Item.ReferencePhoneMobile}}</Mobile>
+          {{end}}
         </Telephone>
       </Verifier>
       {{end}}

--- a/api/templates/personal-references.xml
+++ b/api/templates/personal-references.xml
@@ -33,12 +33,16 @@
         />
         <RelationshipTypeOtherExplanation>{{text $Item.RelationshipOther}}</RelationshipTypeOtherExplanation>
         <Telephone>
-          <Home DoNotKnow="{{telephoneNoNumber $Item.OtherTelephone}}">
-            {{telephone $Item.OtherTelephone}}
-          </Home>
-          <Mobile DoNotKnow="{{telephoneNoNumber $Item.MobileTelephone}}">
-            {{telephone $Item.MobileTelephone}}
-          </Mobile>
+          {{if telephoneNoNumber $Item.OtherTelephone | eq "True"}}
+          <Home DoNotKnow="True"></Home>
+          {{else}}
+          <Home>{{telephone $Item.OtherTelephone}}</Home>
+          {{end}}
+          {{if telephoneNoNumber $Item.MobileTelephone | eq "True"}}
+          <Mobile DoNotKnow="True"></Mobile>
+          {{else}}
+          <Mobile>{{telephone $Item.MobileTelephone}}</Mobile>
+          {{end}}
         </Telephone>
         {{if notApplicable $Item.RankNotApplicable | eq "True"}}
         <Title NotApplicable="True"></Title>

--- a/api/templates/personal-references.xml
+++ b/api/templates/personal-references.xml
@@ -9,7 +9,7 @@
         {{location $Item.Address}}
       </Address>
       {{monthYearDaterange $Item.Dates}}
-      <Email DoNotKnow="{{notApplicable $Item.EmailNotApplicable}}">{{text $Item.Email}}</Email>
+      {{emailOptional $Item.Email $Item.EmailNotApplicable}}
       <EntryComment></EntryComment>
       <LegalName>
         {{name $Item.Name}}

--- a/api/templates/relatives-and-associates.xml
+++ b/api/templates/relatives-and-associates.xml
@@ -125,9 +125,11 @@
         <Employer>
           {{address $Item.EmployerAddress $Item.EmployerAddressNotApplicable}}
           <Comment></Comment>
-          <Name DoNotKnow="{{notApplicable $Item.EmployerNotApplicable}}">
-            {{text $Item.Employer}}
-          </Name>
+          {{if notApplicable $Item.EmployerNotApplicable | eq "True"}}
+          <Name DoNotKnow="True"></Name>
+          {{else}}
+          <Name>{{text $Item.Employer}}</Name>
+          {{end}}
         </Employer>
         <FirstContactDate Type="{{dateEstimated $Item.FirstContact}}">
           {{monthYear $Item.FirstContact}}

--- a/api/testdata/complete-scenarios/test1.xml
+++ b/api/testdata/complete-scenarios/test1.xml
@@ -114,12 +114,7 @@
                   </LegalName>
                   <RelationshipType Friend="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>8319999123</Number>
                       <Time>Both</Time>
@@ -153,12 +148,7 @@
                   </LegalName>
                   <RelationshipType Neighbor="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>8319991230</Number>
                       <Time>Both</Time>
@@ -192,12 +182,7 @@
                   </LegalName>
                   <RelationshipType Neighbor="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>8311311231</Number>
                       <Time>Both</Time>

--- a/api/testdata/complete-scenarios/test10.xml
+++ b/api/testdata/complete-scenarios/test10.xml
@@ -114,12 +114,7 @@
                   </LegalName>
                   <RelationshipType WorkAssociate="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>1115556633</Number>
                       <Extension>4</Extension>
@@ -154,12 +149,7 @@
                   </LegalName>
                   <RelationshipType WorkAssociate="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>1115556789</Number>
                       <Time>Day</Time>
@@ -196,12 +186,7 @@
                   </LegalName>
                   <RelationshipType Neighbor="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>4325551234</Number>
                       <Time>Both</Time>

--- a/api/testdata/complete-scenarios/test2.xml
+++ b/api/testdata/complete-scenarios/test2.xml
@@ -108,12 +108,7 @@
                   </LegalName>
                   <RelationshipType Schoolmate="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>5027893456</Number>
                       <Time>Both</Time>
@@ -147,12 +142,7 @@
                   </LegalName>
                   <RelationshipType Neighbor="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>3334442233</Number>
                       <Time>Both</Time>
@@ -186,12 +176,7 @@
                   </LegalName>
                   <RelationshipType Neighbor="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>4442342567</Number>
                       <Time>Both</Time>
@@ -334,9 +319,7 @@
                       <Evening>
                         <Number>5677554321</Number>
                       </Evening>
-                      <Mobile DoNotKnow="True">
-
-</Mobile>
+                      <Mobile DoNotKnow="True"/>
                     </Telephone>
                   </Verifier>
                 </Residency>

--- a/api/testdata/complete-scenarios/test3.xml
+++ b/api/testdata/complete-scenarios/test3.xml
@@ -186,12 +186,7 @@
                   </LegalName>
                   <RelationshipType Neighbor="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>5036563231</Number>
                       <Time>Both</Time>
@@ -778,9 +773,7 @@
                     <ZipCode>02130</ZipCode>
                   </Address>
                   <Birth>
-                    <Date DoNotKnow="True">
-  
-</Date>
+                    <Date DoNotKnow="True"/>
                     <Place>
                       <City>New York</City>
                       <Country>France</Country>
@@ -903,16 +896,10 @@
                   </OtherNamesUsed>
                 </Contact>
                 <Contact ID="3">
-                  <Address DoNotKnow="True">
-  
-</Address>
+                  <Address DoNotKnow="True"/>
                   <Birth>
-                    <Date DoNotKnow="True">
-  
-</Date>
-                    <Place DoNotKnow="True">
-          
-        </Place>
+                    <Date DoNotKnow="True"/>
+                    <Place DoNotKnow="True"/>
                   </Birth>
                   <Citizenships>
                     <Citizenship ID="1">
@@ -939,9 +926,7 @@
                     </To>
                   </DateRange>
                   <Employer>
-                    <Address DoNotKnow="True">
-  
-</Address>
+                    <Address DoNotKnow="True"/>
                     <Name DoNotKnow="True"/>
                   </Employer>
                   <ForeignAffiliation>

--- a/api/testdata/complete-scenarios/test4.xml
+++ b/api/testdata/complete-scenarios/test4.xml
@@ -116,12 +116,7 @@
                       <Number>9999999991</Number>
                       <Time>Both</Time>
                     </Home>
-                    <Mobile DoNotKnow="True">
-            
-
-
-
-          </Mobile>
+                    <Mobile DoNotKnow="True"/>
                   </Telephone>
                   <Title>Brevet Colonel</Title>
                 </Reference>
@@ -151,12 +146,7 @@
                   </LegalName>
                   <RelationshipType WorkAssociate="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>2341222211</Number>
                       <Time>Both</Time>
@@ -190,12 +180,7 @@
                   </LegalName>
                   <RelationshipType WorkAssociate="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>8281881291</Number>
                       <Time>Both</Time>
@@ -329,15 +314,11 @@
                     <RelationshipOtherExplanation>Brother in law</RelationshipOtherExplanation>
                     <RelationshipTypes Neighbor="True" Other="True"/>
                     <Telephone>
-                      <Day DoNotKnow="True">
-
-</Day>
+                      <Day DoNotKnow="True"/>
                       <Evening>
                         <Number>9822843881</Number>
                       </Evening>
-                      <Mobile DoNotKnow="True">
-
-</Mobile>
+                      <Mobile DoNotKnow="True"/>
                     </Telephone>
                   </Verifier>
                 </Residency>

--- a/api/testdata/complete-scenarios/test5.xml
+++ b/api/testdata/complete-scenarios/test5.xml
@@ -166,12 +166,7 @@
                   </LegalName>
                   <RelationshipType Neighbor="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>8311231291</Number>
                       <Time>Both</Time>
@@ -205,12 +200,7 @@
                   </LegalName>
                   <RelationshipType Friend="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>1248889312</Number>
                       <Time>Both</Time>
@@ -244,12 +234,7 @@
                   </LegalName>
                   <RelationshipType Neighbor="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>1341214444</Number>
                       <Time>Both</Time>
@@ -343,9 +328,7 @@
                         <City>London</City>
                         <Country>United Kingdom</Country>
                       </Address>
-                      <Name>
-            Brown's meat market
-          </Name>
+                      <Name>Brown's meat market</Name>
                     </Employer>
                     <FirstContactDate>
                       <Month>01</Month>
@@ -2578,16 +2561,10 @@
               </ContactWithForeignNationalBoundByAffectionInfluenceObligation>
               <Contacts>
                 <Contact ID="1">
-                  <Address DoNotKnow="True">
-  
-</Address>
+                  <Address DoNotKnow="True"/>
                   <Birth>
-                    <Date DoNotKnow="True">
-  
-</Date>
-                    <Place DoNotKnow="True">
-          
-        </Place>
+                    <Date DoNotKnow="True"/>
+                    <Place DoNotKnow="True"/>
                   </Birth>
                   <Citizenships>
                     <Citizenship ID="1">

--- a/api/testdata/complete-scenarios/test6.xml
+++ b/api/testdata/complete-scenarios/test6.xml
@@ -108,12 +108,7 @@
                   </LegalName>
                   <RelationshipType Neighbor="True" Friend="True" Schoolmate="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>7245555553</Number>
                       <Time>Both</Time>
@@ -147,12 +142,7 @@
                   </LegalName>
                   <RelationshipType Neighbor="True" Friend="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>7245555554</Number>
                       <Time>Both</Time>
@@ -187,12 +177,7 @@
                   </LegalName>
                   <RelationshipType Friend="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>7245555555</Number>
                       <Time>Both</Time>

--- a/api/testdata/complete-scenarios/test6.xml
+++ b/api/testdata/complete-scenarios/test6.xml
@@ -979,14 +979,10 @@
                   <Agency>Unknown</Agency>
                   <ClearanceLevel>Unknown</ClearanceLevel>
                   <GrantedDate>
-                    <Date DoNotKnow="True">
-  
-</Date>
+                    <Date DoNotKnow="True"/>
                   </GrantedDate>
                   <InvestigationDate>
-                    <Date DoNotKnow="True">
-  
-</Date>
+                    <Date DoNotKnow="True"/>
                   </InvestigationDate>
                   <IssuingAgency>
       

--- a/api/testdata/complete-scenarios/test7.xml
+++ b/api/testdata/complete-scenarios/test7.xml
@@ -368,9 +368,7 @@ are now called - nay!</Reason>
                         <State>CA</State>
                         <ZipCode>93955</ZipCode>
                       </Address>
-                      <Name>
-            I WAS born in the year 1632, in the city of York, of a good family,  though not of that country, my father being a foreigner of Bremen,  who settled first at Hull. He got a good estate by merchandise,  and leaving off his trade, lived afterwards at York,
-          </Name>
+                      <Name>I WAS born in the year 1632, in the city of York, of a good family,  though not of that country, my father being a foreigner of Bremen,  who settled first at Hull. He got a good estate by merchandise,  and leaving off his trade, lived afterwards at York,</Name>
                     </Employer>
                     <FirstContactDate Type="Estimated">
                       <Month>01</Month>
@@ -601,9 +599,7 @@ in the case. What has occurred in this case!</ReasonForChange>
                         <State>GA</State>
                         <ZipCode>30533</ZipCode>
                       </Address>
-                      <Name>
-            FIL EMPLXXXXXXXXOO
-          </Name>
+                      <Name>FIL EMPLXXXXXXXXOO</Name>
                     </Employer>
                     <FirstContactDate>
                       <Month>01</Month>

--- a/api/testdata/complete-scenarios/test8.xml
+++ b/api/testdata/complete-scenarios/test8.xml
@@ -105,12 +105,7 @@
                   </LegalName>
                   <RelationshipType Friend="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>3332123331</Number>
                       <Time>Both</Time>
@@ -143,12 +138,7 @@
                   </LegalName>
                   <RelationshipType Friend="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>7773222133</Number>
                       <Time>Both</Time>
@@ -182,12 +172,7 @@
                   </LegalName>
                   <RelationshipType Schoolmate="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>3335123132</Number>
                       <Time>Both</Time>
@@ -318,15 +303,11 @@
                     </LegalName>
                     <RelationshipTypes Neighbor="True"/>
                     <Telephone>
-                      <Day DoNotKnow="True">
-
-</Day>
+                      <Day DoNotKnow="True"/>
                       <Evening>
                         <Number>5033323103</Number>
                       </Evening>
-                      <Mobile DoNotKnow="True">
-
-</Mobile>
+                      <Mobile DoNotKnow="True"/>
                     </Telephone>
                   </Verifier>
                 </Residency>

--- a/api/testdata/complete-scenarios/test9.xml
+++ b/api/testdata/complete-scenarios/test9.xml
@@ -114,12 +114,7 @@
                   </LegalName>
                   <RelationshipType Neighbor="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>3331119999</Number>
                       <Time>Both</Time>
@@ -153,12 +148,7 @@
                   </LegalName>
                   <RelationshipType Friend="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>1113331121</Number>
                       <Time>Both</Time>
@@ -192,12 +182,7 @@
                   </LegalName>
                   <RelationshipType Friend="True"/>
                   <Telephone>
-                    <Home DoNotKnow="True">
-            
-
-
-
-          </Home>
+                    <Home DoNotKnow="True"/>
                     <Mobile>
                       <Number>3338889999</Number>
                       <Time>Both</Time>
@@ -983,9 +968,7 @@
                     </Address>
                   </APOFPO>
                   <Birth>
-                    <Date DoNotKnow="True">
-  
-</Date>
+                    <Date DoNotKnow="True"/>
                     <Place>
                       <City>Belfast</City>
                       <Country>United Kingdom</Country>
@@ -1016,9 +999,7 @@
                     </To>
                   </DateRange>
                   <Employer>
-                    <Address DoNotKnow="True">
-  
-</Address>
+                    <Address DoNotKnow="True"/>
                     <Name DoNotKnow="True"/>
                   </Employer>
                   <ForeignAffiliation>

--- a/api/xml/xml.go
+++ b/api/xml/xml.go
@@ -69,6 +69,7 @@ func (service Service) DefaultTemplate(templateName string, data map[string]inte
 		"foreignAffiliation":     foreignAffiliation,
 		"frequencyType":          frequencyType,
 		"email":                  email,
+		"emailOptional":          emailOptional,
 		"employmentType":         employmentType,
 		"hairType":               hairType,
 		"hasRelativeType":        hasRelativeType,
@@ -317,6 +318,19 @@ func branchcollectionHas(data map[string]interface{}) string {
 
 func email(data map[string]interface{}) string {
 	return simpleValue(data)
+}
+
+func emailOptional(e, dnk map[string]interface{}) (template.HTML, error) {
+	view := make(map[string]interface{})
+	view["Email"] = e
+	view["DoNotKnow"] = dnk
+
+	fmap := template.FuncMap{
+		"notApplicable": notApplicable,
+		"email":         email,
+	}
+
+	return xmlTemplateWithFuncs("email-optional.xml", view, fmap)
 }
 
 func text(data map[string]interface{}) string {


### PR DESCRIPTION
Makes XML generation code more consistent, defensive when DoNotKnow is an option. Helps backend code be resilient to frontend situations where toggling a branch doesn't always clear state of closed off branch.