### PR TITLE
[EN-3795] Fixes the filling out of mandatory counseling and navigation to voluntary subsection

### DIFF
--- a/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.jsx
+++ b/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.jsx
@@ -11,7 +11,7 @@ import {
   Textarea,
   DateRange,
   Telephone,
-  Show
+  Show,
 } from '../../../Form'
 import DrugType from './DrugType'
 
@@ -304,7 +304,7 @@ export default class OrderedTreatment extends ValidationElement {
               <DateRange
                 name="TreatmentDates"
                 className="treatment-dates"
-                {...this.props.TreatmentDates}                
+                {...this.props.TreatmentDates}
                 minDateEqualTo={true}
                 onUpdate={this.updateTreatmentDates}
                 onError={this.props.onError}
@@ -353,10 +353,8 @@ export default class OrderedTreatment extends ValidationElement {
 OrderedTreatment.defaultProps = {
   ActionTaken: {},
   TreatmentCompleted: {},
-  OrderedBy: [],
+  OrderedBy: { values: [] },
   addressBooks: {},
-  dispatch: action => {},
-  onError: (value, arr) => {
-    return arr
-  }
+  dispatch: () => {},
+  onError: (value, arr) => arr,
 }

--- a/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.jsx
+++ b/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.jsx
@@ -57,27 +57,34 @@ export default class OrderedTreatment extends ValidationElement {
         TreatmentDates: this.props.TreatmentDates,
         TreatmentCompleted: this.props.TreatmentCompleted,
         NoTreatmentExplanation: this.props.NoTreatmentExplanation,
-        ...updateValues
+        ...updateValues,
       })
     }
   }
 
