### PR TITLE
[EN-3739] Enable CSS Modules

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -17,7 +17,33 @@ module.exports = async ({ config, mode }) => {
       rules: [
         ...config.module.rules,
         {
+          test: /\.module\.scss$/,
+          use: [
+            { loader: 'style-loader' },
+            {
+              loader: 'css-loader',
+              options: {
+                modules: true,
+                localIdentName: '[name]__[local]--[hash:base64:5]',
+              },
+            },
+            { loader: 'sass-loader' },
+            {
+              loader: 'sass-resources-loader',
+              options: {
+                resources: [
+                  './node_modules/uswds/src/stylesheets/lib/addons/_font-stacks.scss',
+                  './node_modules/uswds/src/stylesheets/core/_variables.scss',
+                  './src/sass/_eqip-colors.scss',
+                  './src/sass/_eqip-fonts.scss',
+                ],
+              },
+            },
+          ],
+        },
+        {
           test: /\.scss$/,
+          exclude: /\.module\.scss$/,
           use: [
             { loader: 'style-loader' },
             { loader: 'css-loader' },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,10 @@
     },
     "setupFiles": [
       "<rootDir>/node_modules/regenerator-runtime/runtime"
-    ]
+    ],
+    "moduleNameMapper": {
+      "\\.(css|scss)$": "identity-obj-proxy"
+    }
   },
   "scripts": {
     "test": "NODE_ENV=test jest",
@@ -123,6 +126,7 @@
     "html-webpack-plugin": "^3.2.0",
     "husky": "^1.3.1",
     "i18n-extract": "^0.6.3",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^24.8.0",
     "mini-css-extract-plugin": "^0.5.0",
     "node-sass": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "mini-css-extract-plugin": "^0.5.0",
     "node-sass": "^4.11.0",
     "sass-loader": "^7.1.0",
+    "sass-resources-loader": "^2.0.1",
     "storybook-react-router": "^1.0.5",
     "style-loader": "^0.23.1",
     "webpack": "^4.29.0",

--- a/src/components/Main/__snapshots__/App.test.jsx.snap
+++ b/src/components/Main/__snapshots__/App.test.jsx.snap
@@ -881,7 +881,7 @@ exports[`App component for the SF85 renders the homepage 1`] = `
         className="eapp-structure-left eapp-navigation mobile-hidden"
       >
         <div
-          className="score-card"
+          className="ScoreCard score-card"
         >
           <span
             className="score-card-done"
@@ -895,7 +895,7 @@ exports[`App component for the SF85 renders the homepage 1`] = `
             7
           </span>
           <span
-            className="score-card-text"
+            className="text score-card-text"
           >
             Sections complete
           </span>
@@ -3044,7 +3044,7 @@ exports[`App component for the SF85P renders the homepage 1`] = `
         className="eapp-structure-left eapp-navigation mobile-hidden"
       >
         <div
-          className="score-card"
+          className="ScoreCard score-card"
         >
           <span
             className="score-card-done"
@@ -3058,7 +3058,7 @@ exports[`App component for the SF85P renders the homepage 1`] = `
             9
           </span>
           <span
-            className="score-card-text"
+            className="text score-card-text"
           >
             Sections complete
           </span>
@@ -5811,7 +5811,7 @@ exports[`App component for the SF86 renders the homepage 1`] = `
         className="eapp-structure-left eapp-navigation mobile-hidden"
       >
         <div
-          className="score-card"
+          className="ScoreCard score-card"
         >
           <span
             className="score-card-done"
@@ -5825,7 +5825,7 @@ exports[`App component for the SF86 renders the homepage 1`] = `
             10
           </span>
           <span
-            className="score-card-text"
+            className="text score-card-text"
           >
             Sections complete
           </span>

--- a/src/components/ScoreCard/ScoreCard.jsx
+++ b/src/components/ScoreCard/ScoreCard.jsx
@@ -7,10 +7,18 @@ import i18n from 'util/i18n'
 
 import { totalSections, completedSections } from 'helpers/navigation'
 
+import styles from './ScoreCard.module.scss'
+
 export const ScoreCard = ({ total, completed }) => {
   const scoreCardClasses = classnames(
+    styles.ScoreCard,
     'score-card',
-    { completed: completed >= total }
+    { [`${styles.completed}`]: completed >= total }
+  )
+
+  const textClasses = classnames(
+    styles.text,
+    'score-card-text',
   )
 
   return (
@@ -18,7 +26,7 @@ export const ScoreCard = ({ total, completed }) => {
       <span className="score-card-done">{completed}</span>
       /
       <span className="score-card-total">{total}</span>
-      <span className="score-card-text">{i18n.t('scorecard.complete')}</span>
+      <span className={textClasses}>{i18n.t('scorecard.complete')}</span>
     </div>
   )
 }

--- a/src/components/ScoreCard/ScoreCard.module.scss
+++ b/src/components/ScoreCard/ScoreCard.module.scss
@@ -1,4 +1,4 @@
-.score-card {
+.ScoreCard {
   font-size: 5rem;
   font-weight: $eapp-bold;
   color: $eapp-grey-darker;
@@ -11,7 +11,7 @@
     color: $eapp-green;
   }
 
-  .score-card-text {
+  .text {
     display: block;
     font-size: 1.9rem;
   }

--- a/src/eqip.scss
+++ b/src/eqip.scss
@@ -63,7 +63,6 @@ $fa-font-path: '/fonts/';
 @import 'components/Navigation/ToggleItem';
 @import 'components/ProgressBar/ProgressBar';
 @import 'components/SavedIndicator/SavedIndicator';
-@import 'components/ScoreCard/ScoreCard';
 @import 'components/Section/Citizenship/Citizenship';
 @import 'components/Section/Citizenship/UsPassport/UsPassport';
 @import 'components/Section/Citizenship/Multiple/Multiple';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,38 +12,75 @@ module.exports = {
   mode: production ? 'production' : 'development',
   entry: {
     polyfills: './src/polyfills.js',
-    eqip: './src/boot.jsx'
+    eqip: './src/boot.jsx',
   },
   output: {
     filename: '[name].[contenthash].js',
     path: path.resolve(__dirname, 'dist', 'js'),
-    publicPath: '/js/'
+    publicPath: '/js/',
   },
   resolve: {
-    extensions: ['.js', '.jsx']
+    extensions: ['.js', '.jsx'],
   },
   module: {
     rules: [
       {
         test: /\.jsx?$/,
         include: path.resolve(__dirname, 'src'),
-        use: ['cache-loader', 'babel-loader']
+        use: ['cache-loader', 'babel-loader'],
       },
       {
-        test: /\.scss$/,
+        test: /\.module\.scss$/,
         use: [
           MiniCssExtractPlugin.loader,
-          { loader: 'css-loader', options: { url: false, sourceMap: true } },
+          {
+            loader: 'css-loader',
+            options: {
+              url: false,
+              sourceMap: true,
+              modules: true,
+              localIdentName: '[name]__[local]--[hash:base64:5]',
+            },
+          },
           {
             loader: 'sass-loader',
             options: {
               sourceMap: true,
-              includePaths: [path.resolve(__dirname, 'src', 'sass')]
-            }
-          }
-        ]
-      }
-    ]
+              includePaths: [path.resolve(__dirname, 'src', 'sass')],
+            },
+          },
+          {
+            loader: 'sass-resources-loader',
+            options: {
+              resources: [
+                './node_modules/uswds/src/stylesheets/lib/addons/_font-stacks.scss',
+                './node_modules/uswds/src/stylesheets/core/_variables.scss',
+                './src/sass/_eqip-colors.scss',
+                './src/sass/_eqip-fonts.scss',
+              ],
+            },
+          },
+        ],
+      },
+      {
+        test: /\.scss$/,
+        exclude: /\.module\.scss$/,
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            options: { url: false, sourceMap: true },
+          },
+          {
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true,
+              includePaths: [path.resolve(__dirname, 'src', 'sass')],
+            },
+          },
+        ],
+      },
+    ],
   },
   optimization: {
     runtimeChunk: 'single',
@@ -52,10 +89,10 @@ module.exports = {
         vendor: {
           test: /[\\/]node_modules[\\/]/,
           name: 'vendors',
-          chunks: 'all'
-        }
-      }
-    }
+          chunks: 'all',
+        },
+      },
+    },
   },
   devtool: debug ? 'cheap-module-source-map' : 'source-map',
   plugins: [
@@ -69,22 +106,22 @@ module.exports = {
       'SESSION_TIMEOUT',
       'ATTACHMENTS_ENABLED',
       'FILE_MAXIMUM_SIZE',
-      'FILE_TYPES'
+      'FILE_TYPES',
     ]),
     new webpack.DefinePlugin({
       EAPP_VERSION: JSON.stringify(
         new GitRevisionPlugin({
-          versionCommand: 'describe --tags --always'
+          versionCommand: 'describe --tags --always',
         }).version()
-      )
+      ),
     }),
     new CleanWebpackPlugin(['dist/js', 'dist/css']),
     new MiniCssExtractPlugin({
-      filename: '../css/[name].[contenthash].css'
+      filename: '../css/[name].[contenthash].css',
     }),
     new HtmlWebpackPlugin({
       filename: '../index.html',
-      template: './src/index.html'
-    })
-  ]
+      template: './src/index.html',
+    }),
+  ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6976,6 +6976,11 @@ har-validator@~5.1.0:
     ajv "^6.5.5"
     har-schema "^2.0.0"
 
