### PR TITLE
[EN-3706] Validation Refactor - Military / U.S. Military

### DIFF
--- a/src/components/Section/Military/History/History.jsx
+++ b/src/components/Section/Military/History/History.jsx
@@ -20,6 +20,9 @@ export const serviceNameDisplay = (service) => {
   let display = (service || {}).value
 
   switch (display) {
+    case 'Army':
+      display = 'Army'
+      break
     case 'AirForce':
       display = 'Air Force'
       break

--- a/src/components/Section/Military/History/History.jsx
+++ b/src/components/Section/Military/History/History.jsx
@@ -38,6 +38,9 @@ export const serviceNameDisplay = (service) => {
     case 'MarineCorps':
       display = 'Marine Corps'
       break
+    case 'Navy':
+      display = 'Navy'
+      break
     default:
       display = 'Unknown'
   }

--- a/src/constants/enums/militaryDischargeOptions.js
+++ b/src/constants/enums/militaryDischargeOptions.js
@@ -1,0 +1,10 @@
+const militaryDischargeOptions = [
+  'Honorable',
+  'Dishonorable',
+  'LessThan',
+  'General',
+  'BadConduct',
+  'Other',
+]
+
+export default militaryDischargeOptions

--- a/src/constants/enums/militaryOfficerOptions.js
+++ b/src/constants/enums/militaryOfficerOptions.js
@@ -1,0 +1,7 @@
+const militaryOfficerOptions = [
+  'Officer',
+  'Enlisted',
+  'NotApplicable',
+]
+
+export default militaryOfficerOptions

--- a/src/constants/enums/militaryServiceOptions.js
+++ b/src/constants/enums/militaryServiceOptions.js
@@ -1,0 +1,11 @@
+const militaryServiceOptions = [
+  'Army',
+  'ArmyNationalGuard',
+  'Navy',
+  'AirForce',
+  'AirNationalGuard',
+  'MarineCorps',
+  'CoastGuard',
+]
+
+export default militaryServiceOptions

--- a/src/constants/enums/militaryStatusOptions.js
+++ b/src/constants/enums/militaryStatusOptions.js
@@ -1,0 +1,7 @@
+const militaryStatusOptions = [
+  'ActiveDuty',
+  'ActiveReserve',
+  'InactiveReserve',
+]
+
+export default militaryStatusOptions

--- a/src/models/__tests__/militaryHistory.test.js
+++ b/src/models/__tests__/militaryHistory.test.js
@@ -1,0 +1,38 @@
+import { validateModel } from 'models/validate'
+import militaryHistory from '../militaryHistory'
+
+describe('The military history model', () => {
+  it('requires HasServed', () => {
+    const testData = {
+      HasServed: {},
+    }
+    const expectedErrors = ['HasServed.required']
+
+    expect(validateModel(testData, militaryHistory))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('requires a List if HasServed is Yes', () => {
+    const testData = {
+      HasServed: {
+        value: 'Yes',
+      },
+    }
+    const expectedErrors = ['List.required']
+
+    expect(validateModel(testData, militaryHistory))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('HasServed requires an accepted value (Yes or No)', () => {
+    const testData = {
+      HasServed: {
+        value: 'Yaaas',
+      },
+    }
+    const expectedErrors = ['HasServed.hasValue']
+
+    expect(validateModel(testData, militaryHistory))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+})

--- a/src/models/__tests__/militaryService.test.js
+++ b/src/models/__tests__/militaryService.test.js
@@ -93,72 +93,76 @@ describe('The military service model', () => {
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
-  it('requires DischargeType if applicant was discharged', () => {
-    const testData = {
-      HasBeenDischarged: {
-        value: 'Yes',
-      },
-    }
-    const expectedErrors = ['DischargeType.required']
+  describe('if applicant was discharged', () => {
+    it('requires DischargeType', () => {
+      const testData = {
+        HasBeenDischarged: {
+          value: 'Yes',
+        },
+      }
+      const expectedErrors = ['DischargeType.required']
 
-    expect(validateModel(testData, militaryService))
-      .toEqual(expect.arrayContaining(expectedErrors))
-  })
+      expect(validateModel(testData, militaryService))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
 
-  it('requires a valid DischargeType if applicant was discharged', () => {
-    const testData = {
-      HasBeenDischarged: {
-        value: 'Yes',
-      },
-      DischargeType: {
-        value: 'InvalidType',
-      },
-    }
-    const expectedErrors = ['DischargeType.hasValue']
+    it('requires a valid DischargeType', () => {
+      const testData = {
+        HasBeenDischarged: {
+          value: 'Yes',
+        },
+        DischargeType: {
+          value: 'InvalidType',
+        },
+      }
+      const expectedErrors = ['DischargeType.hasValue']
 
-    expect(validateModel(testData, militaryService))
-      .toEqual(expect.arrayContaining(expectedErrors))
-  })
+      expect(validateModel(testData, militaryService))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
 
-  it('requires a DischargeReason for discharge types other than Honorable', () => {
-    const testData = {
-      HasBeenDischarged: {
-        value: 'Yes',
-      },
-      DischargeType: {
-        value: 'Dishonorable',
-      },
-    }
-    const expectedErrors = ['DischargeReason.required', 'DischargeReason.hasValue']
 
-    expect(validateModel(testData, militaryService))
-      .toEqual(expect.arrayContaining(expectedErrors))
-  })
+    it('requires a DischargeReason for discharge types other than Honorable', () => {
+      const testData = {
+        HasBeenDischarged: {
+          value: 'Yes',
+        },
+        DischargeType: {
+          value: 'Dishonorable',
+        },
+      }
+      const expectedErrors = ['DischargeReason.required', 'DischargeReason.hasValue']
 
-  it('requires a DischargeTypeOther for DischargeType = Other', () => {
-    const testData = {
-      HasBeenDischarged: {
-        value: 'Yes',
-      },
-      DischargeType: {
-        value: 'Other',
-      },
-    }
-    const expectedErrors = ['DischargeTypeOther.required', 'DischargeTypeOther.hasValue']
+      expect(validateModel(testData, militaryService))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
 
-    expect(validateModel(testData, militaryService))
-      .toEqual(expect.arrayContaining(expectedErrors))
-  })
+    it('requires a DischargeTypeOther for DischargeType = Other', () => {
+      const testData = {
+        HasBeenDischarged: {
+          value: 'Yes',
+        },
+        DischargeType: {
+          value: 'Other',
+        },
+      }
+      const expectedErrors = ['DischargeTypeOther.required', 'DischargeTypeOther.hasValue']
 
-  it('requires a DischargeDate if applicant has been discharged', () => {
-    const testData = {
-      HasBeenDischarged: {
-        value: 'Yes',
-      },
-    }
-    const expectedErrors = ['DischargeDate.required']
+      expect(validateModel(testData, militaryService))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
 
-    expect(validateModel(testData, militaryService))
-      .toEqual(expect.arrayContaining(expectedErrors))
+
+    it('requires a DischargeDate', () => {
+      const testData = {
+        HasBeenDischarged: {
+          value: 'Yes',
+        },
+      }
+      const expectedErrors = ['DischargeDate.required']
+
+      expect(validateModel(testData, militaryService))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
   })
 })

--- a/src/models/__tests__/militaryService.test.js
+++ b/src/models/__tests__/militaryService.test.js
@@ -31,13 +31,6 @@ describe('The military service model', () => {
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
-  it('requires Status to have a value', () => {
-    const testData = {}
-    const expectedErrors = ['Status.required']
-
-    expect(validateModel(testData, militaryService))
-      .toEqual(expect.arrayContaining(expectedErrors))
-  })
 
   it('requires Status to have a valid value', () => {
     const testData = {
@@ -46,14 +39,6 @@ describe('The military service model', () => {
       },
     }
     const expectedErrors = ['Status.hasValue']
-
-    expect(validateModel(testData, militaryService))
-      .toEqual(expect.arrayContaining(expectedErrors))
-  })
-
-  it('requires Officer to have a value', () => {
-    const testData = {}
-    const expectedErrors = ['Officer.required']
 
     expect(validateModel(testData, militaryService))
       .toEqual(expect.arrayContaining(expectedErrors))

--- a/src/models/__tests__/militaryService.test.js
+++ b/src/models/__tests__/militaryService.test.js
@@ -1,0 +1,179 @@
+import { validateModel } from 'models/validate'
+import militaryService from '../militaryService'
+import { validate } from '@babel/types';
+
+describe('The military service model', () => {
+  it('requires required fields to be filled', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Service.required',
+      'Status.required',
+      'Officer.required',
+      'Dates.required',
+      'ServiceNumber.required',
+      'HasBeenDischarged.required',
+    ]
+
+
+    expect(validateModel(testData, militaryService))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('requires Service to have a valid value', () => {
+    const testData = {
+      Service: {
+        value: 'InvalidArmy',
+      },
+    }
+    const expectedErrors = ['Service.hasValue']
+
+    expect(validateModel(testData, militaryService))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('requires Status to have a value', () => {
+    const testData = {}
+    const expectedErrors = ['Status.required']
+
+    expect(validateModel(testData, militaryService))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('requires Status to have a valid value', () => {
+    const testData = {
+      Status: {
+        value: 'InvalidValue',
+      },
+    }
+    const expectedErrors = ['Status.hasValue']
+
+    expect(validateModel(testData, militaryService))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('requires Officer to have a value', () => {
+    const testData = {}
+    const expectedErrors = ['Officer.required']
+
+    expect(validateModel(testData, militaryService))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('requires Officer to have a valid value', () => {
+    const testData = {
+      Officer: {
+        value: 'InvalidType',
+      },
+    }
+    const expectedErrors = ['Officer.hasValue']
+
+    expect(validateModel(testData, militaryService))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('requires the ServiceNumber to be filled', () => {
+    const testData = {
+      ServiceNumber: {
+        value: '',
+      },
+    }
+    const expectedErrors = ['ServiceNumber.hasValue']
+
+    expect(validateModel(testData, militaryService))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('requires a ServiceState if national guard is selected', () => {
+    const testData = {
+      Service: {
+        value: 'AirNationalGuard',
+      },
+    }
+    const expectedErrors = ['ServiceState.required']
+
+    expect(validateModel(testData, militaryService))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('requires HasBeenDischarged to be filled', () => {
+    const testData = {
+      HasBeenDischarged: {
+        value: '',
+      },
+    }
+
+    const expectedErrors = ['HasBeenDischarged.hasValue']
+
+    expect(validateModel(testData, militaryService))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('requires DischargeType if applicant was discharged', () => {
+    const testData = {
+      HasBeenDischarged: {
+        value: 'Yes',
+      },
+    }
+    const expectedErrors = ['DischargeType.required']
+
+    expect(validateModel(testData, militaryService))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('requires a valid DischargeType if applicant was discharged', () => {
+    const testData = {
+      HasBeenDischarged: {
+        value: 'Yes',
+      },
+      DischargeType: {
+        value: 'InvalidType',
+      },
+    }
+    const expectedErrors = ['DischargeType.hasValue']
+
+    expect(validateModel(testData, militaryService))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('requires a DischargeReason for discharge types other than Honorable', () => {
+    const testData = {
+      HasBeenDischarged: {
+        value: 'Yes',
+      },
+      DischargeType: {
+        value: 'Dishonorable',
+      },
+    }
+    const expectedErrors = ['DischargeReason.required', 'DischargeReason.hasValue']
+
+    expect(validateModel(testData, militaryService))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('requires a DischargeTypeOther for DischargeType = Other', () => {
+    const testData = {
+      HasBeenDischarged: {
+        value: 'Yes',
+      },
+      DischargeType: {
+        value: 'Other',
+      },
+    }
+    const expectedErrors = ['DischargeTypeOther.required', 'DischargeTypeOther.hasValue']
+
+    expect(validateModel(testData, militaryService))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('requires a DischargeDate if applicant has been discharged', () => {
+    const testData = {
+      HasBeenDischarged: {
+        value: 'Yes',
+      },
+    }
+    const expectedErrors = ['DischargeDate.required']
+
+    expect(validateModel(testData, militaryService))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+})

--- a/src/models/militaryHistory.js
+++ b/src/models/militaryHistory.js
@@ -1,0 +1,18 @@
+import { hasYesOrNo, checkValue } from 'models/validate'
+import militaryService from './militaryService'
+
+const militaryHistory = {
+  HasServed: {
+    presence: true,
+    hasValue: { validator: hasYesOrNo },
+  },
+  List: (value, attributes) => (
+    checkValue(attributes.HasServed, 'Yes')
+      ? {
+        presence: true,
+        accordion: { validator: militaryService },
+      } : {}
+  ),
+}
+
+export default militaryHistory

--- a/src/models/militaryService.js
+++ b/src/models/militaryService.js
@@ -33,10 +33,7 @@ const militaryService = {
     },
   },
   Dates: { presence: true, daterange: true },
-  ServiceNumber: {
-    presence: true,
-    hasValue: true,
-  },
+  ServiceNumber: { presence: true, hasValue: true },
   ServiceState: (value, attributes) => {
     if (isAirOrArmyNationalGuard(attributes.Service)) {
       return {
@@ -69,24 +66,17 @@ const militaryService = {
       return {}
     }
 
-    return {
-      presence: true,
-      hasValue: true,
-    }
+    return { presence: true, hasValue: true }
   },
   DischargeTypeOther: (value, attributes) => (
     checkValue(attributes.DischargeType, 'Other')
-      ? {
-        presence: true,
-        hasValue: true,
-      } : {}
+      ? { presence: true, hasValue: true }
+      : {}
   ),
   DischargeDate: (value, attributes) => (
     checkValue(attributes.HasBeenDischarged, 'Yes')
-      ? {
-        presence: true,
-        date: true,
-      } : {}
+      ? { presence: true, date: true }
+      : {}
   ),
 }
 

--- a/src/models/militaryService.js
+++ b/src/models/militaryService.js
@@ -1,4 +1,4 @@
-import { hasYesOrNo, checkValue, hasLength } from 'models/validate'
+import { hasYesOrNo, checkValue } from 'models/validate'
 import state from 'models/shared/locations/state'
 
 const isAirOrArmyNationalGuard = serviceType => (
@@ -35,7 +35,7 @@ const militaryService = {
   Dates: { presence: true, daterange: true },
   ServiceNumber: {
     presence: true,
-    hasValue: { validator: hasLength },
+    hasValue: true,
   },
   ServiceState: (value, attributes) => {
     if (isAirOrArmyNationalGuard(attributes.Service)) {
@@ -71,14 +71,14 @@ const militaryService = {
 
     return {
       presence: true,
-      hasValue: { validator: hasLength },
+      hasValue: true,
     }
   },
   DischargeTypeOther: (value, attributes) => (
     checkValue(attributes.DischargeType, 'Other')
       ? {
         presence: true,
-        hasValue: { validator: hasLength },
+        hasValue: true,
       } : {}
   ),
   DischargeDate: (value, attributes) => (

--- a/src/models/militaryService.js
+++ b/src/models/militaryService.js
@@ -20,7 +20,6 @@ const militaryService = {
     presence: true,
     hasValue: {
       validator: {
-        // Double Check: (15.2.3) says `Active`, not `ActiveDuty`
         inclusion: ['ActiveDuty', 'ActiveReserve', 'InactiveReserve'],
       },
     },
@@ -57,7 +56,7 @@ const militaryService = {
         presence: true,
         hasValue: {
           validator: {
-            inclusion: ['Honorable', 'Dishonorable', 'OtherThanHonorable', 'General', 'BadConduct', 'Other']
+            inclusion: ['Honorable', 'Dishonorable', 'LessThan', 'General', 'BadConduct', 'Other'],
           },
         },
       } : {}

--- a/src/models/militaryService.js
+++ b/src/models/militaryService.js
@@ -1,5 +1,9 @@
 import { hasYesOrNo, checkValue } from 'models/validate'
 import state from 'models/shared/locations/state'
+import militaryServiceOptions from 'constants/enums/militaryServiceOptions'
+import militaryStatusOptions from 'constants/enums/militaryStatusOptions'
+import militaryOfficerOptions from 'constants/enums/militaryOfficerOptions'
+import militaryDischargeOptions from 'constants/enums/militaryDischargeOptions'
 
 const isAirOrArmyNationalGuard = serviceType => (
   serviceType
@@ -12,7 +16,7 @@ const militaryService = {
     presence: true,
     hasValue: {
       validator: {
-        inclusion: ['Army', 'ArmyNationalGuard', 'Navy', 'AirForce', 'AirNationalGuard', 'MarineCorps', 'CoastGuard'],
+        inclusion: militaryServiceOptions,
       },
     },
   },
@@ -20,7 +24,7 @@ const militaryService = {
     presence: true,
     hasValue: {
       validator: {
-        inclusion: ['ActiveDuty', 'ActiveReserve', 'InactiveReserve'],
+        inclusion: militaryStatusOptions,
       },
     },
   },
@@ -28,7 +32,7 @@ const militaryService = {
     presence: true,
     hasValue: {
       validator: {
-        inclusion: ['Officer', 'Enlisted', 'NotApplicable'],
+        inclusion: militaryOfficerOptions,
       },
     },
   },
@@ -53,7 +57,7 @@ const militaryService = {
         presence: true,
         hasValue: {
           validator: {
-            inclusion: ['Honorable', 'Dishonorable', 'LessThan', 'General', 'BadConduct', 'Other'],
+            inclusion: militaryDischargeOptions,
           },
         },
       } : {}

--- a/src/models/militaryService.js
+++ b/src/models/militaryService.js
@@ -1,0 +1,94 @@
+import { hasYesOrNo, checkValue, hasLength } from 'models/validate'
+import state from 'models/shared/locations/state'
+
+const isAirOrArmyNationalGuard = serviceType => (
+  serviceType
+  && serviceType.value
+  && ['AirNationalGuard', 'ArmyNationalGuard'].includes(serviceType.value)
+)
+
+const militaryService = {
+  Service: {
+    presence: true,
+    hasValue: {
+      validator: {
+        inclusion: ['Army', 'ArmyNationalGuard', 'Navy', 'AirForce', 'AirNationalGuard', 'MarineCorps', 'CoastGuard'],
+      },
+    },
+  },
+  Status: {
+    presence: true,
+    hasValue: {
+      validator: {
+        // Double Check: (15.2.3) says `Active`, not `ActiveDuty`
+        inclusion: ['ActiveDuty', 'ActiveReserve', 'InactiveReserve'],
+      },
+    },
+  },
+  Officer: {
+    presence: true,
+    hasValue: {
+      validator: {
+        inclusion: ['Officer', 'Enlisted', 'NotApplicable'],
+      },
+    },
+  },
+  Dates: { presence: true, daterange: true },
+  ServiceNumber: {
+    presence: true,
+    hasValue: { validator: hasLength },
+  },
+  ServiceState: (value, attributes) => {
+    if (isAirOrArmyNationalGuard(attributes.Service)) {
+      return {
+        presence: true,
+        location: { validator: state },
+      }
+    }
+    return {}
+  },
+  HasBeenDischarged: {
+    presence: true,
+    hasValue: { validator: hasYesOrNo },
+  },
+  DischargeType: (value, attributes) => (
+    checkValue(attributes.HasBeenDischarged, 'Yes')
+      ? {
+        presence: true,
+        hasValue: {
+          validator: {
+            inclusion: ['Honorable', 'Dishonorable', 'OtherThanHonorable', 'General', 'BadConduct', 'Other']
+          },
+        },
+      } : {}
+  ),
+  DischargeReason: (value, attributes) => {
+    if (
+      (attributes.HasBeenDischarged && attributes.HasBeenDischarged.value === 'No')
+      || (attributes.DischargeType && attributes.DischargeType.value === 'Honorable')
+    ) {
+      return {}
+    }
+
+    return {
+      presence: true,
+      hasValue: { validator: hasLength },
+    }
+  },
+  DischargeTypeOther: (value, attributes) => (
+    checkValue(attributes.DischargeType, 'Other')
+      ? {
+        presence: true,
+        hasValue: { validator: hasLength },
+      } : {}
+  ),
+  DischargeDate: (value, attributes) => (
+    checkValue(attributes.HasBeenDischarged, 'Yes')
+      ? {
+        presence: true,
+        date: true,
+      } : {}
+  ),
+}
+
+export default militaryService

--- a/src/models/shared/locations/__tests__/state.test.js
+++ b/src/models/shared/locations/__tests__/state.test.js
@@ -1,0 +1,28 @@
+import { validateModel } from 'models/validate'
+import state from '../state'
+
+describe('The location/state model', () => {
+  it('requires a state', () => {
+    const testData = { state: '' }
+    const expectedErrors = ['state.required']
+
+    expect(validateModel(testData, state))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('must be a valid US state', () => {
+    const testData = { state: 'XY', country: 'United States' }
+    const expectedErrors = ['state.inclusion']
+
+    expect(validateModel(testData, state))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid address', () => {
+    const testData = {
+      state: 'CA',
+    }
+
+    expect(validateModel(testData, state)).toEqual(true)
+  })
+})

--- a/src/models/shared/locations/state.js
+++ b/src/models/shared/locations/state.js
@@ -1,0 +1,11 @@
+import { usStatesValues } from 'constants/enums/usStates'
+import { usTerritoriesValues } from 'constants/enums/usTerritories'
+
+const state = {
+  state: {
+    presence: true,
+    inclusion: [...usStatesValues, ...usTerritoriesValues],
+  },
+}
+
+export default state

--- a/src/models/validate.js
+++ b/src/models/validate.js
@@ -100,6 +100,10 @@ export default validateModel
 export const hasYesOrNo = {
   inclusion: ['Yes', 'No'],
 }
+/** checks whether a field a minimum of 1 character filled */
+export const hasLength = {
+  length: { minimum: 1 },
+}
 
 /** check the value of an attribute.value */
 export const checkValue = (attribute, expected) => !!(attribute

--- a/src/models/validate.js
+++ b/src/models/validate.js
@@ -100,10 +100,6 @@ export default validateModel
 export const hasYesOrNo = {
   inclusion: ['Yes', 'No'],
 }
-/** checks whether a field a minimum of 1 character filled */
-export const hasLength = {
-  length: { minimum: 1 },
-}
 
 /** check the value of an attribute.value */
 export const checkValue = (attribute, expected) => !!(attribute

--- a/src/validators/militaryhistory.js
+++ b/src/validators/militaryhistory.js
@@ -1,151 +1,41 @@
-import DateRangeValidator from './daterange'
-import LocationValidator from './location'
-import {
-  validAccordion,
-  validGenericTextfield,
-  validDateField
-} from './helpers'
+import militaryService from 'models/militaryService'
+import militaryHistory from 'models/militaryHistory'
+import { validateModel } from 'models/validate'
+
+export const validateMilitaryHistory = data => (
+  validateModel(data, militaryHistory) === true
+)
+
+export const validateMilitaryService = data => (
+  validateModel(data, militaryService) === true
+)
 
 export default class MilitaryHistoryValidator {
   constructor(data = {}) {
+    this.data = data
     this.hasServed = (data.HasServed || {}).value
     this.list = data.List || {}
   }
 
-  hasHistory() {
-    return this.hasServed === 'Yes'
-  }
-
   validServed() {
-    return this.hasServed === 'Yes' || this.hasServed === 'No'
+    return validateModel(this.data, { HasServed: militaryHistory.HasServed }) === true
   }
 
   validItems() {
-    if (this.hasServed === 'No') {
-      return true
-    }
-
-    return validAccordion(this.list, item => {
-      return new MilitaryServiceValidator(item).isValid()
-    })
+    return validateModel(this.data, { List: militaryHistory.List }) === true
   }
 
   isValid() {
-    return this.validServed() && this.validItems()
+    return validateMilitaryHistory(this.data)
   }
 }
 
 export class MilitaryServiceValidator {
   constructor(data = {}) {
-    this.service = (data.Service || {}).value
-    this.status = (data.Status || {}).value
-    this.officer = (data.Officer || {}).value
-    this.serviceNumber = data.ServiceNumber || {}
-    this.dates = data.Dates || {}
-    this.serviceState = data.ServiceState || {}
-    this.hasBeenDischarged = (data.HasBeenDischarged || {}).value
-    this.dischargeType = (data.DischargeType || {}).value
-    this.dischargeTypeOther = data.DischargeTypeOther || {}
-    this.dischargeReason = data.DischargeReason || {}
-    this.dischargeDate = data.DischargeDate || {}
-  }
-
-  validService() {
-    return this.service && this.service.length > 0
-  }
-
-  validStatus() {
-    if (['AirNationalGuard', 'ArmyNationalGuard'].includes(this.service)) {
-      return this.status && this.status.length > 0
-    }
-
-    return true
-  }
-
-  validOfficer() {
-    return this.officer && this.officer.length > 0
-  }
-
-  validServiceNumber() {
-    return !!this.serviceNumber && validGenericTextfield(this.serviceNumber)
-  }
-
-  validDates() {
-    return new DateRangeValidator(this.dates, null).isValid()
-  }
-
-  validServiceState() {
-    if (['AirNationalGuard', 'ArmyNationalGuard'].includes(this.service)) {
-      return new LocationValidator(this.serviceState).isValid()
-    }
-
-    return true
-  }
-
-  validHasBeenDischarged() {
-    return this.hasBeenDischarged === 'Yes' || this.hasBeenDischarged === 'No'
-  }
-
-  validDischargeType() {
-    if (this.hasBeenDischarged === 'No') {
-      return true
-    }
-
-    return (
-      this.validHasBeenDischarged() &&
-      this.dischargeType &&
-      this.dischargeType.length > 0
-    )
-  }
-
-  validDischargeTypeOther() {
-    if (this.hasBeenDischarged === 'No') {
-      return true
-    }
-
-    if (this.validDischargeDate() && this.dischargeType !== 'Other') {
-      return true
-    }
-
-    return (
-      this.validHasBeenDischarged() &&
-      this.dischargeType === 'Other' &&
-      validGenericTextfield(this.dischargeTypeOther)
-    )
-  }
-
-  validDischargeReason() {
-    if (this.hasBeenDischarged === 'No' || this.dischargeType === 'Honorable') {
-      return true
-    }
-
-    return (
-      this.validHasBeenDischarged() &&
-      validGenericTextfield(this.dischargeReason)
-    )
-  }
-
-  validDischargeDate() {
-    if (this.hasBeenDischarged === 'No') {
-      return true
-    }
-
-    return this.validHasBeenDischarged() && validDateField(this.dischargeDate)
+    this.data = data
   }
 
   isValid() {
-    return (
-      this.validService() &&
-      this.validStatus() &&
-      this.validOfficer() &&
-      this.validServiceNumber() &&
-      this.validDates() &&
-      this.validServiceState() &&
-      this.validHasBeenDischarged() &&
-      this.validDischargeType() &&
-      this.validDischargeTypeOther() &&
-      this.validDischargeReason() &&
-      this.validDischargeDate()
-    )
+    return validateMilitaryService(this.data)
   }
 }

--- a/src/validators/militaryhistory.test.js
+++ b/src/validators/militaryhistory.test.js
@@ -1,43 +1,43 @@
 import MilitaryHistoryValidator from './militaryhistory'
 import Location from '../components/Form/Location'
 
-describe('Military history validation', function() {
+describe('Military history validation', () => {
   it('handle whether subject has served in the military', () => {
     const tests = [
       {
         state: {
-          HasServed: { value: '' }
+          HasServed: { value: '' },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
-          HasServed: { value: 'No' }
+          HasServed: { value: 'No' },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
-          HasServed: { value: 'Yes' }
+          HasServed: { value: 'Yes' },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new MilitaryHistoryValidator(test.state, null).validServed()).toBe(
         test.expected
       )
     })
   })
 
-  it('handle overall validity', function() {
+  it('handle overall validity', () => {
     const tests = [
       {
         state: {
-          HasServed: { value: 'Yes' }
+          HasServed: { value: 'Yes' },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
@@ -51,32 +51,32 @@ describe('Military history validation', function() {
                   Status: { value: 'ActiveDuty' },
                   Officer: { value: 'Enlisted' },
                   ServiceNumber: {
-                    value: '0123456789'
+                    value: '0123456789',
                   },
                   Dates: {
                     from: {
                       month: '1',
                       day: '1',
-                      year: '2010'
+                      year: '2010',
                     },
                     to: {
                       month: '1',
                       day: '1',
-                      year: '2012'
+                      year: '2012',
                     },
-                    present: false
+                    present: false,
                   },
                   ServiceState: {
                     state: 'AZ',
-                    layout: Location.STATE
+                    layout: Location.STATE,
                   },
-                  HasBeenDischarged: { value: 'Yes' }
-                }
-              }
-            ]
-          }
+                  HasBeenDischarged: { value: 'Yes' },
+                },
+              },
+            ],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
@@ -90,44 +90,44 @@ describe('Military history validation', function() {
                   Status: { value: 'ActiveDuty' },
                   Officer: { value: 'Enlisted' },
                   ServiceNumber: {
-                    value: '0123456789'
+                    value: '0123456789',
                   },
                   Dates: {
                     from: {
                       month: '1',
                       day: '1',
-                      year: '2010'
+                      year: '2010',
                     },
                     to: {
                       month: '1',
                       day: '1',
-                      year: '2012'
+                      year: '2012',
                     },
-                    present: false
+                    present: false,
                   },
                   ServiceState: {
                     state: 'AZ',
-                    layout: Location.STATE
+                    layout: Location.STATE,
                   },
                   HasBeenDischarged: { value: 'Yes' },
                   DischargeType: { value: 'Other' },
                   DischargeTypeOther: {
-                    value: 'Something'
+                    value: 'Something',
                   },
                   DischargeReason: {
-                    value: 'My reason'
+                    value: 'My reason',
                   },
                   DischargeDate: {
                     day: '1',
                     month: '1',
-                    year: '2016'
-                  }
-                }
-              }
-            ]
-          }
+                    year: '2016',
+                  },
+                },
+              },
+            ],
+          },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
@@ -141,38 +141,38 @@ describe('Military history validation', function() {
                   Status: { value: 'ActiveDuty' },
                   Officer: { value: 'Enlisted' },
                   ServiceNumber: {
-                    value: '0123456789'
+                    value: '0123456789',
                   },
                   Dates: {
                     from: {
                       month: '1',
                       day: '1',
-                      year: '2010'
+                      year: '2010',
                     },
                     to: {
                       month: '1',
                       day: '1',
-                      year: '2012'
+                      year: '2012',
                     },
-                    present: false
+                    present: false,
                   },
                   ServiceState: {
                     state: 'AZ',
-                    layout: Location.STATE
+                    layout: Location.STATE,
                   },
                   HasBeenDischarged: { value: 'Yes' },
                   DischargeType: { value: 'Honorable' },
                   DischargeDate: {
                     day: '1',
                     month: '1',
-                    year: '2016'
-                  }
-                }
-              }
-            ]
-          }
+                    year: '2016',
+                  },
+                },
+              },
+            ],
+          },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
@@ -186,41 +186,41 @@ describe('Military history validation', function() {
                   Status: { value: 'ActiveDuty' },
                   Officer: { value: 'Enlisted' },
                   ServiceNumber: {
-                    value: '0123456789'
+                    value: '0123456789',
                   },
                   Dates: {
                     from: {
                       month: '1',
                       day: '1',
-                      year: '2010'
+                      year: '2010',
                     },
                     to: {
                       month: '1',
                       day: '1',
-                      year: '2012'
+                      year: '2012',
                     },
-                    present: false
+                    present: false,
                   },
                   ServiceState: {
                     state: 'AZ',
-                    layout: Location.STATE
+                    layout: Location.STATE,
                   },
                   HasBeenDischarged: { value: 'Yes' },
                   DischargeType: { value: 'General' },
                   DischargeReason: {
-                    value: 'My reason'
+                    value: 'My reason',
                   },
                   DischargeDate: {
                     day: '1',
                     month: '1',
-                    year: '2016'
-                  }
-                }
-              }
-            ]
-          }
+                    year: '2016',
+                  },
+                },
+              },
+            ],
+          },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
@@ -234,32 +234,32 @@ describe('Military history validation', function() {
                   Status: { value: 'ActiveDuty' },
                   Officer: { value: 'Enlisted' },
                   ServiceNumber: {
-                    value: '0123456789'
+                    value: '0123456789',
                   },
                   Dates: {
                     from: {
                       month: '1',
                       day: '1',
-                      year: '2010'
+                      year: '2010',
                     },
                     to: {
                       month: '1',
                       day: '1',
-                      year: '2012'
+                      year: '2012',
                     },
-                    present: false
+                    present: false,
                   },
                   ServiceState: {
                     state: 'AZ',
-                    layout: Location.STATE
+                    layout: Location.STATE,
                   },
-                  HasBeenDischarged: { value: 'No' }
-                }
-              }
-            ]
-          }
+                  HasBeenDischarged: { value: 'No' },
+                },
+              },
+            ],
+          },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
@@ -270,34 +270,35 @@ describe('Military history validation', function() {
               {
                 Item: {
                   Service: { value: 'Army' },
+                  Status: { value: 'ActiveDuty' },
                   Officer: { value: 'Enlisted' },
                   ServiceNumber: {
-                    value: '0123456789'
+                    value: '0123456789',
                   },
                   Dates: {
                     from: {
                       month: '1',
                       day: '1',
-                      year: '2010'
+                      year: '2010',
                     },
                     to: {
                       month: '1',
                       day: '1',
-                      year: '2012'
+                      year: '2012',
                     },
-                    present: false
+                    present: false,
                   },
-                  HasBeenDischarged: { value: 'No' }
-                }
-              }
-            ]
-          }
+                  HasBeenDischarged: { value: 'No' },
+                },
+              },
+            ],
+          },
         },
-        expected: true
+        expected: true,
       }
     ]
 
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new MilitaryHistoryValidator(test.state, null).isValid()).toBe(
         test.expected
       )

--- a/src/validators/militaryhistory.test.js
+++ b/src/validators/militaryhistory.test.js
@@ -295,7 +295,7 @@ describe('Military history validation', () => {
           },
         },
         expected: true,
-      }
+      },
     ]
 
     tests.forEach((test) => {


### PR DESCRIPTION
## Description
- Refactors the Military / U.S. Military subsection
- Adds a location state validator that only validates against a single state
- Adds a shared `hasLength` validator that makes sure a field has at least 1 charager. this indicates a field is filled out


Note
There are two instances I noticed that the values sent to e-QIP from eApp don't match up with the validation matrix. The values from eApp validate against e-QIP, so I stuck with those values.

eApp Values|Validation Matrix Values
-------------|-----------------------
ActiveDuty|Active
LessThan|OtherThanHonorable

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
