### PR TITLE
[EN-3753] Validation Refactor - Legal / Other Offenses

### DIFF
--- a/src/components/Section/Legal/Police/OtherOffense.jsx
+++ b/src/components/Section/Legal/Police/OtherOffense.jsx
@@ -12,7 +12,6 @@ import {
   RadioGroup,
   Radio,
   Field,
-  Svg
 } from '../../../Form'
 
 export default class OtherOffense extends ValidationElement {
@@ -56,97 +55,97 @@ export default class OtherOffense extends ValidationElement {
       Sentence: this.props.Sentence,
       AwaitingTrial: this.props.AwaitingTrial,
       AwaitingTrialExplanation: this.props.AwaitingTrialExplanation,
-      ...queue
+      ...queue,
     })
   }
 
   updateDate(values) {
     this.update({
-      Date: values
+      Date: values,
     })
   }
 
   updateDescription(values) {
     this.update({
-      Description: values
+      Description: values,
     })
   }
 
   updateInvolvedViolence(values) {
     this.update({
-      InvolvedViolence: values
+      InvolvedViolence: values,
     })
   }
 
   updateInvolvedFirearms(values) {
     this.update({
-      InvolvedFirearms: values
+      InvolvedFirearms: values,
     })
   }
 
   updateInvolvedSubstances(values) {
     this.update({
-      InvolvedSubstances: values
+      InvolvedSubstances: values,
     })
   }
 
   updateCourtName(value) {
     this.update({
-      CourtName: value
+      CourtName: value,
     })
   }
 
   updateCourtAddress(value) {
     this.update({
-      CourtAddress: value
+      CourtAddress: value,
     })
   }
 
   updateChargeType(values) {
     this.update({
-      ChargeType: values
+      ChargeType: values,
     })
   }
 
   updateCourtCharge(value) {
     this.update({
-      CourtCharge: value
+      CourtCharge: value,
     })
   }
 
   updateCourtOutcome(value) {
     this.update({
-      CourtOutcome: value
+      CourtOutcome: value,
     })
   }
 
   updateCourtDate(value) {
     this.update({
-      CourtDate: value
+      CourtDate: value,
     })
   }
 
   updateWasSentenced(values) {
     this.update({
-      WasSentenced: values
+      WasSentenced: values,
     })
   }
 
   updateSentence(values) {
     this.update({
-      Sentence: values
+      Sentence: values,
     })
   }
 
   updateAwaitingTrial(values) {
     this.update({
-      AwaitingTrial: values
+      AwaitingTrial: values,
     })
   }
 
   updateAwaitingTrialExplanation(values) {
     this.update({
-      AwaitingTrialExplanation: values
+      AwaitingTrialExplanation: values,
     })
   }
 
