### PR TITLE
Re add the validation handler b/c it's where USPS geocoding calls are made (!)

### DIFF
--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -97,6 +97,7 @@ func main() {
 	a.Handle("/logout", sec.Middleware(http.LogoutHandler{Env: settings, Log: logger, Token: token, Database: database})).Methods("GET")
 	a.Handle("/save", sec.Middleware(http.SaveHandler{Env: settings, Log: logger, Token: token, Database: database, Store: store})).Methods("POST", "PUT")
 	a.Handle("/status", sec.Middleware(http.StatusHandler{Env: settings, Log: logger, Token: token, Database: database, Store: store})).Methods("GET")
+	a.Handle("/validate", sec.Middleware(http.ValidateHandler{Log: logger})).Methods("POST")
 	a.Handle("/form", sec.Middleware(http.FormHandler{Env: settings, Log: logger, Token: token, Database: database, Store: store})).Methods("GET")
 	a.Handle("/form/submit", sec.Middleware(http.SubmitHandler{Env: settings, Log: logger, Database: database, Store: store, Submitter: submitter})).Methods("POST")
 	a.Handle("/attachment", sec.Middleware(http.AttachmentListHandler{Env: settings, Log: logger, Token: token, Database: database, Store: store})).Methods("GET")

--- a/api/http/validate.go
+++ b/api/http/validate.go
@@ -1,0 +1,40 @@
+package http
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"github.com/18F/e-QIP-prototype/api"
+)
+
+// ValidateHandler is the handler for validating a payload.
+type ValidateHandler struct {
+	Log api.LogService
+}
+
+// ServeHTTP validates if the payload pass validation procedures.
+func (service ValidateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Read the body of the request (which should be in JSON)
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		service.Log.WarnError(api.PayloadEmpty, err, api.LogFields{})
+		EncodeErrJSON(w, err)
+		return
+	}
+
+	// Deserialize the initial payload from a JSON structure
+	payload := &api.Payload{}
+	if err := payload.Unmarshal(body); err != nil {
+		service.Log.WarnError(api.PayloadDeserializeError, err, api.LogFields{})
+		EncodeErrJSON(w, err)
+		return
+	}
+
+	// Extract the entity interface of the payload and validate it
+	if ok, err := payload.Valid(); !ok {
+		service.Log.WarnError(api.PayloadInvalid, err, api.LogFields{})
+		EncodeErrJSON(w, err)
+		return
+	}
+
+}


### PR DESCRIPTION
Additionally, it is not actually dependent on the DB for anything so it should keep working fine with simple storage

## Description

I deleted this handler during the simple storage migration. Validate can be used on many models and it will just return if the model is valid, but if you call it on a location, it will make an API call to the USPS website to validate the address via them. This is a bizarre crossing of the streams but there you go. At least the frontend doesn't call /validate for anything else, so it basically is just an api for calling the USPS validation. 

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)