### PR TITLE
[EN-3760] Relatives - Fix address filling for court of naturalization

### DIFF
--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -692,7 +692,7 @@ export default class Relative extends ValidationElement {
                 geocode
                 className="relative-courtaddress"
                 onError={this.props.onError}
-                onUpdate={(value) => { this.updateField('Courtaddress', value) }}
+                onUpdate={(value) => { this.updateField('CourtAddress', value) }}
                 required={this.props.required}
               />
             </Field>


### PR DESCRIPTION
## Description
This PR fixes a typo error that preventing applicants from being able to fill out the court address for naturalization. The input field didn't have a proper mapping to the Redux store because of the typo.

The user's interaction with the form and filling out fields should be tested with e2e/integration tests.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)