### PR TITLE
[EN-3802] Fix CivilUnion address validation

### DIFF
--- a/src/models/__tests__/civilUnion.test.js
+++ b/src/models/__tests__/civilUnion.test.js
@@ -110,12 +110,12 @@ describe('The civilUnion model', () => {
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
-  it('the Address field is not required', () => {
+  it('the Address field is required', () => {
     const testData = {}
     const expectedErrors = ['Address.required']
 
     expect(validateModel(testData, civilUnion))
-      .not.toEqual(expect.arrayContaining(expectedErrors))
+      .toEqual(expect.arrayContaining(expectedErrors))
   })
 
   it('the Address field must be a valid location', () => {
@@ -129,6 +129,19 @@ describe('The civilUnion model', () => {
 
     expect(validateModel(testData, civilUnion))
       .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if UseCurrentAddress is checked', () => {
+    it('the Address field is not required', () => {
+      const testData = {
+        UseCurrentAddress: { applicable: true },
+      }
+
+      const expectedErrors = ['Address.required']
+
+      expect(validateModel(testData, civilUnion))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
   })
 
   it('the Location field is required', () => {
@@ -251,6 +264,7 @@ describe('The civilUnion model', () => {
         Telephone: { number: '1234567890', type: 'Domestic', timeOfDay: 'Both' },
         SSN: { first: '234', middle: '12', last: '3490' },
         Separated: { value: 'No' },
+        UseCurrentAddress: { applicable: true },
         Location: {
           city: 'Boston', state: 'MA', country: 'United States', county: 'County',
         },
@@ -334,6 +348,14 @@ describe('The civilUnion model', () => {
         Telephone: { number: '1234567890', type: 'Domestic', timeOfDay: 'Both' },
         SSN: { first: '234', middle: '12', last: '3490' },
         Separated: { value: 'Yes' },
+        Address: {
+          street: '123 Test St',
+          city: 'Boston',
+          state: 'MA',
+          zipcode: '02421',
+          country: 'United States',
+          county: 'County',
+        },
         Location: {
           city: 'Boston', state: 'MA', country: 'United States', county: 'County',
         },
@@ -379,6 +401,7 @@ describe('The civilUnion model', () => {
           Telephone: { number: '1234567890', type: 'Domestic', timeOfDay: 'Both' },
           SSN: { first: '234', middle: '12', last: '3490' },
           Separated: { value: 'Yes' },
+          UseCurrentAddress: { applicable: true },
           Location: {
             city: 'Boston', state: 'MA', country: 'United States', county: 'County',
           },
@@ -430,6 +453,7 @@ describe('The civilUnion model', () => {
         Telephone: { number: '1234567890', type: 'Domestic', timeOfDay: 'Both' },
         SSN: { first: '234', middle: '12', last: '3490' },
         Separated: { value: 'No' },
+        UseCurrentAddress: { applicable: true },
         Location: {
           city: 'Boston', state: 'MA', country: 'United States', county: 'County',
         },

--- a/src/models/civilUnion.js
+++ b/src/models/civilUnion.js
@@ -42,7 +42,13 @@ const civilUnion = {
     presence: true,
     hasValue: { validator: hasYesOrNo },
   },
-  Address: { location: { validator: address } },
+  Address: (value, attributes) => {
+    // UseCurrentAddress applicable is the opposite of all other NotApplicable patterns
+    if (attributes.UseCurrentAddress
+      && attributes.UseCurrentAddress.applicable === true) return {}
+
+    return { location: { validator: address } }
+  },
   Location: {
     presence: true,
     location: { validator: birthplace },

--- a/src/models/civilUnion.js
+++ b/src/models/civilUnion.js
@@ -47,7 +47,7 @@ const civilUnion = {
     if (attributes.UseCurrentAddress
       && attributes.UseCurrentAddress.applicable === true) return {}
 
-    return { location: { validator: address } }
+    return { presence: true, location: { validator: address } }
   },
   Location: {
     presence: true,

--- a/src/validators/civilunion.test.js
+++ b/src/validators/civilunion.test.js
@@ -208,6 +208,7 @@ describe('CivilUnion validation', () => {
       {
         data: {
           Address: {},
+          UseCurrentAddress: { applicable: true },
         },
         expected: true,
       },


### PR DESCRIPTION
## Description

- Take into account `UseCurrentAddress` field when validating civil union address.
- Require spouse `Address` if `UseCurrentAddress` is not checked.
- This fixes an issue where test scenario 5 was not validating the Marital section.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