-  updateOrderedBy(cb) {
-    let selected = cb.value
+  /**
+   * This is the list of people that ordered counseling or treatment
+   */
+  getPeopleWhoOrderedCounseling = (cb) => {
+    const selected = cb.value
     let list = [...((this.props.OrderedBy || {}).values || [])]
 
-      if (list.includes(selected)) {
-        list.splice(list.indexOf(selected), 1)
-      } else {
-        if (selected !== "None" && list.includes("None") || selected === "None") {
-            list = [selected]
-        }
-        else {
-          list.push(selected)
-        }
-      }
+    if (list.includes(selected)) {
+      list.splice(list.indexOf(selected), 1)
+    } else if (selected === 'None' || list.includes('None')) {
+      list = [selected]
+    } else {
+      list.push(selected)
+    }
+    return list
+  }
 
-    this.update({ OrderedBy: { values: list } })
+  updateOrderedBy(cb) {
+    this.update({
+      OrderedBy: {
+        values: this.getPeopleWhoOrderedCounseling(cb),
+      },
+    })
   }
 
   updateExplanation(values) {

--- a/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.test.jsx
+++ b/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 import configureMockStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
 import OrderedTreatment from './OrderedTreatment'
@@ -10,12 +10,13 @@ describe('The OrderedTreatment component', () => {
 
   beforeEach(() => {
     const store = mockStore()
-    createComponent = (expected = {}) =>
+    createComponent = (expected = {}) => (
       mount(
         <Provider store={store}>
           <OrderedTreatment {...expected} />
         </Provider>
       )
+    )
   })
 
   it('Renders without errors', () => {
@@ -25,13 +26,11 @@ describe('The OrderedTreatment component', () => {
 
   it('Performs update of basic fields', () => {
     let updates = 0
-    const onUpdate = () => {
-      updates++
-    }
+
     const expected = {
       onUpdate: () => {
-        updates++
-      }
+        updates += 1
+      },
     }
     const component = createComponent(expected)
     expect(component.find('.drug-ordered-treatment').length).toBe(1)
@@ -46,11 +45,11 @@ describe('The OrderedTreatment component', () => {
     let updates = 0
     const expected = {
       onUpdate: () => {
-        updates++
+        updates += 1
       },
       ActionTaken: {
-        value: 'Yes'
-      }
+        value: 'Yes',
+      },
     }
     const component = createComponent(expected)
 
@@ -70,14 +69,14 @@ describe('The OrderedTreatment component', () => {
     let updates = 0
     const expected = {
       onUpdate: () => {
-        updates++
+        updates += 1
       },
       ActionTaken: {
-        value: 'Yes'
+        value: 'Yes',
       },
       TreatmentCompleted: {
-        value: 'No'
-      }
+        value: 'No',
+      },
     }
     const component = createComponent(expected)
 
@@ -89,11 +88,11 @@ describe('The OrderedTreatment component', () => {
     let updates = 0
     const expected = {
       onUpdate: () => {
-        updates++
+        updates += 1
       },
       ActionTaken: {
-        value: 'No'
-      }
+        value: 'No',
+      },
     }
     const component = createComponent(expected)
 
@@ -101,36 +100,80 @@ describe('The OrderedTreatment component', () => {
     expect(updates).toBe(1)
   })
 
-  it('Deselect ordered by', () => {
-    let updates = 0
-    const expected = {
-      onUpdate: () => {
-        updates++
-      },
-      ActionTaken: {
-        value: 'No'
-      },
-      OrderedBy: ['Employer']
+  it('returns the correct people that ordered counseling', () => {
+    const props = {
+      OrderedBy: { values: ['Employer', 'MedicalProfessional', 'MentalHealthProfessional'] },
     }
-    const component = createComponent(expected)
 
-    component.find('.ordered-by .employer input').simulate('change')
-    expect(updates).toBe(1)
+    const component = shallow(
+      <OrderedTreatment {...props} />
+    )
+    expect(component.instance().getPeopleWhoOrderedCounseling({ value: 'Judge' }))
+      .toEqual(expect.arrayContaining([
+        'Employer',
+        'MedicalProfessional',
+        'MentalHealthProfessional',
+        'Judge',
+      ]))
   })
 
-  it('Select none', () => {
-    let none = []
-    const expected = {
-      onUpdate: selected => {
-        none = selected.OrderedBy
-      },
-      ActionTaken: {
-        value: 'No'
-      },
-      OrderedBy: ['Employer', 'Judge']
+  it('unselects a person that ordered counseling', () => {
+    const props = {
+      OrderedBy: { values: ['Employer', 'MedicalProfessional', 'MentalHealthProfessional', 'Judge'] },
     }
-    const component = createComponent(expected)
-    component.find('.ordered-by .none input').simulate('change')
-    expect(none).toEqual({ values: ['None'] })
+
+    // const component = createComponent(props)
+    const component = shallow(
+      <OrderedTreatment {...props} />
+    )
+    expect(component.instance().getPeopleWhoOrderedCounseling({ value: 'Judge' }))
+      .toEqual(expect.arrayContaining([
+        'Employer',
+        'MedicalProfessional',
+        'MentalHealthProfessional',
+      ]))
+  })
+
+  it('unselects a person that ordered counseling', () => {
+    const props = {
+      OrderedBy: { values: ['Employer', 'MedicalProfessional', 'MentalHealthProfessional', 'Judge'] },
+    }
+
+    // const component = createComponent(props)
+    const component = shallow(
+      <OrderedTreatment {...props} />
+    )
+    expect(component.instance().getPeopleWhoOrderedCounseling({ value: 'Judge' }))
+      .toEqual(expect.arrayContaining([
+        'Employer',
+        'MedicalProfessional',
+        'MentalHealthProfessional',
+      ]))
+  })
+
+  it('unselects all people if None is selected', () => {
+    const props = {
+      OrderedBy: { values: ['Employer', 'MedicalProfessional', 'MentalHealthProfessional', 'Judge'] },
+    }
+
+    // const component = createComponent(props)
+    const component = shallow(
+      <OrderedTreatment {...props} />
+    )
+    expect(component.instance().getPeopleWhoOrderedCounseling({ value: 'None' }))
+      .toEqual(expect.arrayContaining(['None']))
+  })
+
+  it('unselects None if a person who ordered counseling is selected', () => {
+    const props = {
+      OrderedBy: { values: ['None'] },
+    }
+
+    // const component = createComponent(props)
+    const component = shallow(
+      <OrderedTreatment {...props} />
+    )
+    expect(component.instance().getPeopleWhoOrderedCounseling({ value: 'Judge' }))
+      .toEqual(expect.arrayContaining(['Judge']))
   })
 })


### PR DESCRIPTION
## Description
This PR fixes two issues that come from a single root cause.

- `Have any of the following ordered, advised, or asked you to seek counseling or treatment as a result of your illegal use of drugs or controlled substances?` does not save.
- Cannot navigate to the next section

It's not exactly clear how or when this bug was introduced, but the issue in the code has to do with the variable type. The function was expecting an object, but it was being passed an array. This issue is similar to the `values`, but that seems to occasionally reoccur. I've updated that component function and a number of tests to make sure this doesn't happen again.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
