### PR TITLE
[EN-3700] Change form versions for consistency with e-QIP

### DIFF
--- a/api/account.go
+++ b/api/account.go
@@ -21,11 +21,11 @@ var (
 var knownFormVersions = map[string][]string{
 
 	"SF86": []string{
-		"2016-11",
+		"2017-07",
 	},
 
 	"SF85": []string{
-		"2017-12_draft7",
+		"2017-12-draft7",
 	},
 }
 

--- a/api/account_test.go
+++ b/api/account_test.go
@@ -15,7 +15,7 @@ func TestBasicAuthentication(t *testing.T) {
 		Firstname:   "Admin",
 		Lastname:    "Last",
 		FormType:    "SF86",
-		FormVersion: "2016-11",
+		FormVersion: "2017-07",
 	}
 
 	membership := &BasicAuthMembership{
@@ -39,7 +39,7 @@ func TestValidFormType(t *testing.T) {
 		Username:    "glarbal@example.com",
 		Email:       "glarbal@example.com",
 		FormType:    "SF86",
-		FormVersion: "2016-11",
+		FormVersion: "2017-07",
 	}
 
 	type testCase struct {
@@ -49,12 +49,12 @@ func TestValidFormType(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{"SF86", "2016-11", true},
-		testCase{"SF 86", "2016-11", false},
+		testCase{"SF86", "2017-07", true},
+		testCase{"SF 86", "2017-07", false},
 		testCase{"SF86", "2036-11", false},
 
-		testCase{"SF85", "2017-12_draft7", true},
-		testCase{"SF85", "2016-11", false},
+		testCase{"SF85", "2017-12-draft7", true},
+		testCase{"SF85", "2017-07", false},
 	}
 
 	for _, tCase := range testCases {

--- a/api/cmd/sftype/test_sftype.sh
+++ b/api/cmd/sftype/test_sftype.sh
@@ -15,9 +15,9 @@ original_type=$(./sftype test07 || echo "FAIL: Print Form Type")
 # try an invalid form type
 ./sftype test07 SF85 2001-03 && echo "FAIL: invalid form type worked"
 
-./sftype test07 SF85 2017-12_draft7 || echo "FAIL: exit non-zero"
+./sftype test07 SF85 2017-12-draft7 || echo "FAIL: exit non-zero"
 
-expected_type="test07 SF85 2017-12_draft7"
+expected_type="test07 SF85 2017-12-draft7"
 
 set_type=$(./sftype test07)
 

--- a/api/integration/application_status_test.go
+++ b/api/integration/application_status_test.go
@@ -75,8 +75,8 @@ func TestStatus(t *testing.T) {
 		t.Fail()
 	}
 
-	if status.Hash != "eee1ded7714837bd7270a8b34455a1d2d7de792dfa1511b3fe4da6471d005b12" {
-		t.Log("The hash has changed.")
+	if status.Hash != "50b174251cce87a6d52f7049feb609034834b0084a8019974e2615a5e7ea9406" {
+		t.Log("The hash has changed to " + status.Hash)
 		t.Fail()
 	}
 

--- a/api/integration/form_version_test.go
+++ b/api/integration/form_version_test.go
@@ -73,7 +73,7 @@ func TestFormVersionSave(t *testing.T) {
 {
 	"type": "metadata",
 	"form_type": "SF86",
-	"form_version": "2016-11"
+	"form_version": "2017-07"
 }`
 
 	resp := saveJSON(services, []byte(metadataBody), account.ID)

--- a/api/integration/helpers.go
+++ b/api/integration/helpers.go
@@ -100,7 +100,7 @@ func createLockedTestAccount(t *testing.T, db api.DatabaseService) api.Account {
 		Username:    email,
 		Email:       email,
 		FormType:    "SF86",
-		FormVersion: "2016-11",
+		FormVersion: "2017-07",
 		Locked:      true,
 		ExternalID:  uuid.New().String(),
 	}
@@ -122,7 +122,7 @@ func createTestAccount(t *testing.T, db api.DatabaseService) api.Account {
 		Username:    email,
 		Email:       email,
 		FormType:    "SF86",
-		FormVersion: "2016-11",
+		FormVersion: "2017-07",
 		ExternalID:  uuid.New().String(),
 	}
 

--- a/api/integration/save_sections_test.go
+++ b/api/integration/save_sections_test.go
@@ -241,7 +241,7 @@ func TestDeleteApplication(t *testing.T) {
 	}
 	body := readBody(t, formResp)
 
-	if string(body) != `{"Metadata":{"form_type":"SF86","form_version":"2016-11","type":"metadata"}}` {
+	if string(body) != `{"Metadata":{"form_type":"SF86","form_version":"2017-07","type":"metadata"}}` {
 		t.Fatal("Should have just got back the metadata")
 	}
 

--- a/api/migrations/20190530164751_change_form_versions.sql
+++ b/api/migrations/20190530164751_change_form_versions.sql
@@ -1,0 +1,14 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+-- +goose StatementBegin
+UPDATE accounts SET form_version = '2017-07' where form_version = '2016-11';
+UPDATE accounts SET form_version = '2017-12-draft7' where form_version = '2017-12_draft7';
+-- +goose StatementEnd
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+-- +goose StatementBegin
+UPDATE accounts SET form_version = '2016-11' where form_version = '2017-07';
+UPDATE accounts SET form_version = '2017-12_draft7' where form_version = '2017-12-draft7';
+-- +goose StatementEnd

--- a/api/postgresql/db_test.go
+++ b/api/postgresql/db_test.go
@@ -32,7 +32,7 @@ func TestAccountPersistence(t *testing.T) {
 		Username:    "buzz1@example.com",
 		Email:       "buzz1@example.com",
 		FormType:    "SF86",
-		FormVersion: "2016-11",
+		FormVersion: "2017-07",
 		ExternalID:  uuid.New().String(),
 	}
 

--- a/api/simplestore/applications_test.go
+++ b/api/simplestore/applications_test.go
@@ -95,7 +95,7 @@ func createAccount(t *testing.T, store SimpleStore) api.Account {
 
 	externalID := uuid.New().String()
 
-	createErr := store.db.Get(&result, createQuery, email, "SF86", "2016-11", externalID)
+	createErr := store.db.Get(&result, createQuery, email, "SF86", "2017-07", externalID)
 	if createErr != nil {
 		t.Log("Failed to create Account", createErr)
 		t.Fatal()

--- a/api/testdata/complete-scenarios/test10.json
+++ b/api/testdata/complete-scenarios/test10.json
@@ -6358,7 +6358,7 @@
   },
   "Metadata": {
     "form_type": "SF86",
-    "form_version": "2016-11",
+    "form_version": "2017-07",
     "type": "metadata"
   },
   "Military": {

--- a/api/testdata/complete-scenarios/test3.json
+++ b/api/testdata/complete-scenarios/test3.json
@@ -6612,7 +6612,7 @@
   },
   "Metadata": {
     "form_type": "SF86",
-    "form_version": "2016-11",
+    "form_version": "2017-07",
     "type": "metadata"
   },
   "Military": {

--- a/api/testdata/complete-scenarios/test6.json
+++ b/api/testdata/complete-scenarios/test6.json
@@ -2938,7 +2938,7 @@
   },
   "Metadata": {
     "form_type": "SF86",
-    "form_version": "2016-11",
+    "form_version": "2017-07",
     "type": "metadata"
   },
   "Military": {


### PR DESCRIPTION
July 2017 is the most recent version of SF-86, which is identical to the November 2016 version. It is the revision e-QIP references.

The XML XSDs we are using for the 86 and 85 use '2017-07' and '2017-12-draft7' respectively, so this change creates consistency there as well.

Testing shows that the stored, serialized JSON meta-data for form version is automatically updated once account.form_version is updated.