### PR TITLE
Fix race condition in /save call

### DIFF
--- a/api/http/save.go
+++ b/api/http/save.go
@@ -70,7 +70,8 @@ func (service SaveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Save to storage and report any errors
-	if saveErr := service.Store.SaveSection(section, id); saveErr != nil {
+	saveErr := service.Store.SaveSection(section, id)
+	if saveErr != nil {
 		if saveErr == api.ErrApplicationDoesNotExist {
 			// if the application doesn't exist, we need to create it.
 			newApplication := api.BlankApplication(account.ID, account.FormType, account.FormVersion)
@@ -78,9 +79,23 @@ func (service SaveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			createErr := service.Store.CreateApplication(newApplication)
 			if createErr != nil {
-				service.Log.WarnError(api.EntitySaveError, createErr, api.LogFields{})
-				RespondWithStructuredError(w, api.EntitySaveError, http.StatusInternalServerError)
-				return
+				// This should happen but rarely, but there is a race condition here where multiple /save calls
+				// get ApplicationDoesNotExist above. In that case, some of them will get ApplicationExists here,
+				// but it's safe for them to just try again.
+				if createErr == api.ErrApplicationAlreadyExists {
+					service.Log.Info("Having to double save due to /save race", api.LogFields{})
+					saveAgainErr := service.Store.SaveSection(section, id)
+					if saveAgainErr != nil {
+						// this time, nothing will save you.
+						service.Log.WarnError(api.EntitySaveError, saveAgainErr, api.LogFields{})
+						RespondWithStructuredError(w, api.EntitySaveError, http.StatusInternalServerError)
+						return
+					}
+				} else {
+					service.Log.WarnError(api.EntitySaveError, createErr, api.LogFields{})
+					RespondWithStructuredError(w, api.EntitySaveError, http.StatusInternalServerError)
+					return
+				}
 			}
 		} else {
 			service.Log.WarnError(api.EntitySaveError, saveErr, api.LogFields{})

--- a/api/http/save.go
+++ b/api/http/save.go
@@ -83,7 +83,7 @@ func (service SaveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				// get ApplicationDoesNotExist above. In that case, some of them will get ApplicationExists here,
 				// but it's safe for them to just try again.
 				if createErr == api.ErrApplicationAlreadyExists {
-					service.Log.Info("Having to double save due to /save race", api.LogFields{})
+					service.Log.Debug("Having to double save due to /save race", api.LogFields{})
 					saveAgainErr := service.Store.SaveSection(section, id)
 					if saveAgainErr != nil {
 						// this time, nothing will save you.

--- a/api/simplestore/applications.go
+++ b/api/simplestore/applications.go
@@ -19,6 +19,9 @@ func runCreateApplication(conn simpleConnection, serializer api.Serializer, app 
 
 	_, saveErr := conn.Exec(saveQuery, app.AccountID, serializedApp)
 	if saveErr != nil {
+		if saveErr.Error() == "pq: duplicate key value violates unique constraint \"applications_pkey\"" {
+			return api.ErrApplicationAlreadyExists
+		}
 		return errors.Wrap(saveErr, "Failed to create Application")
 	}
 

--- a/api/simplestore/applications_test.go
+++ b/api/simplestore/applications_test.go
@@ -140,6 +140,11 @@ func TestSaveSection(t *testing.T) {
 		t.Fatal(createErr)
 	}
 
+	createAgainErr := store.CreateApplication(newApplication)
+	if createAgainErr != api.ErrApplicationAlreadyExists {
+		t.Fatal("Should have gotten an already exists error", createAgainErr)
+	}
+
 	app, loadErr := store.LoadApplication(accountID)
 	if loadErr != nil {
 		t.Fatal(loadErr)

--- a/api/store.go
+++ b/api/store.go
@@ -8,6 +8,9 @@ var (
 	// ErrApplicationDoesNotExist is an error when a given application does not exist
 	ErrApplicationDoesNotExist = errors.New("Application does not exist")
 
+	// ErrApplicationAlreadyExists is an error when a given application does not exist
+	ErrApplicationAlreadyExists = errors.New("Application already exists")
+
 	// ErrAttachmentDoesNotExist is returned when the requested attchment does not exist.
 	// Note: this could mean that you requested a valid ID but for a different user.
 	ErrAttachmentDoesNotExist = errors.New("Attachment does not exist")


### PR DESCRIPTION
## Description

The new save implementation introduced a race condition where data could be lost if too many save calls were happening when there wasn't yet an application row for the given user. Fix is just to try and update again if you fail both to update and then create. There are definitely faster solutions to this problem but since it is only possible for it to happen to a user when they are filling out their first section and then never again it doesn't seem worth the complication. 

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)