@@ -157,13 +156,14 @@ export default class OtherOffense extends ValidationElement {
           title={i18n.t('legal.police.heading.date')}
           help="legal.police.help.date"
           adjustFor="labels"
-          shrink={true}
-          scrollIntoView={this.props.scrollIntoView}>
+          shrink
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <DateControl
             name="Date"
             {...this.props.Date}
             className="offense-date"
-            minDateEqualTo={true}
+            minDateEqualTo
             onUpdate={this.updateDate}
             onError={this.props.onError}
             required={this.props.required}
@@ -173,7 +173,8 @@ export default class OtherOffense extends ValidationElement {
         <Field
           title={i18n.t('legal.police.heading.description')}
           help="legal.police.help.description"
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <Textarea
             name="Description"
             {...this.props.Description}
@@ -193,7 +194,8 @@ export default class OtherOffense extends ValidationElement {
           onUpdate={this.updateInvolvedViolence}
           required={this.props.required}
           onError={this.props.onError}
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           {i18n.m('legal.police.label.violence')}
         </Branch>
 
@@ -204,7 +206,8 @@ export default class OtherOffense extends ValidationElement {
           onUpdate={this.updateInvolvedFirearms}
           required={this.props.required}
           onError={this.props.onError}
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           {i18n.m('legal.police.label.firearms')}
         </Branch>
 
@@ -215,14 +218,16 @@ export default class OtherOffense extends ValidationElement {
           onUpdate={this.updateInvolvedSubstances}
           required={this.props.required}
           onError={this.props.onError}
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           {i18n.m('legal.police.label.substances')}
         </Branch>
 
         <Field
           title={i18n.t('legal.police.heading.courtname')}
           adjustFor="labels"
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <Text
             name="CourtName"
             {...this.props.CourtName}
@@ -236,18 +241,19 @@ export default class OtherOffense extends ValidationElement {
 
         <Field
           title={i18n.t('legal.police.heading.courtaddress')}
-          optional={true}
+          optional
           help="legal.police.help.courtaddress"
           adjustFor="address"
-          shrink={true}
-          scrollIntoView={this.props.scrollIntoView}>
+          shrink
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <Location
             name="CourtAddress"
             {...this.props.CourtAddress}
             label={i18n.t('legal.police.label.address')}
             className="offense-courtaddress"
             layout={Location.OFFENSE}
-            geocode={true}
+            geocode
             addressBooks={this.props.addressBooks}
             addressBook="Court"
             dispatch={this.props.dispatch}
@@ -260,7 +266,8 @@ export default class OtherOffense extends ValidationElement {
         <Field
           title={i18n.t('legal.police.heading.chargedetails')}
           titleSize="h4"
-          className="no-margin-bottom">
+          className="no-margin-bottom"
+        >
           {i18n.m('legal.police.para.chargedetails')}
         </Field>
 
@@ -268,12 +275,14 @@ export default class OtherOffense extends ValidationElement {
           title={i18n.t('legal.police.heading.chargeType')}
           titleSize="label"
           adjustFor="buttons"
-          scrollIntoView={this.props.scrollIntoView}>
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <RadioGroup
             className="offense-chargetype option-list"
             onError={this.props.onErro}
             required={this.props.required}
-            selectedValue={(this.props.ChargeType || {}).value}>
+            selectedValue={(this.props.ChargeType || {}).value}
+          >
             <Radio
               name="charge-felony"
               className="charge-felony"
@@ -325,13 +334,14 @@ export default class OtherOffense extends ValidationElement {
           titleSize="h4"
           help="legal.police.help.courtdate"
           adjustFor="labels"
-          shrink={true}
-          scrollIntoView={this.props.scrollIntoView}>
+          shrink
+          scrollIntoView={this.props.scrollIntoView}
+        >
           <DateControl
             name="CourtDate"
             {...this.props.CourtDate}
-            hideDay={true}
-            minDateEqualTo={true}
+            hideDay
+            minDateEqualTo
             className="offense-courtdate"
             onUpdate={this.updateCourtDate}
             onError={this.props.onError}
@@ -360,6 +370,8 @@ export default class OtherOffense extends ValidationElement {
               required={this.props.required}
               onUpdate={this.updateSentence}
               scrollIntoView={this.props.scrollIntoView}
+              requireLegalOffenseSentenced
+              requireLegalOffenseIncarcerated
             />
           </div>
         </Show>
@@ -379,7 +391,8 @@ export default class OtherOffense extends ValidationElement {
             <Field
               title={i18n.t('legal.police.heading.awaitingTrialExplanation')}
               titleSize="label"
-              scrollIntoView={this.props.scrollIntoView}>
+              scrollIntoView={this.props.scrollIntoView}
+            >
               <Textarea
                 className="awaiting-trial-explanation"
                 {...this.props.AwaitingTrialExplanation}
@@ -402,9 +415,7 @@ OtherOffense.defaultProps = {
   InvolvedSubstances: {},
   WasSentenced: {},
   addressBooks: {},
-  dispatch: action => {},
-  onUpdate: queue => {},
-  onError: (value, arr) => {
-    return arr
-  }
+  dispatch: () => {},
+  onUpdate: () => {},
+  onError: (value, arr) => arr,
 }

--- a/src/models/__tests__/otherOffense.test.js
+++ b/src/models/__tests__/otherOffense.test.js
@@ -1,0 +1,357 @@
+import { validateModel } from 'models/validate'
+import offense from '../otherOffense'
+
+describe('The offense model', () => {
+  it('the Date field is required', () => {
+    const testData = {}
+    const expectedErrors = ['Date.required']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the Date field must be a valid date', () => {
+    const testData = {
+      Date: 'not a date',
+    }
+    const expectedErrors = ['Date.date']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the Description field is required', () => {
+    const testData = {}
+    const expectedErrors = ['Description.required']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the Description field must have a value', () => {
+    const testData = { Description: 'something' }
+    const expectedErrors = ['Description.hasValue']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the InvolvedViolence field must have a valid value', () => {
+    const testData = { InvolvedViolence: { value: 'true' } }
+    const expectedErrors = ['InvolvedViolence.hasValue']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the InvolvedFirearms field must have a valid value', () => {
+    const testData = { InvolvedFirearms: { value: 'false' } }
+    const expectedErrors = ['InvolvedFirearms.hasValue']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the InvolvedSubstances field must have a valid value', () => {
+    const testData = { InvolvedSubstances: { value: 100 } }
+    const expectedErrors = ['InvolvedSubstances.hasValue']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the CourtName field is required', () => {
+    const testData = {}
+    const expectedErrors = ['CourtName.required']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the CourtName field must have a value', () => {
+    const testData = {
+      CourtName: { value: '' },
+    }
+    const expectedErrors = ['CourtName.hasValue']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the CourtAddress field is required', () => {
+    const testData = {}
+    const expectedErrors = ['CourtAddress.required']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the CourtAddress field must be a valid address', () => {
+    const testData = {
+      CourtAddress: { city: 'New York', state: 'MA', country: 'United States' },
+    }
+    const expectedErrors = ['CourtAddress.location']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the ChargeType field is required', () => {
+    const testData = {}
+    const expectedErrors = ['ChargeType.required']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the ChargeType field must have a valid value', () => {
+    const testData = {
+      ChargeType: { value: 'Test' },
+    }
+    const expectedErrors = ['ChargeType.hasValue']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the CourtCharge field is required', () => {
+    const testData = {}
+    const expectedErrors = ['CourtCharge.required']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the CourtCharge field must have a value', () => {
+    const testData = {
+      CourtCharge: 'invalid',
+    }
+    const expectedErrors = ['CourtCharge.hasValue']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the CourtOutcome field is required', () => {
+    const testData = {}
+    const expectedErrors = ['CourtOutcome.required']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the CourtOutcome field must have a value', () => {
+    const testData = {
+      CourtOutcome: [],
+    }
+    const expectedErrors = ['CourtOutcome.hasValue']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the CourtDate field is required', () => {
+    const testData = {}
+    const expectedErrors = ['CourtDate.required']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the CourtDate field must be a valid date', () => {
+    const testData = {
+      CourtDate: { year: 3000, month: 13, day: 2 },
+    }
+    const expectedErrors = ['CourtDate.date']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the WasSentenced field is required', () => {
+    const testData = {}
+    const expectedErrors = ['WasSentenced.required']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('the WasSentenced field must have a valid value', () => {
+    const testData = {
+      WasSentenced: { value: 'invalid' },
+    }
+    const expectedErrors = ['WasSentenced.hasValue']
+
+    expect(validateModel(testData, offense))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if Sentenced is Yes', () => {
+    it('the Sentence field is required', () => {
+      const testData = {
+        WasSentenced: { value: 'Yes' },
+      }
+      const expectedErrors = ['Sentence.required']
+
+      expect(validateModel(testData, offense))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('the Sentence field must be a valid Sentence', () => {
+      const testData = {
+        WasSentenced: { value: 'Yes' },
+        Sentence: {
+          Description: {},
+          ExceedsYear: { value: '' },
+          Incarcerated: { value: 'Yes' },
+          IncarcerationDates: {
+            from: { year: 1995, month: 2, day: 10 },
+            to: { year: 2010, month: 10, day: 1 },
+          },
+        },
+      }
+      const expectedErrors = ['Sentence.model']
+
+      expect(validateModel(testData, offense))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('the AwaitingTrial field is not required', () => {
+      const testData = {
+        WasSentenced: { value: 'Yes' },
+      }
+      const expectedErrors = ['AwaitingTrial.required']
+
+      expect(validateModel(testData, offense))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('the AwaitingTrialExplanation field is not required', () => {
+      const testData = {
+        WasSentenced: { value: 'Yes' },
+      }
+      const expectedErrors = ['AwaitingTrialExplanation.required']
+
+      expect(validateModel(testData, offense))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid Offense', () => {
+      const testData = {
+        Date: { year: 2015, month: 6, day: 2 },
+        Description: { value: 'I did something bad' },
+        InvolvedViolence: { value: 'Yes' },
+        InvolvedFirearms: { value: 'No' },
+        InvolvedSubstances: { value: 'Yes' },
+        CourtName: { value: 'Test Court' },
+        CourtAddress: {
+          city: 'Somecity',
+          state: 'NY',
+          zipcode: '10022',
+          country: { value: 'United States' },
+        },
+        ChargeType: { value: 'Felony' },
+        CourtCharge: { value: 'My charges' },
+        CourtOutcome: { value: 'The outcome' },
+        CourtDate: { year: 2017, day: 3, month: 12 },
+        WasSentenced: { value: 'Yes' },
+        Sentence: {
+          Description: { value: 'Something' },
+          ExceedsYear: { value: 'No' },
+          Incarcerated: { value: 'Yes' },
+          ProbationDates: {
+            from: { year: 2010, month: 2, day: 10 },
+            to: { year: 2013, month: 10, day: 1 },
+          },
+          IncarcerationDates: {
+            from: { year: 1995, month: 2, day: 10 },
+            to: { year: 2010, month: 10, day: 1 },
+          },
+        },
+      }
+
+      expect(validateModel(testData, offense)).toEqual(true)
+    })
+  })
+
+  describe('if Sentenced is No', () => {
+    it('the Sentence field is not required', () => {
+      const testData = {
+        WasSentenced: { value: 'No' },
+      }
+      const expectedErrors = ['Sentence.required']
+
+      expect(validateModel(testData, offense))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('the AwaitingTrial field is required', () => {
+      const testData = {
+        WasSentenced: { value: 'No' },
+      }
+      const expectedErrors = ['AwaitingTrial.required']
+
+      expect(validateModel(testData, offense))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('the AwaitingTrial field must have a valid value', () => {
+      const testData = {
+        WasSentenced: { value: 'No' },
+        AwaitingTrial: 'Yes',
+      }
+      const expectedErrors = ['AwaitingTrial.hasValue']
+
+      expect(validateModel(testData, offense))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('the AwaitingTrialExplanation field is required', () => {
+      const testData = {
+        WasSentenced: { value: 'No' },
+        AwaitingTrialExplanation: undefined,
+      }
+      const expectedErrors = ['AwaitingTrialExplanation.required']
+
+      expect(validateModel(testData, offense))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('the AwaitingTrialExplanation field must have a value', () => {
+      const testData = {
+        WasSentenced: { value: 'No' },
+        AwaitingTrialExplanation: 'something',
+      }
+      const expectedErrors = ['AwaitingTrialExplanation.hasValue']
+
+      expect(validateModel(testData, offense))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid Offense', () => {
+      const testData = {
+        Date: { year: 2015, month: 6, day: 2 },
+        Description: { value: 'I did something bad' },
+        InvolvedViolence: { value: 'Yes' },
+        InvolvedFirearms: { value: 'No' },
+        InvolvedSubstances: { value: 'Yes' },
+        CourtName: { value: 'Test Court' },
+        CourtAddress: {
+          city: 'Somecity',
+          state: 'NY',
+          zipcode: '10022',
+          country: { value: 'United States' },
+        },
+        ChargeType: { value: 'Felony' },
+        CourtCharge: { value: 'My charges' },
+        CourtOutcome: { value: 'The outcome' },
+        CourtDate: { year: 2017, day: 3, month: 12 },
+        WasSentenced: { value: 'No' },
+        AwaitingTrial: { value: 'Yes' },
+        AwaitingTrialExplanation: { value: 'Something' },
+      }
+
+      expect(validateModel(testData, offense)).toEqual(true)
+    })
+  })
+})

--- a/src/models/otherOffense.js
+++ b/src/models/otherOffense.js
@@ -1,0 +1,51 @@
+import { hasYesOrNo, checkValue } from 'models/validate'
+import offenseAddress from 'models/shared/locations/offense'
+import sentence from 'models/shared/sentence'
+import { offenseChargeTypes } from 'constants/enums/legalOptions'
+
+const offense = {
+  Date: { presence: true, date: true },
+  Description: { presence: true, hasValue: true },
+  InvolvedViolence: {
+    presence: true,
+    hasValue: { validator: hasYesOrNo },
+  },
+  InvolvedFirearms: {
+    presence: true,
+    hasValue: { validator: hasYesOrNo },
+  },
+  InvolvedSubstances: {
+    presence: true,
+    hasValue: { validator: hasYesOrNo },
+  },
+  CourtName: { presence: true, hasValue: true },
+  CourtAddress: {
+    presence: true,
+    location: { validator: offenseAddress },
+  },
+  ChargeType: {
+    presence: true,
+    hasValue: { validator: { inclusion: offenseChargeTypes } },
+  },
+  CourtCharge: { presence: true, hasValue: true },
+  CourtOutcome: { presence: true, hasValue: true },
+  CourtDate: { presence: true, date: true },
+  WasSentenced: { presence: true, hasValue: { validator: hasYesOrNo } },
+  AwaitingTrial: (value, attributes) => (
+    checkValue(attributes.WasSentenced, 'No')
+      ? { presence: true, hasValue: { validator: hasYesOrNo } }
+      : {}
+  ),
+  AwaitingTrialExplanation: (value, attributes) => (
+    checkValue(attributes.WasSentenced, 'No')
+      ? { presence: true, hasValue: true }
+      : {}
+  ),
+  Sentence: (value, attributes) => (
+    checkValue(attributes.WasSentenced, 'Yes')
+      ? { presence: true, model: { validator: sentence } }
+      : {}
+  ),
+}
+
+export default offense

--- a/src/validators/otheroffense.js
+++ b/src/validators/otheroffense.js
@@ -1,113 +1,94 @@
-import LocationValidator from './location'
-import SentenceValidator from './sentence'
-import { validGenericTextfield, validDateField, validBranch } from './helpers'
+import { validateModel } from 'models/validate'
+import otherOffense from 'models/otherOffense'
+
+export const validateOtherOffense = data => validateModel(data, otherOffense) === true
 
 export default class OtherOffenseValidator {
   constructor(data = {}) {
-    this.date = data.Date
-    this.description = data.Description
-    this.involvedViolence = (data.InvolvedViolence || {}).value
-    this.involvedFirearms = (data.InvolvedFirearms || {}).value
-    this.involvedSubstances = (data.InvolvedSubstances || {}).value
-    this.agencyAddress = data.AgencyAddress
-    this.explanation = data.Explanation
-    this.courtName = data.CourtName
-    this.courtAddress = data.CourtAddress
-    this.chargeType = (data.ChargeType || {}).value
-    this.courtCharge = data.CourtCharge
-    this.courtOutcome = data.CourtOutcome
-    this.courtDate = data.CourtDate
-    this.sentence = data.Sentence
-    this.wasSentenced = (data.WasSentenced || {}).value
-    this.awaitingTrial = (data.AwaitingTrial || {}).value
-    this.awaitingTrialExplanation = data.AwaitingTrialExplanation
+    this.data = data
   }
 
   validDate() {
-    return !!this.date && validDateField(this.date)
+    return validateModel(this.data, {
+      Date: otherOffense.Date,
+    }) === true
   }
 
   validDescription() {
-    return !!this.description && validGenericTextfield(this.description)
+    return validateModel(this.data, {
+      Description: otherOffense.Description,
+    }) === true
   }
 
   validViolence() {
-    return this.involvedViolence === 'Yes' || this.involvedViolence === 'No'
+    return validateModel(this.data, {
+      InvolvedViolence: otherOffense.InvolvedViolence,
+    }) === true
   }
 
   validFirearms() {
-    return this.involvedFirearms === 'Yes' || this.involvedFirearms === 'No'
+    return validateModel(this.data, {
+      InvolvedFirearms: otherOffense.InvolvedFirearms,
+    }) === true
   }
 
   validSubstances() {
-    return this.involvedSubstances === 'Yes' || this.involvedSubstances === 'No'
+    return validateModel(this.data, {
+      InvolvedSubstances: otherOffense.InvolvedSubstances,
+    }) === true
   }
 
   validCourtName() {
-    return !!this.courtName && validGenericTextfield(this.courtName)
+    return validateModel(this.data, {
+      CourtName: otherOffense.CourtName,
+    }) === true
   }
 
   validCourtAddress() {
-    return (
-      !!this.courtAddress && new LocationValidator(this.courtAddress).isValid()
-    )
+    return validateModel(this.data, {
+      CourtAddress: otherOffense.CourtAddress,
+    }) === true
   }
 
   validChargeType() {
-    return (
-      !!this.chargeType &&
-      ['Felony', 'Misdemeanor', 'Other'].includes(this.chargeType)
-    )
+    return validateModel(this.data, {
+      ChargeType: otherOffense.ChargeType,
+    }) === true
   }
 
   validCourtCharge() {
-    return !!this.courtCharge && validGenericTextfield(this.courtCharge)
+    return validateModel(this.data, {
+      CourtCharge: otherOffense.CourtCharge,
+    }) === true
   }
 
   validCourtOutcome() {
-    return !!this.courtOutcome && validGenericTextfield(this.courtOutcome)
+    return validateModel(this.data, {
+      CourtOutcome: otherOffense.CourtOutcome,
+    }) === true
   }
 
   validCourtDate() {
-    return !!this.courtDate && validDateField(this.courtDate)
+    return validateModel(this.data, {
+      CourtDate: otherOffense.CourtDate,
+    }) === true
   }
 
   validSentenced() {
-    if (this.wasSentenced === 'No') {
-      return true
-    }
-
-    if (this.wasSentenced === 'Yes') {
-      return new SentenceValidator(this.sentence).isValid()
-    }
-
-    return false
+    return validateModel(this.data, {
+      WasSentenced: otherOffense.WasSentenced,
+      Sentence: otherOffense.Sentence,
+    }) === true
   }
 
   validAwaitingTrial() {
-    if (this.wasSentenced === 'No') {
-      return (
-        validBranch(this.awaitingTrial) &&
-        validGenericTextfield(this.awaitingTrialExplanation)
-      )
-    }
-    return true
+    return validateModel(this.data, {
+      AwaitingTrial: otherOffense.AwaitingTrial,
+      AwaitingTrialExplanation: otherOffense.AwaitingTrialExplanation,
+    }) === true
   }
 
   isValid() {
-    return (
-      this.validDate() &&
-      this.validDescription() &&
-      this.validViolence() &&
-      this.validFirearms() &&
-      this.validSubstances() &&
-      this.validCourtName() &&
-      this.validChargeType() &&
-      this.validCourtCharge() &&
-      this.validCourtOutcome() &&
-      this.validCourtDate() &&
-      this.validSentenced() &&
-      this.validAwaitingTrial()
-    )
+    return validateOtherOffense(this.data)
   }
 }

--- a/src/validators/policeotheroffenses.js
+++ b/src/validators/policeotheroffenses.js
@@ -1,23 +1,27 @@
-import OtherOffenseValidator from './otheroffense'
-import { validAccordion, validBranch } from './helpers'
+import { validateModel, hasYesOrNo, checkValue } from 'models/validate'
+import otherOffense from 'models/otherOffense'
+
+export const validatePoliceOtherOffenses = (data) => {
+  const policeOtherOffensesModel = {
+    HasOtherOffenses: { presence: true, hasValue: { validator: hasYesOrNo } },
+    List: (value, attributes) => (
+      checkValue(attributes.HasOtherOffenses, 'Yes')
+        ? {
+          presence: true,
+          accordion: { validator: otherOffense },
+        } : {}
+    ),
+  }
+
+  return validateModel(data, policeOtherOffensesModel) === true
+}
 
 export default class PoliceOtherOffensesValidator {
   constructor(data = {}) {
-    this.list = data.List || {}
-    this.hasOtherOffenses = (data.HasOtherOffenses || {}).value
-  }
-
-  validItems() {
-    if (this.hasOtherOffenses === 'No') {
-      return true
-    }
-
-    return validAccordion(this.list, item => {
-      return new OtherOffenseValidator(item).isValid()
-    })
+    this.data = data
   }
 
   isValid() {
-    return validBranch(this.hasOtherOffenses) && this.validItems()
+    return validatePoliceOtherOffenses(this.data)
   }
 }


### PR DESCRIPTION
## Description

- Create validation model and tests for Police Other Offenses (very similar to the Offense model added in https://github.com/18F/e-QIP-prototype/pull/1679)
- Also fixes EN-3798 -- root cause was two required fields in the `Sentence` component were not being rendered due to undefined props, preventing an additional offense with a sentence from being valid. This was likely introduced in the SF-85 branching work.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
