### PR TITLE
[EN-3799] Fix countryString if an empty object

### DIFF
--- a/src/validators/location.js
+++ b/src/validators/location.js
@@ -106,16 +106,18 @@ export class Geocoder {
 
 export default class LocationValidator {
   constructor(data = {}) {
-    this.layout = data.layout
+    if (data) {
+      this.layout = data.layout
 
-    // Data
-    this.street = data.street
-    this.street2 = data.street2
-    this.city = data.city
-    this.state = data.state
-    this.zipcode = data.zipcode
-    this.county = data.county
-    this.country = countryString(data.country)
+      // Data
+      this.street = data.street
+      this.street2 = data.street2
+      this.city = data.city
+      this.state = data.state
+      this.zipcode = data.zipcode
+      this.county = data.county
+      this.country = countryString(data.country)
+    }
   }
 
   canGeocode() {

--- a/src/validators/location.js
+++ b/src/validators/location.js
@@ -6,25 +6,17 @@ import militaryStatesEnum from 'constants/enums/militaryStates'
 import { api } from '../services/api'
 import Layouts from '../components/Form/Location/Layouts'
 import { isZipcodeState, zipcodes } from '../config'
-import { isDefined } from './helpers'
 
 export const countryString = (country) => {
   if (validate.isHash(country)) {
-    if (isDefined(country.value)) {
-      if (Array.isArray(country.value)) {
-        return country.value[0]
-      }
+    if (country.value === null) return null
+    if (country.value === undefined) return undefined
 
-      return country.value
+    if (Array.isArray(country.value)) {
+      return country.value[0]
     }
 
-    if (country.value === null) {
-      return null
-    }
-
-    if (country.value === undefined) {
-      return undefined
-    }
+    return country.value
   }
 
   return country

--- a/src/validators/location.js
+++ b/src/validators/location.js
@@ -1,33 +1,111 @@
+import { validate } from 'validate.js'
+import usStates from 'constants/enums/usStates'
+import usTerritories from 'constants/enums/usTerritories'
+import militaryStatesEnum from 'constants/enums/militaryStates'
+
 import { api } from '../services/api'
 import Layouts from '../components/Form/Location/Layouts'
 import { isZipcodeState, zipcodes } from '../config'
 import { isDefined } from './helpers'
 
-export const isInternational = location => {
-  return !['United States', 'POSTOFFICE'].includes(
-    countryString(location.country || {})
-  )
-}
-
-export const countryString = country => {
-  if (country) {
+export const countryString = (country) => {
+  if (validate.isHash(country)) {
     if (isDefined(country.value)) {
       if (Array.isArray(country.value)) {
         return country.value[0]
       }
 
       return country.value
-    } else if (country.value === null) {
+    }
+
+    if (country.value === null) {
       return null
+    }
+
+    if (country.value === undefined) {
+      return undefined
     }
   }
 
   return country
 }
 
+export const isInternational = location => (
+  !['United States', 'POSTOFFICE'].includes(
+    countryString(location.country || {})
+  )
+)
+
+export const unitedStates = usStates
+export const otherUsTerritories = usTerritories
+export const militaryStates = militaryStatesEnum
+
+/**
+ * Take a potential state name and convert it to its state code.
+ * @param {Type of state} state - The state name.
+ * @returns {Return Type} State code.
+ */
+const toCode = (state) => {
+  const allUsStates = [
+    ...unitedStates,
+    ...otherUsTerritories,
+    ...militaryStates,
+  ]
+
+  const selectedState = allUsStates
+    .find(stateObj => stateObj.name.toLowerCase() === state.toLowerCase())
+
+  if (selectedState) {
+    return selectedState.postalCode
+  }
+
+  return state
+}
+
+export class Geocoder {
+  isSystemError = (data) => {
+    if (!data || !data.Errors || !data.Errors.length) {
+      return false
+    }
+
+    for (let i = 0; i < data.Errors.length; i += 1) {
+      const e = data.Errors[i]
+      if (e.Error.indexOf('error.geocode.system') !== -1) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  geocode(location) {
+    return new Promise((resolve, reject) => {
+      api
+        .validate({
+          type: 'location',
+          props: location,
+        })
+        .then((r) => {
+          const { data } = r
+          if (this.isSystemError(data)) {
+            return reject(data)
+          }
+
+          if (!r.data.Errors || !r.data.Errors.length) {
+            return resolve({})
+          }
+
+          return resolve(r.data.Errors[0])
+        })
+        .catch(() => {
+          reject(new Error('Failed to validate address'))
+        })
+    })
+  }
+}
+
 export default class LocationValidator {
   constructor(data = {}) {
-    data = data || {}
     this.layout = data.layout
 
     // Data
@@ -63,7 +141,7 @@ export default class LocationValidator {
       zipcode: this.zipcode,
       county: this.county,
       country: countryString(this.country) || '',
-      validated: false
+      validated: false,
     })
   }
 
@@ -128,7 +206,8 @@ export default class LocationValidator {
     return this.country === 'POSTOFFICE'
   }
 
-  // TODO: this function doesn't quite work as an empty value for country should not necessarily preclude a valid international address
+  // TODO: this function doesn't quite work as an empty value for country
+  // should not necessarily preclude a valid international address
   // for example, if the address is pristine and hasnt been modified
   isInternational() {
     return this.validCountry() && !this.isDomestic() && !this.isPostOffice()
@@ -171,7 +250,7 @@ export default class LocationValidator {
           'city',
           'state',
           'zipcode',
-          'stateZipcode'
+          'stateZipcode',
         ])
       case Layouts.STREET_CITY:
         return this.validFields(['street', 'city'])
@@ -182,7 +261,7 @@ export default class LocationValidator {
             'city',
             'state',
             'zipcode',
-            'stateZipcode'
+            'stateZipcode',
           ])
         }
         return this.validFields(['street', 'city', 'country'])
@@ -200,8 +279,10 @@ export default class LocationValidator {
     if (!fields || !fields.length) {
       return false
     }
+
     let valid = true
-    for (let field of fields) {
+    for (let i = 0; i < fields.length; i += 1) {
+      const field = fields[i]
       switch (field) {
         case 'street':
           valid = valid && this.validStreet()
@@ -224,8 +305,10 @@ export default class LocationValidator {
         case 'country':
           valid = valid && this.validCountry()
           break
+        default:
       }
     }
+
     return valid
   }
 
@@ -233,141 +316,3 @@ export default class LocationValidator {
     return this.validLocation()
   }
 }
-
-export class Geocoder {
-  isSystemError(data) {
-    if (!data || !data.Errors || !data.Errors.length) {
-      return false
-    }
-    for (let e of data.Errors) {
-      if (e.Error.indexOf('error.geocode.system') !== -1) {
-        return true
-      }
-    }
-    return false
-  }
-
-  geocode(location) {
-    return new Promise((resolve, reject) => {
-      api
-        .validate({
-          type: 'location',
-          props: location
-        })
-        .then(r => {
-          const data = r.data
-          if (this.isSystemError(data)) {
-            return reject(data)
-          }
-          if (!r.data.Errors || !r.data.Errors.length) {
-            resolve({})
-          }
-          resolve(r.data.Errors[0])
-        })
-        .catch(() => {
-          reject(new Error('Failed to validate address'))
-        })
-    })
-  }
-}
-
-/**
- * Take a potential state name and convert it to its state code.
- * @param {Type of state} state - The state name.
- * @returns {Return Type} State code.
- */
-const toCode = state => {
-  const allUsStates = [
-    ...unitedStates,
-    ...otherUsTerritories,
-    ...militaryStates
-  ]
-  const selectedState = allUsStates.find(stateObj => {
-    return stateObj.name.toLowerCase() === state.toLowerCase()
-  })
-
-  if (selectedState) {
-    return selectedState.postalCode
-  }
-  return state
-}
-
-export const unitedStates = [
-  { name: 'Alabama', postalCode: 'AL' },
-  { name: 'Alaska', postalCode: 'AK' },
-  { name: 'Arizona', postalCode: 'AZ' },
-  { name: 'Arkansas', postalCode: 'AR' },
-  { name: 'California', postalCode: 'CA' },
-  { name: 'Colorado', postalCode: 'CO' },
-  { name: 'Connecticut', postalCode: 'CT' },
-  { name: 'Delaware', postalCode: 'DE' },
-  { name: 'Washington D.C.', postalCode: 'DC' },
-  { name: 'Florida', postalCode: 'FL' },
-  { name: 'Georgia', postalCode: 'GA' },
-  { name: 'Hawaii', postalCode: 'HI' },
-  { name: 'Idaho', postalCode: 'ID' },
-  { name: 'Illinois', postalCode: 'IL' },
-  { name: 'Indiana', postalCode: 'IN' },
-  { name: 'Iowa', postalCode: 'IA' },
-  { name: 'Kansas', postalCode: 'KS' },
-  { name: 'Kentucky', postalCode: 'KY' },
-  { name: 'Louisiana', postalCode: 'LA' },
-  { name: 'Maine', postalCode: 'ME' },
-  { name: 'Maryland', postalCode: 'MD' },
-  { name: 'Massachusetts', postalCode: 'MA' },
-  { name: 'Michigan', postalCode: 'MI' },
-  { name: 'Minnesota', postalCode: 'MN' },
-  { name: 'Mississippi', postalCode: 'MS' },
-  { name: 'Missouri', postalCode: 'MO' },
-  { name: 'Montana', postalCode: 'MT' },
-  { name: 'Nebraska', postalCode: 'NE' },
-  { name: 'Nevada', postalCode: 'NV' },
-  { name: 'New Hampshire', postalCode: 'NH' },
-  { name: 'New Jersey', postalCode: 'NJ' },
-  { name: 'New Mexico', postalCode: 'NM' },
-  { name: 'New York', postalCode: 'NY' },
-  { name: 'North Carolina', postalCode: 'NC' },
-  { name: 'North Dakota', postalCode: 'ND' },
-  { name: 'Ohio', postalCode: 'OH' },
-  { name: 'Oklahoma', postalCode: 'OK' },
-  { name: 'Oregon', postalCode: 'OR' },
-  { name: 'Pennsylvania', postalCode: 'PA' },
-  { name: 'Rhode Island', postalCode: 'RI' },
-  { name: 'South Carolina', postalCode: 'SC' },
-  { name: 'South Dakota', postalCode: 'SD' },
-  { name: 'Tennessee', postalCode: 'TN' },
-  { name: 'Texas', postalCode: 'TX' },
-  { name: 'Utah', postalCode: 'UT' },
-  { name: 'Vermont', postalCode: 'VT' },
-  { name: 'Virginia', postalCode: 'VA' },
-  { name: 'Washington', postalCode: 'WA' },
-  { name: 'West Virginia', postalCode: 'WV' },
-  { name: 'Wisconsin', postalCode: 'WI' },
-  { name: 'Wyoming', postalCode: 'WY' }
-]
-
-export const otherUsTerritories = [
-  { name: 'American Samoa', postalCode: 'AS' },
-  { name: 'FQ', postalCode: 'FQ' },
-  { name: 'Guam', postalCode: 'GU' },
-  { name: 'HQ', postalCode: 'HQ' },
-  { name: 'DQ', postalCode: 'DQ' },
-  { name: 'JQ', postalCode: 'JQ' },
-  { name: 'KQ', postalCode: 'KQ' },
-  { name: 'Marshall Islands', postalCode: 'MH' },
-  { name: 'Micronesia', postalCode: 'FM' },
-  { name: 'MQ', postalCode: 'MQ' },
-  { name: 'BQ', postalCode: 'BQ' },
-  { name: 'Northern Mariana Islands', postalCode: 'MP' },
-  { name: 'Palau', postalCode: 'PW' },
-  { name: 'LQ', postalCode: 'LQ' },
-  { name: 'Puerto Rico', postalCode: 'PR' },
-  { name: 'Virgin Islands', postalCode: 'VI' },
-  { name: 'WQ', postalCode: 'WQ' }
-]
-
-export const militaryStates = [
-  { name: 'U.S. Armed Forces - Americas', postalCode: 'AA' },
-  { name: 'U.S. Armed Forces - Europe', postalCode: 'AE' },
-  { name: 'U.S. Armed Forces - Pacific', postalCode: 'AP' }
-]

--- a/src/validators/location.test.js
+++ b/src/validators/location.test.js
@@ -1,21 +1,23 @@
+import MockAdapter from 'axios-mock-adapter'
+
 import LocationValidator, { Geocoder, countryString } from './location'
 import Location from '../components/Form/Location'
 import { api } from '../services/api'
-import MockAdapter from 'axios-mock-adapter'
 
-describe('the location validator', function() {
+describe('the location validator', () => {
   describe('.countryString', () => {
     it('properly extracts the country string from the supplied value', () => {
-      const noOpValues = ['', false, true, {}, 'United States', 0]
+      const noOpValues = ['', false, true, 'United States', 0]
       noOpValues.forEach(v => expect(countryString(v)).toEqual(v))
 
+      expect(countryString({})).toEqual(undefined)
       expect(countryString({ value: '' })).toEqual('')
       expect(countryString({ value: 'Portugal' })).toEqual('Portugal')
-      expect(countryString({ value: [ 'Portugal' ]})).toEqual('Portugal')
+      expect(countryString({ value: ['Portugal'] })).toEqual('Portugal')
     })
   })
 
-  it('should validate locations', function() {
+  it('should validate locations', () => {
     const tests = [
       {
         data: {
@@ -23,34 +25,34 @@ describe('the location validator', function() {
           state: 'VA',
           county: 'Arlington',
           country: { value: 'United States' },
-          layout: Location.BIRTHPLACE
+          layout: Location.BIRTHPLACE,
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
           city: 'Munich',
           country: { value: 'Germany' },
-          layout: Location.BIRTHPLACE
+          layout: Location.BIRTHPLACE,
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
           city: 'A-Town',
           state: 'VA',
           country: { value: 'United States' },
-          layout: Location.BIRTHPLACE_WITHOUT_COUNTY
+          layout: Location.BIRTHPLACE_WITHOUT_COUNTY,
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
           city: 'Munich',
           country: { value: 'Germany States' },
-          layout: Location.BIRTHPLACE_WITHOUT_COUNTY
+          layout: Location.BIRTHPLACE_WITHOUT_COUNTY,
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
@@ -58,144 +60,144 @@ describe('the location validator', function() {
           state: 'VA',
           zipcode: '22202',
           country: { value: 'United States' },
-          layout: Location.US_CITY_STATE_ZIP_INTERNATIONAL_CITY
+          layout: Location.US_CITY_STATE_ZIP_INTERNATIONAL_CITY,
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
           state: 'AZ',
-          layout: Location.STATE
+          layout: Location.STATE,
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
           city: 'Arlington',
           state: 'VA',
-          layout: Location.CITY_STATE
+          layout: Location.CITY_STATE,
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
           street: '123 Some rd',
           city: 'Arlington',
           country: { value: 'Germany' },
-          layout: Location.STREET_CITY_COUNTRY
+          layout: Location.STREET_CITY_COUNTRY,
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
           city: 'Munich',
           country: { value: 'Germany' },
-          layout: Location.CITY_COUNTRY
+          layout: Location.CITY_COUNTRY,
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
           city: 'Arlington',
           state: 'VA',
           country: { value: 'United States' },
-          layout: Location.CITY_STATE_COUNTRY
+          layout: Location.CITY_STATE_COUNTRY,
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
           city: 'Munich',
           state: '',
           country: { value: 'Germany' },
-          layout: Location.CITY_STATE_COUNTRY
+          layout: Location.CITY_STATE_COUNTRY,
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
           city: 'Munich',
           country: { value: 'Germany' },
-          layout: ''
+          layout: '',
         },
-        expected: false
-      }
+        expected: false,
+      },
     ]
 
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new LocationValidator(test.data).isValid(test.fields)).toBe(
         test.expected
       )
     })
   })
 
-  it('should validate fields', function() {
+  it('should validate fields', () => {
     const tests = [
       {
         data: {
-          city: 'Arlington'
+          city: 'Arlington',
         },
         fields: ['city'],
-        expected: true
+        expected: true,
       },
       {
         data: {
           city: 'Arlington',
           state: 'VA',
           county: 'Thecountry',
-          country: { value: 'United States' }
+          country: { value: 'United States' },
         },
         fields: ['city', 'state', 'county', 'country'],
-        expected: true
+        expected: true,
       },
       {
         data: {},
         fields: [],
-        expected: false
-      }
+        expected: false,
+      },
     ]
 
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new LocationValidator(test.data).validFields(test.fields)).toBe(
         test.expected
       )
     })
   })
 
-  it('should check if international', function() {
+  it('should check if international', () => {
     const tests = [
       {
         data: {
-          country: { value: 'United States' }
+          country: { value: 'United States' },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
-          country: { value: 'POSTOFFICE' }
+          country: { value: 'POSTOFFICE' },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
-          country: { value: 'Germany' }
+          country: { value: 'Germany' },
         },
-        expected: true
+        expected: true,
       },
       {
         data: {},
-        expected: false
-      }
+        expected: false,
+      },
     ]
 
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new LocationValidator(test.data).isInternational()).toBe(
         test.expected
       )
     })
   })
 
-  it('should check if it can geocode', function() {
+  it('should check if it can geocode', () => {
     const tests = [
       {
         data: {
@@ -205,9 +207,9 @@ describe('the location validator', function() {
           zipcode: '22202',
           county: 'Thecountry',
           country: { value: 'United States' },
-          layout: Location.ADDRESS
+          layout: Location.ADDRESS,
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
@@ -217,65 +219,65 @@ describe('the location validator', function() {
           zipcode: '22202',
           county: 'Thecounty',
           country: { value: 'United States' },
-          layout: Location.US_ADDRESS
+          layout: Location.US_ADDRESS,
         },
-        expected: true
-      },
-      {
-        data: {
-          street: '123 Some Rd',
-          city: 'Arlington',
-          country: { value: 'United States' }
-        },
-        expected: false
+        expected: true,
       },
       {
         data: {
           street: '123 Some Rd',
           city: 'Arlington',
           country: { value: 'United States' },
-          layout: Location.CITY_STATE_COUNTRY
         },
-        expected: false
-      }
+        expected: false,
+      },
+      {
+        data: {
+          street: '123 Some Rd',
+          city: 'Arlington',
+          country: { value: 'United States' },
+          layout: Location.CITY_STATE_COUNTRY,
+        },
+        expected: false,
+      },
     ]
 
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new LocationValidator(test.data).canGeocode()).toBe(test.expected)
     })
   })
 
-  it('should handle geocode errors', function() {
+  it('should handle geocode errors', () => {
     const tests = [
       {
         data: {
           Errors: [
             {
-              Error: 'error.geocode.system'
-            }
-          ]
+              Error: 'error.geocode.system',
+            },
+          ],
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
-          Errors: []
+          Errors: [],
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
           Errors: [
             {
-              Error: 'error.geocode.city'
-            }
-          ]
+              Error: 'error.geocode.city',
+            },
+          ],
         },
-        expected: false
-      }
+        expected: false,
+      },
     ]
 
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new Geocoder(test.data).isSystemError(test.data)).toBe(
         test.expected
       )
@@ -289,15 +291,15 @@ describe('the location validator', function() {
         address: '1234 Some Rd',
         city: 'Arlington',
         state: 'VA',
-        zipcode: '22202'
+        zipcode: '22202',
       },
       expected: {
         Errors: [
           {
-            Error: 'error.geocode.system'
-          }
-        ]
-      }
+            Error: 'error.geocode.system',
+          },
+        ],
+      },
     }
 
     api.setToken('my-token')
@@ -305,14 +307,14 @@ describe('the location validator', function() {
     mock.onPost('/me/validate').reply(200, {
       Errors: [
         {
-          Error: 'error.geocode.system'
-        }
-      ]
+          Error: 'error.geocode.system',
+        },
+      ],
     })
     return new LocationValidator(test.state, null)
       .geocode()
-      .then(r => {})
-      .catch(r => {
+      .then(() => {})
+      .catch((r) => {
         expect(r).toEqual(test.expected)
       })
   })
@@ -324,15 +326,15 @@ describe('the location validator', function() {
         street: '1234 Some Rd',
         city: 'Arlington',
         state: 'VA',
-        zipcode: '22202'
+        zipcode: '22202',
       },
       expected: {
         Errors: [
           {
-            Error: 'error.geocode.partial'
-          }
-        ]
-      }
+            Error: 'error.geocode.partial',
+          },
+        ],
+      },
     }
 
     api.setToken('my-token')
@@ -340,14 +342,14 @@ describe('the location validator', function() {
     mock.onPost('/me/validate').reply(200, {
       Errors: [
         {
-          Error: 'error.geocode.partial'
-        }
-      ]
+          Error: 'error.geocode.partial',
+        },
+      ],
     })
     return new LocationValidator(test.state, null)
       .geocode()
-      .then(r => {})
-      .catch(r => {
+      .then(() => {})
+      .catch((r) => {
         expect(r).toEqual(test.expected)
       })
   })
@@ -359,27 +361,27 @@ describe('the location validator', function() {
         street: '1234 Some Rd',
         city: 'Arlington',
         state: 'VA',
-        zipcode: '22202'
+        zipcode: '22202',
       },
       expected: {
-        Errors: []
-      }
+        Errors: [],
+      },
     }
 
     api.setToken('my-token')
     const mock = new MockAdapter(api.proxy)
     mock.onPost('/me/validate').reply(200, {
-      Errors: []
+      Errors: [],
     })
     return new LocationValidator(test.state, null)
       .geocode()
-      .then(r => {})
-      .catch(r => {
+      .then(() => {})
+      .catch((r) => {
         expect(r).toEqual(test.expected)
       })
   })
 
-  it('should validate zipcode', function() {
+  it('should validate zipcode', () => {
     const tests = [
       {
         state: {
@@ -387,9 +389,9 @@ describe('the location validator', function() {
           street: '1234 Some Rd',
           city: 'Arlington',
           state: 'VA',
-          zipcode: '2'
+          zipcode: '2',
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
@@ -397,20 +399,20 @@ describe('the location validator', function() {
           street: '1234 Some Rd',
           city: 'Arlington',
           state: 'VA',
-          zipcode: null
+          zipcode: null,
         },
-        expected: false
-      }
+        expected: false,
+      },
     ]
 
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new LocationValidator(test.state, null).validZipcode()).toEqual(
         test.expected
       )
     })
   })
 
-  it('should validate zipcode is in correct state if in US', function() {
+  it('should validate zipcode is in correct state if in US', () => {
     const tests = [
       {
         state: {
@@ -418,9 +420,9 @@ describe('the location validator', function() {
           street: '1 Great Teen Drama Dr.',
           city: 'Beverly Hills',
           state: 'CA',
-          zipcode: '90210'
+          zipcode: '90210',
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
@@ -428,9 +430,9 @@ describe('the location validator', function() {
           street: '1 Great Teen Drama Dr.',
           city: 'Beverly Hills',
           state: 'ca',
-          zipcode: '90210'
+          zipcode: '90210',
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
@@ -438,9 +440,9 @@ describe('the location validator', function() {
           street: '1234 Some Rd',
           city: 'Arlington',
           state: 'VA',
-          zipcode: '90210'
+          zipcode: '90210',
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
@@ -448,13 +450,13 @@ describe('the location validator', function() {
           street: '1234 Some Rd',
           city: 'City',
           state: 'DQ',
-          zipcode: '12321'
+          zipcode: '12321',
         },
-        expected: false
-      }
+        expected: false,
+      },
     ]
 
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(
         new LocationValidator(test.state, null).validZipcodeState()
       ).toEqual(test.expected)


### PR DESCRIPTION
## Description

Fixes an issue with the `countryString` normalizer function. All uses of this function expect it to return a value that is render-able by React (ie a string, boolean, or null/undefined -- but not an array or object). However, with the existing function if the parameter is an empty object or an object that is missing a `value` key it will just return the object, causing an error at render time. This PR fixes this use case and also includes linter fixes.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
