### PR TITLE
[EN-3715] Validation Refactor - Citizenship / Foreign Passports

### DIFF
--- a/src/models/__tests__/foreignPassport.test.js
+++ b/src/models/__tests__/foreignPassport.test.js
@@ -1,0 +1,222 @@
+import { validateModel } from 'models/validate'
+import foreignPassport from '../foreignPassport'
+
+describe('The foreignPassport model', () => {
+  it('Country is required', () => {
+    const testData = {}
+    const expectedErrors = ['Country.required']
+
+    expect(validateModel(testData, foreignPassport))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Country must have a value', () => {
+    const testData = { Country: 'Canada' }
+    const expectedErrors = ['Country.hasValue']
+
+    expect(validateModel(testData, foreignPassport))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Issued is required', () => {
+    const testData = {}
+    const expectedErrors = ['Issued.required']
+
+    expect(validateModel(testData, foreignPassport))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Issued must be a valid date', () => {
+    const testData = { Issued: 'May 2 1990' }
+    const expectedErrors = ['Issued.date']
+
+    expect(validateModel(testData, foreignPassport))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Location is required', () => {
+    const testData = {}
+    const expectedErrors = ['Location.required']
+
+    expect(validateModel(testData, foreignPassport))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Location must be a valid location', () => {
+    const testData = {
+      Location: {
+        city: 'Test city',
+      },
+    }
+    const expectedErrors = ['Location.location']
+
+    expect(validateModel(testData, foreignPassport))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Name is required', () => {
+    const testData = {}
+    const expectedErrors = ['Name.required']
+
+    expect(validateModel(testData, foreignPassport))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Name must be a valid name', () => {
+    const testData = {
+      Name: {
+        first: 'Tester',
+        last: 'Person',
+      },
+    }
+    const expectedErrors = ['Name.model']
+
+    expect(validateModel(testData, foreignPassport))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Number is required', () => {
+    const testData = {}
+    const expectedErrors = ['Number.required']
+
+    expect(validateModel(testData, foreignPassport))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Number must have a value', () => {
+    const testData = { Number: '123' }
+    const expectedErrors = ['Number.hasValue']
+
+    expect(validateModel(testData, foreignPassport))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Expiration is required', () => {
+    const testData = {}
+    const expectedErrors = ['Expiration.required']
+
+    expect(validateModel(testData, foreignPassport))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Expiration must be a valid date', () => {
+    const testData = { Expiration: 'May 2 1990' }
+    const expectedErrors = ['Expiration.date']
+
+    expect(validateModel(testData, foreignPassport))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Used is required', () => {
+    const testData = {}
+    const expectedErrors = ['Used.required']
+
+    expect(validateModel(testData, foreignPassport))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Used must have a valid value', () => {
+    const testData = { Used: 'true' }
+    const expectedErrors = ['Used.hasValue']
+
+    expect(validateModel(testData, foreignPassport))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if Used is "No"', () => {
+    it('Countries are not required', () => {
+      const testData = { Used: { value: 'No' } }
+      const expectedErrors = ['Countries.required']
+
+      expect(validateModel(testData, foreignPassport))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid foreign passport', () => {
+      const testData = {
+        Country: { value: 'Canada' },
+        Issued: { year: 2015, month: 5, day: 2 },
+        Location: { city: 'Toronto', country: 'Canada' },
+        Name: {
+          first: 'Tester',
+          noMiddleName: true,
+          last: 'Person',
+        },
+        Number: { value: '123abc345' },
+        Expiration: { year: 2025, month: 5, day: 2 },
+        Used: { value: 'No' },
+      }
+
+      expect(validateModel(testData, foreignPassport)).toEqual(true)
+    })
+  })
+
+  describe('if Used is "Yes"', () => {
+    it('Countries are required', () => {
+      const testData = { Used: { value: 'Yes' } }
+      const expectedErrors = ['Countries.required']
+
+      expect(validateModel(testData, foreignPassport))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('Countries must be valid foreign passport travel items', () => {
+      const testData = {
+        Used: { value: 'Yes' },
+        Countries: {
+          items: [
+            {
+              Item: {
+                Country: 'invalid',
+              },
+            },
+          ],
+        },
+      }
+      const expectedErrors = ['Countries.accordion']
+
+      expect(validateModel(testData, foreignPassport))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid foreign passport', () => {
+      const testData = {
+        Country: { value: 'Canada' },
+        Issued: { year: 2015, month: 5, day: 2 },
+        Location: { city: 'Toronto', country: 'Canada' },
+        Name: {
+          first: 'Tester',
+          noMiddleName: true,
+          last: 'Person',
+        },
+        Number: { value: '123abc345' },
+        Expiration: { year: 2025, month: 5, day: 2 },
+        Used: { value: 'Yes' },
+        Countries: {
+          items: [
+            {
+              Item: {
+                Country: { value: 'Germany' },
+                Dates: {
+                  from: { year: 2017, month: 1, day: 2 },
+                  to: { year: 2017, month: 1, day: 20 },
+                },
+              },
+            },
+            {
+              Item: {
+                Country: { value: 'United Kingdom' },
+                Dates: {
+                  from: { year: 2018, month: 12, day: 2 },
+                  to: { year: 2019, month: 1, day: 3 },
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      expect(validateModel(testData, foreignPassport)).toEqual(true)
+    })
+  })
+})

--- a/src/models/__tests__/foreignPassportTravel.test.js
+++ b/src/models/__tests__/foreignPassportTravel.test.js
@@ -1,0 +1,53 @@
+import { validateModel } from 'models/validate'
+import foreignPassportTravel from '../foreignPassportTravel'
+
+describe('The foreignPassportTravel model', () => {
+  it('Country is required', () => {
+    const testData = {}
+    const expectedErrors = ['Country.required']
+
+    expect(validateModel(testData, foreignPassportTravel))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Country must have a value', () => {
+    const testData = { Country: 'Canada' }
+    const expectedErrors = ['Country.hasValue']
+
+    expect(validateModel(testData, foreignPassportTravel))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Dates are required', () => {
+    const testData = {}
+    const expectedErrors = ['Dates.required']
+
+    expect(validateModel(testData, foreignPassportTravel))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Dates must be a valid date range', () => {
+    const testData = {
+      Dates: {
+        from: { year: 2010, day: 2, month: 5 },
+        to: { year: 2010, day: 1, month: 3 },
+      },
+    }
+    const expectedErrors = ['Dates.daterange']
+
+    expect(validateModel(testData, foreignPassportTravel))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid foreign passport travel', () => {
+    const testData = {
+      Country: { value: 'Germany' },
+      Dates: {
+        from: { year: 2010, day: 2, month: 5 },
+        to: { year: 2010, day: 1, month: 6 },
+      },
+    }
+
+    expect(validateModel(testData, foreignPassportTravel)).toEqual(true)
+  })
+})

--- a/src/models/foreignPassport.js
+++ b/src/models/foreignPassport.js
@@ -1,0 +1,32 @@
+import { checkValue, hasYesOrNo } from 'models/validate'
+import cityCountry from 'models/shared/locations/cityCountry'
+import name from 'models/shared/name'
+import foreignPassportTravel from 'models/foreignPassportTravel'
+
+const foreignPassport = {
+  Country: { presence: true, hasValue: true },
+  Issued: { presence: true, date: true },
+  Location: {
+    presence: true,
+    location: { validator: cityCountry },
+  },
+  Name: {
+    presence: true,
+    model: { validator: name },
+  },
+  Number: { presence: true, hasValue: true },
+  Expiration: { presence: true, date: true },
+  Used: { presence: true, hasValue: { validator: hasYesOrNo } },
+  Countries: (value, attributes) => (
+    checkValue(attributes.Used, 'Yes')
+      ? {
+        presence: true,
+        accordion: {
+          validator: foreignPassportTravel,
+          ignoreBranch: true,
+        },
+      } : {}
+  ),
+}
+
+export default foreignPassport

--- a/src/models/foreignPassportTravel.js
+++ b/src/models/foreignPassportTravel.js
@@ -1,0 +1,6 @@
+const foreignPassportTravel = {
+  Country: { presence: true, hasValue: true },
+  Dates: { presence: true, daterange: true },
+}
+
+export default foreignPassportTravel

--- a/src/models/shared/locations/__tests__/cityCountry.test.js
+++ b/src/models/shared/locations/__tests__/cityCountry.test.js
@@ -1,0 +1,42 @@
+import { validateModel } from 'models/validate'
+import cityCountry from '../cityCountry'
+
+describe('The location/cityCountry model', () => {
+  it('city is required', () => {
+    const testData = { city: '' }
+    const expectedErrors = ['city.required']
+
+    expect(validateModel(testData, cityCountry))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('country is required', () => {
+    const testData = { country: '' }
+    const expectedErrors = ['country.required']
+
+    expect(validateModel(testData, cityCountry))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('for a domestic address', () => {
+    it('passes a valid domestic address', () => {
+      const testData = {
+        city: 'New York',
+        country: 'United States',
+      }
+
+      expect(validateModel(testData, cityCountry)).toEqual(true)
+    })
+  })
+
+  describe('for an international address', () => {
+    it('passes a valid international address', () => {
+      const testData = {
+        city: 'Toronto',
+        country: 'Canada',
+      }
+
+      expect(validateModel(testData, cityCountry)).toEqual(true)
+    })
+  })
+})

--- a/src/models/shared/locations/cityCountry.js
+++ b/src/models/shared/locations/cityCountry.js
@@ -1,0 +1,8 @@
+import locationModel from '../location'
+
+const locationCityCountry = {
+  city: locationModel.city,
+  country: locationModel.country,
+}
+
+export default locationCityCountry

--- a/src/models/validators/__tests__/accordion.test.js
+++ b/src/models/validators/__tests__/accordion.test.js
@@ -2,18 +2,32 @@ import accordion from '../accordion'
 
 describe('The accordion validator', () => {
   it('fails if items is undefined', () => {
-    const testData = { items: undefined }
-    expect(accordion(testData)).toBeTruthy()
+    const testData = { items: undefined, branch: { value: 'No' } }
+    const validator = { value: { email: true } }
+    expect(accordion(testData, { validator })).toEqual('No items')
   })
 
   it('fails if there are no items', () => {
-    const testData = { items: [] }
-    expect(accordion(testData)).toBeTruthy()
+    const testData = { items: [], branch: { value: 'No' } }
+    const validator = { value: { email: true } }
+    expect(accordion(testData, { validator })).toEqual('No items')
   })
 
   it('fails if there is no validator', () => {
     const testData = { items: [{ Item: 'Thing' }] }
-    expect(accordion(testData)).toBeTruthy()
+    expect(accordion(testData)).toEqual('Invalid validator')
+  })
+
+  it('fails if there is no branch value', () => {
+    const testData = { items: [] }
+    const validator = { value: { email: true } }
+    expect(accordion(testData, { validator })).toEqual('Invalid branch')
+  })
+
+  it('fails if the branch value is not "No"', () => {
+    const testData = { items: [], branch: { value: 'Yes' } }
+    const validator = { value: { email: true } }
+    expect(accordion(testData, { validator })).toEqual('Invalid branch')
   })
 
   it('fails if any of the items fail the validator', () => {
@@ -23,6 +37,7 @@ describe('The accordion validator', () => {
         { Item: { value: 'email@gmail.com' } },
         { Item: { value: '' } },
       ],
+      branch: { value: 'No' },
     }
 
     const validator = { value: { email: true } }
@@ -54,7 +69,7 @@ describe('The accordion validator', () => {
       }
 
       const validator = { value: { email: true } }
-      expect(accordion(testData, { validator, length: { minimum: 3 } })).toBeTruthy()
+      expect(accordion(testData, { validator, length: { minimum: 3 } })).toEqual(['items.length'])
     })
 
     it('passes if there are enough items to pass the length validator', () => {
@@ -69,6 +84,33 @@ describe('The accordion validator', () => {
 
       const validator = { value: { email: true } }
       expect(accordion(testData, { validator, length: { minimum: 3 } })).toBeNull()
+    })
+  })
+
+  describe('with the ignoreBranch option', () => {
+    it('does not fail if there is no branch value', () => {
+      const testData = { items: [] }
+      const validator = { value: { email: true } }
+      expect(accordion(testData, { validator, ignoreBranch: true })).not.toEqual('Invalid branch')
+    })
+
+    it('does not fail if the branch value is not "No"', () => {
+      const testData = { items: [], branch: { value: 'Yes' } }
+      const validator = { value: { email: true } }
+      expect(accordion(testData, { validator, ignoreBranch: true })).not.toEqual('Invalid branch')
+    })
+
+    it('passes a valid accordion with no branch', () => {
+      const testData = {
+        items: [
+          { Item: { value: 'myemail@yahoo.com' } },
+          { Item: { value: 'email@gmail.com' } },
+          { Item: { value: 'another@email.org' } },
+        ],
+      }
+
+      const validator = { value: { email: true } }
+      expect(accordion(testData, { validator, ignoreBranch: true })).toBeNull()
     })
   })
 })

--- a/src/models/validators/accordion.js
+++ b/src/models/validators/accordion.js
@@ -4,16 +4,18 @@ import { validateModel } from 'models/validate'
 const accordionValidator = (value, options = {}) => {
   if (validate.isEmpty(value)) return null // Don't validate if there is no value
 
-  const { validator, length } = options
+  const { validator, length, ignoreBranch } = options
   if (!validator) return 'Invalid validator'
 
   const { items, branch } = value
-  if (!branch || !branch.value || branch.value !== 'No') {
+  // Validate branch
+  if (!ignoreBranch && (!branch || !branch.value || branch.value !== 'No')) {
     return 'Invalid branch'
   }
 
   if (!items || (items && items.length < 1)) return 'No items'
 
+  // Validate item length
   if (length) {
     const lengthErrors = validateModel({ items }, { items: { length } })
     if (lengthErrors !== true) return lengthErrors

--- a/src/validators/citizenship-passports.js
+++ b/src/validators/citizenship-passports.js
@@ -1,121 +1,113 @@
-import DateRangeValidator from './daterange'
-import LocationValidator from './location'
-import NameValidator from './name'
-import {
-  validAccordion,
-  validGenericTextfield,
-  validDateField,
-  BranchCollection
-} from './helpers'
+import { validateModel } from 'models/validate'
+import foreignPassport from 'models/foreignPassport'
+import foreignPassportTravel from 'models/foreignPassportTravel'
+
+export const validateForeignPassportTravel = data => (
+  validateModel(data, foreignPassportTravel) === true)
+
+export const validateForeignPassport = data => (
+  validateModel(data, foreignPassport) === true)
+
+export const validateCitizenshipPassports = (data) => {
+  const citizenshipPassportsModel = {
+    Passports: {
+      presence: true,
+      branchCollection: {
+        validator: foreignPassport,
+      },
+    },
+  }
+
+  return validateModel(data, citizenshipPassportsModel) === true
+}
 
 export default class CitizenshipPassportsValidator {
   constructor(data = {}) {
-    this.passports = data.Passports || []
-  }
-
-  validPassports() {
-    const bc = new BranchCollection(this.passports)
-    if (!bc.validKeyValues()) {
-      return false
-    }
-
-    if (bc.hasNo()) {
-      return true
-    }
-
-    return bc.each(item => {
-      return new PassportItemValidator(item.Item, null).isValid()
-    })
+    this.data = data
   }
 
   isValid() {
-    return this.validPassports()
+    return validateCitizenshipPassports(this.data)
   }
 }
 
 export class PassportItemValidator {
   constructor(data = {}) {
-    this.country = data.Country
-    this.issued = data.Issued
-    this.location = data.Location
-    this.name = data.Name
-    this.number = data.Number
-    this.expiration = data.Expiration
-    this.used = (data.Used || {}).value
-    this.countries = data.Countries || {}
+    this.data = data
   }
 
   validCountry() {
-    return validGenericTextfield(this.country)
+    return validateModel(this.data, {
+      Country: foreignPassport.Country,
+    }) === true
   }
 
   validIssued() {
-    return !!this.issued && validDateField(this.issued)
+    return validateModel(this.data, {
+      Issued: foreignPassport.Issued,
+    }) === true
   }
 
   validLocation() {
-    return !!this.location && new LocationValidator(this.location).isValid()
+    return validateModel(this.data, {
+      Location: foreignPassport.Location,
+    }) === true
   }
 
   validName() {
-    return !!this.name && new NameValidator(this.name).isValid()
+    return validateModel(this.data, {
+      Name: foreignPassport.Name,
+    }) === true
   }
 
   validNumber() {
-    return !!this.number && validGenericTextfield(this.number)
+    return validateModel(this.data, {
+      Number: foreignPassport.Number,
+    }) === true
   }
 
   validExpiration() {
-    return !!this.expiration && validDateField(this.expiration)
+    return validateModel(this.data, {
+      Expiration: foreignPassport.Expiration,
+    }) === true
   }
 
   validUsed() {
-    return !!this.used && (this.used === 'Yes' || this.used === 'No')
+    return validateModel(this.data, {
+      Used: foreignPassport.Used,
+    }) === true
   }
 
   validCountries() {
-    if (this.used !== 'Yes') {
-      return true
-    }
-
-    return validAccordion(
-      this.countries,
-      item => {
-        return new TravelItemValidator(item).isValid()
-      },
-      true
-    )
+    return validateModel(this.data, {
+      Used: foreignPassport.Used,
+      Countries: foreignPassport.Countries,
+    }) === true
   }
 
   isValid() {
-    return (
-      this.validCountry() &&
-      this.validIssued() &&
-      this.validLocation() &&
-      this.validName() &&
-      this.validNumber() &&
-      this.validExpiration() &&
-      this.validUsed() &&
-      this.validCountries()
-    )
+    return validateForeignPassport(this.data)
   }
 }
 
 export class TravelItemValidator {
   constructor(data = {}) {
-    this.country = data.Country
-    this.dates = data.Dates
+    this.data = data
   }
 
   validCountry() {
-    return validGenericTextfield(this.country)
+    return validateModel(this.data, {
+      Country: foreignPassportTravel.Country,
+    }) === true
   }
 
   validDates() {
-    return !!this.dates && new DateRangeValidator(this.dates, null).isValid()
+    return validateModel(this.data, {
+      Dates: foreignPassportTravel.Dates,
+    }) === true
   }
 
   isValid() {
-    return this.validCountry() && this.validDates()
+    return validateForeignPassportTravel(this.data)
   }
 }


### PR DESCRIPTION
## Description

- Models, tests, and validator for Foreign Passports (and Foreign Passport Travel items)
- Also adds `ignoreBranch` option to accordion validator

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