+harmony-reflect@^1.4.6:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.1.tgz#c108d4f2bb451efef7a37861fdbdae72c9bdefa9"
+  integrity sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA==
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -7347,6 +7352,13 @@ icss-utils@^4.1.0:
   integrity sha512-3DEun4VOeMvSczifM3F2cKQrDQ5Pj6WKhkOq6HD4QTnDUAq8MQRxy5TX6Sy1iY6WPBe4gQ3p5vTECjbIkglkkQ==
   dependencies:
     postcss "^7.0.14"
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  integrity sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ieee754@^1.1.4:
   version "1.1.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8837,7 +8837,7 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
-loader-utils@1.2.3, loader-utils@^1.0.1, loader-utils@^1.2.1, loader-utils@^1.2.3:
+loader-utils@1.2.3, loader-utils@^1.0.1, loader-utils@^1.0.4, loader-utils@^1.2.1, loader-utils@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
@@ -12322,6 +12322,16 @@ sass-loader@^7.1.0:
     neo-async "^2.5.0"
     pify "^3.0.0"
     semver "^5.5.0"
+
+sass-resources-loader@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/sass-resources-loader/-/sass-resources-loader-2.0.1.tgz#c8427f3760bf7992f24f27d3889a1c797e971d3a"
+  integrity sha512-UsjQWm01xglINC1kPidYwKOBBzOElVupm9RwtOkRlY0hPA4GKi2KFsn4BZypRD1kudaXgUnGnfbiVOE7c+ybAg==
+  dependencies:
+    async "^2.1.4"
+    chalk "^1.1.3"
+    glob "^7.1.1"
+    loader-utils "^1.0.4"
 
 sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"


### PR DESCRIPTION
## Description

This PR enables CSS module (https://github.com/css-modules/css-modules) processing on files ending in `.module.scss`. This will allow us to write locally scoped CSS to components, and reduce risk of side effects. Changes include:
- Added `sass-resource-loader` so that SCSS variables can be used in CSS module files
- Configured CSS modules in project webpack and Storybook webpack
- Convert `ScoreCard.scss` to `ScoreCard.module.scss` as an example, and include in the `ScoreCard.jsx` component (existing class names are also retained).

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
