### PR TITLE
Validation Refactor - Legal

### DIFF
--- a/src/constants/enums/legalOptions.js
+++ b/src/constants/enums/legalOptions.js
@@ -1,4 +1,7 @@
-/* eslint import/prefer-default-export: 0 */
+// Legal / Investigations / History
+export const US_DEPT_OF_TREASURY = 'U.S. Department of Treasury'
+export const FOREIGN_GOVT = 'Foreign government'
+export const OTHER = 'Other'
 
 export const offenseChargeTypes = [
   'Felony', 'Misdemeanor', 'Other',

--- a/src/models/__tests__/activitiesOverthrow.test.js
+++ b/src/models/__tests__/activitiesOverthrow.test.js
@@ -1,0 +1,47 @@
+import { validateModel } from 'models/validate'
+import activitiesOverthrow from '../activitiesOverthrow'
+
+describe('The activitiesOverthrow model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Dates.required',
+      'Reasons.required',
+    ]
+
+    expect(validateModel(testData, activitiesOverthrow))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Dates must be a valid date range', () => {
+    const testData = {
+      Dates: 12345,
+    }
+    const expectedErrors = ['Dates.daterange']
+
+    expect(validateModel(testData, activitiesOverthrow))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Reasons must have a value', () => {
+    const testData = {
+      Reasons: 'test',
+    }
+    const expectedErrors = ['Reasons.hasValue']
+
+    expect(validateModel(testData, activitiesOverthrow))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid activitiesOverthrow', () => {
+    const testData = {
+      Dates: {
+        from: { month: 9, day: 10, year: 1990 },
+        to: { month: 10, day: 12, year: 1995 },
+      },
+      Reasons: { value: 'Because' },
+    }
+
+    expect(validateModel(testData, activitiesOverthrow)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/debarred.test.js
+++ b/src/models/__tests__/debarred.test.js
@@ -1,0 +1,56 @@
+import { validateModel } from 'models/validate'
+import debarred from '../debarred'
+
+describe('The debarred model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Agency.required',
+      'Date.required',
+      'Explanation.required',
+    ]
+
+    expect(validateModel(testData, debarred))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Agency must have a value', () => {
+    const testData = {
+      Agency: 'test agency',
+    }
+    const expectedErrors = ['Agency.hasValue']
+
+    expect(validateModel(testData, debarred))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Date must be a valid date', () => {
+    const testData = {
+      Date: 12345,
+    }
+    const expectedErrors = ['Date.date']
+
+    expect(validateModel(testData, debarred))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Explanation must have a value', () => {
+    const testData = {
+      Explanation: 'test',
+    }
+    const expectedErrors = ['Explanation.hasValue']
+
+    expect(validateModel(testData, debarred))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid debarred', () => {
+    const testData = {
+      Agency: { value: 'Test Agency' },
+      Date: { month: 9, day: 10, year: 1990 },
+      Explanation: { value: 'Something something' },
+    }
+
+    expect(validateModel(testData, debarred)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/domesticViolence.test.js
+++ b/src/models/__tests__/domesticViolence.test.js
@@ -1,0 +1,81 @@
+import { validateModel } from 'models/validate'
+import domesticViolence from '../domesticViolence'
+
+describe('The domesticViolence model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'CourtAddress.required',
+      'CourtName.required',
+      'Explanation.required',
+      'Issued.required',
+    ]
+
+    expect(validateModel(testData, domesticViolence))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('CourtAddress must be a valid location', () => {
+    const testData = {
+      CourtAddress: 'Test address',
+    }
+    const expectedErrors = [
+      'CourtAddress.location',
+    ]
+
+    expect(validateModel(testData, domesticViolence))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('CourtName must have a value', () => {
+    const testData = {
+      CourtName: 'test',
+    }
+    const expectedErrors = [
+      'CourtName.hasValue',
+    ]
+
+    expect(validateModel(testData, domesticViolence))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Explanation must have a value', () => {
+    const testData = {
+      Explanation: true,
+    }
+    const expectedErrors = [
+      'Explanation.hasValue',
+    ]
+
+    expect(validateModel(testData, domesticViolence))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Issued must be a valid date', () => {
+    const testData = {
+      Issued: { month: 2, day: 100 },
+    }
+    const expectedErrors = [
+      'Issued.date',
+    ]
+
+    expect(validateModel(testData, domesticViolence))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid domestic violence', () => {
+    const testData = {
+      CourtAddress: {
+        city: 'New York',
+        state: 'NY',
+        zipcode: '10001',
+        country: 'United States',
+      },
+      CourtName: { value: 'Test Court' },
+      Explanation: { value: 'I did a thing' },
+      Issued: { month: 2, year: 1999 },
+    }
+
+    expect(validateModel(testData, domesticViolence)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/investigation.test.js
+++ b/src/models/__tests__/investigation.test.js
@@ -1,0 +1,285 @@
+import { validateModel } from 'models/validate'
+import investigation, { clearanceLevel } from '../investigation'
+
+describe('The clearanceLevel model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Level.required',
+    ]
+
+    expect(validateModel(testData, clearanceLevel))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Level must have a value', () => {
+    const testData = { Level: 'Secret' }
+    const expectedErrors = ['Level.hasValue']
+    expect(validateModel(testData, clearanceLevel))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if Level is "Other"', () => {
+    it('Explanation is required', () => {
+      const testData = { Level: { value: 'Other' } }
+      const expectedErrors = ['Explanation.required']
+      expect(validateModel(testData, clearanceLevel))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('Explanation must have a value', () => {
+      const testData = {
+        Level: { value: 'Other' },
+        Explanation: 'test',
+      }
+      const expectedErrors = ['Explanation.hasValue']
+      expect(validateModel(testData, clearanceLevel))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid clearanceLevel', () => {
+      const testData = {
+        Level: { value: 'Other' },
+        Explanation: { value: 'Something' },
+      }
+      expect(validateModel(testData, clearanceLevel)).toEqual(true)
+    })
+  })
+
+  it('passes a valid clearanceLevel', () => {
+    const testData = {
+      Level: { value: 'Top Secret' },
+    }
+    expect(validateModel(testData, clearanceLevel)).toEqual(true)
+  })
+})
+
+describe('The investigation model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Agency.required',
+      'Completed.required',
+      'Granted.required',
+      'ClearanceLevel.required',
+    ]
+
+    expect(validateModel(testData, investigation))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Agency must have a value', () => {
+    const testData = { Agency: 'FBI' }
+    const expectedErrors = ['Agency.hasValue']
+    expect(validateModel(testData, investigation))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Completed must be a valid date', () => {
+    const testData = { Completed: { day: 2, year: 1000 } }
+    const expectedErrors = ['Completed.date']
+    expect(validateModel(testData, investigation))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Granted must be a valid date', () => {
+    const testData = { Granted: { day: 2, year: 1000 } }
+    const expectedErrors = ['Granted.date']
+    expect(validateModel(testData, investigation))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('ClearanceLevel must be a valid ClearanceLevel', () => {
+    const testData = {
+      ClearanceLevel: {
+        value: 'Secret',
+      },
+    }
+    const expectedErrors = ['ClearanceLevel.model']
+    expect(validateModel(testData, investigation))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if Agency is not applicable', () => {
+    it('Agency is not required', () => {
+      const testData = {
+        AgencyNotApplicable: { applicable: false },
+      }
+      const expectedErrors = ['Agency.required']
+      expect(validateModel(testData, investigation))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid investigation', () => {
+      const testData = {
+        AgencyNotApplicable: { applicable: false },
+        Completed: { month: 4, day: 10, year: 2010 },
+        Granted: { month: 5, day: 10, year: 2011 },
+        ClearanceLevel: {
+          Level: { value: 'None' },
+        },
+      }
+      expect(validateModel(testData, investigation)).toEqual(true)
+    })
+  })
+
+  describe('if Agency is "U.S. Department of Treasury"', () => {
+    it('AgencyExplanation must have a value', () => {
+      const testData = {
+        Agency: { value: 'U.S. Department of Treasury' },
+      }
+      const expectedErrors = [
+        'AgencyExplanation.required',
+        'AgencyExplanation.hasValue',
+      ]
+      expect(validateModel(testData, investigation))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid investigation', () => {
+      const testData = {
+        Agency: { value: 'U.S. Department of Treasury' },
+        AgencyExplanation: { value: 'Test agency' },
+        Completed: { month: 5, day: 10, year: 2011 },
+        Granted: { month: 5, day: 10, year: 2011 },
+        ClearanceLevel: {
+          Level: { value: 'None' },
+        },
+      }
+      expect(validateModel(testData, investigation)).toEqual(true)
+    })
+  })
+
+  describe('if Agency is "Foreign government"', () => {
+    it('AgencyExplanation must have a value', () => {
+      const testData = {
+        Agency: { value: 'Foreign government' },
+      }
+      const expectedErrors = [
+        'AgencyExplanation.required',
+        'AgencyExplanation.hasValue',
+      ]
+      expect(validateModel(testData, investigation))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid investigation', () => {
+      const testData = {
+        Agency: { value: 'Foreign government' },
+        AgencyExplanation: { value: 'Test agency' },
+        Completed: { month: 5, day: 10, year: 2011 },
+        Granted: { month: 5, day: 10, year: 2011 },
+        ClearanceLevel: {
+          Level: { value: 'None' },
+        },
+      }
+      expect(validateModel(testData, investigation)).toEqual(true)
+    })
+  })
+
+  describe('if Agency is "Other"', () => {
+    it('AgencyExplanation must have a value', () => {
+      const testData = {
+        Agency: { value: 'Other' },
+      }
+      const expectedErrors = [
+        'AgencyExplanation.required',
+        'AgencyExplanation.hasValue',
+      ]
+      expect(validateModel(testData, investigation))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid investigation', () => {
+      const testData = {
+        Agency: { value: 'Other' },
+        AgencyExplanation: { value: 'Test agency' },
+        Completed: { month: 5, day: 10, year: 2011 },
+        Granted: { month: 5, day: 10, year: 2011 },
+        ClearanceLevel: {
+          Level: { value: 'None' },
+        },
+      }
+      expect(validateModel(testData, investigation)).toEqual(true)
+    })
+  })
+
+  describe('if Completed is not applicable', () => {
+    it('Completed is not required', () => {
+      const testData = {
+        CompletedNotApplicable: { applicable: false },
+      }
+      const expectedErrors = ['Completed.required']
+      expect(validateModel(testData, investigation))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid investigation', () => {
+      const testData = {
+        Agency: { value: 'FBI' },
+        CompletedNotApplicable: { applicable: false },
+        Granted: { month: 5, day: 10, year: 2011 },
+        ClearanceLevel: {
+          Level: { value: 'None' },
+        },
+      }
+      expect(validateModel(testData, investigation)).toEqual(true)
+    })
+  })
+
+  describe('if Granted is not applicable', () => {
+    it('Granted is not required', () => {
+      const testData = {
+        GrantedNotApplicable: { applicable: false },
+      }
+      const expectedErrors = ['Granted.required']
+      expect(validateModel(testData, investigation))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid investigation', () => {
+      const testData = {
+        Agency: { value: 'FBI' },
+        GrantedNotApplicable: { applicable: false },
+        Completed: { month: 4, day: 10, year: 2010 },
+        ClearanceLevel: {
+          Level: { value: 'None' },
+        },
+      }
+      expect(validateModel(testData, investigation)).toEqual(true)
+    })
+  })
+
+  describe('if ClearanceLevel is not applicable', () => {
+    it('ClearanceLevel is not required', () => {
+      const testData = {
+        ClearanceLevelNotApplicable: { applicable: false },
+      }
+      const expectedErrors = ['ClearanceLevel.required']
+      expect(validateModel(testData, investigation))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid investigation', () => {
+      const testData = {
+        Agency: { value: 'FBI' },
+        Completed: { month: 4, day: 10, year: 2010 },
+        Granted: { month: 5, day: 10, year: 2011 },
+        ClearanceLevelNotApplicable: { applicable: false },
+      }
+      expect(validateModel(testData, investigation)).toEqual(true)
+    })
+  })
+
+  it('passes a valid investigation', () => {
+    const testData = {
+      Agency: { value: 'FBI' },
+      Completed: { month: 4, day: 10, year: 2010 },
+      Granted: { month: 5, day: 10, year: 2011 },
+      ClearanceLevel: {
+        Level: { value: 'None' },
+      },
+    }
+    expect(validateModel(testData, investigation)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/manipulatingTech.test.js
+++ b/src/models/__tests__/manipulatingTech.test.js
@@ -1,0 +1,74 @@
+import { validateModel } from 'models/validate'
+import manipulatingTech from '../manipulatingTech'
+
+describe('The manipulatingTech model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Date.required',
+      'Incident.required',
+      'Location.required',
+      'Action.required',
+    ]
+
+    expect(validateModel(testData, manipulatingTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Date must be a valid date', () => {
+    const testData = {
+      Date: 12345,
+    }
+    const expectedErrors = ['Date.date']
+
+    expect(validateModel(testData, manipulatingTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Incident must have a value', () => {
+    const testData = {
+      Incident: 'test incident',
+    }
+    const expectedErrors = ['Incident.hasValue']
+
+    expect(validateModel(testData, manipulatingTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Location must be a valid address', () => {
+    const testData = {
+      Location: '123 Main St',
+    }
+    const expectedErrors = ['Location.location']
+
+    expect(validateModel(testData, manipulatingTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Action must have a value', () => {
+    const testData = {
+      Action: 'test',
+    }
+    const expectedErrors = ['Action.hasValue']
+
+    expect(validateModel(testData, manipulatingTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid manipulatingTech', () => {
+    const testData = {
+      Date: { month: 9, day: 10, year: 1990 },
+      Incident: { value: 'Test Court' },
+      Location: {
+        street: '123 Main St',
+        zipcode: '10002',
+        city: 'New York',
+        state: 'NY',
+        country: 'United States',
+      },
+      Action: { value: 'Something I did' },
+    }
+
+    expect(validateModel(testData, manipulatingTech)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/nonCriminalCourtAction.test.js
+++ b/src/models/__tests__/nonCriminalCourtAction.test.js
@@ -1,0 +1,98 @@
+import { validateModel } from 'models/validate'
+import nonCriminalCourtAction from '../nonCriminalCourtAction'
+
+describe('The nonCriminalCourtAction model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'CivilActionDate.required',
+      'CourtName.required',
+      'CourtAddress.required',
+      'NatureOfAction.required',
+      'ResultsOfAction.required',
+      'PrincipalPartyNames.required',
+    ]
+
+    expect(validateModel(testData, nonCriminalCourtAction))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('CivilActionDate must be a valid date', () => {
+    const testData = {
+      CivilActionDate: 12345,
+    }
+    const expectedErrors = ['CivilActionDate.date']
+
+    expect(validateModel(testData, nonCriminalCourtAction))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('CourtName must have a value', () => {
+    const testData = {
+      CourtName: 'test court',
+    }
+    const expectedErrors = ['CourtName.hasValue']
+
+    expect(validateModel(testData, nonCriminalCourtAction))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('CourtAddress must be a valid address', () => {
+    const testData = {
+      CourtAddress: '123 Main St',
+    }
+    const expectedErrors = ['CourtAddress.location']
+
+    expect(validateModel(testData, nonCriminalCourtAction))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('NatureOfAction must have a value', () => {
+    const testData = {
+      NatureOfAction: 'test',
+    }
+    const expectedErrors = ['NatureOfAction.hasValue']
+
+    expect(validateModel(testData, nonCriminalCourtAction))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('ResultsOfAction must have a value', () => {
+    const testData = {
+      ResultsOfAction: 'test',
+    }
+    const expectedErrors = ['ResultsOfAction.hasValue']
+
+    expect(validateModel(testData, nonCriminalCourtAction))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('PrincipalPartyNames must have a value', () => {
+    const testData = {
+      PrincipalPartyNames: 'test',
+    }
+    const expectedErrors = ['PrincipalPartyNames.hasValue']
+
+    expect(validateModel(testData, nonCriminalCourtAction))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid nonCriminalCourtAction', () => {
+    const testData = {
+      CivilActionDate: { month: 9, day: 10, year: 1990 },
+      CourtName: { value: 'Test Court' },
+      CourtAddress: {
+        street: '123 Main St',
+        zipcode: '10002',
+        city: 'New York',
+        state: 'NY',
+        country: 'United States',
+      },
+      NatureOfAction: { value: 'Something I did' },
+      ResultsOfAction: { value: 'This happened' },
+      PrincipalPartyNames: { value: 'Person 1 and Person 2' },
+    }
+
+    expect(validateModel(testData, nonCriminalCourtAction)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/overthrow.test.js
+++ b/src/models/__tests__/overthrow.test.js
@@ -1,0 +1,169 @@
+import { validateModel } from 'models/validate'
+import overthrow from '../overthrow'
+
+describe('The overthrow model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Organization.required',
+      'Address.required',
+      'Dates.required',
+      'Positions.required',
+      'Contributions.required',
+      'Reasons.required',
+    ]
+
+    expect(validateModel(testData, overthrow))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Organization must have a value', () => {
+    const testData = {
+      Organization: 'test organization',
+    }
+    const expectedErrors = ['Organization.hasValue']
+
+    expect(validateModel(testData, overthrow))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Address must be a valid address', () => {
+    const testData = {
+      Address: '123 Main St',
+    }
+    const expectedErrors = ['Address.location']
+
+    expect(validateModel(testData, overthrow))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Dates must be a valid date range', () => {
+    const testData = {
+      Dates: 12345,
+    }
+    const expectedErrors = ['Dates.daterange']
+
+    expect(validateModel(testData, overthrow))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Positions must have a value', () => {
+    const testData = {
+      Positions: 'test',
+    }
+    const expectedErrors = ['Positions.hasValue']
+
+    expect(validateModel(testData, overthrow))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Contributions must have a value', () => {
+    const testData = {
+      Contributions: 'test',
+    }
+    const expectedErrors = ['Contributions.hasValue']
+
+    expect(validateModel(testData, overthrow))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Reasons must have a value', () => {
+    const testData = {
+      Reasons: 'test',
+    }
+    const expectedErrors = ['Reasons.hasValue']
+
+    expect(validateModel(testData, overthrow))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if Positions is not applicable', () => {
+    it('Positions is not required', () => {
+      const testData = {
+        PositionsNotApplicable: { applicable: false },
+      }
+      const expectedErrors = ['Positions.required']
+
+      expect(validateModel(testData, overthrow))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid overthrow', () => {
+      const testData = {
+        Organization: { value: 'Test Organization' },
+        Dates: {
+          from: { month: 9, day: 10, year: 1990 },
+          to: { month: 10, day: 12, year: 1995 },
+        },
+        PositionsNotApplicable: { applicable: false },
+        Address: {
+          street: '123 Main St',
+          zipcode: '10002',
+          city: 'New York',
+          state: 'NY',
+          country: 'United States',
+        },
+        Contributions: { value: '100' },
+        Reasons: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, overthrow)).toEqual(true)
+    })
+  })
+
+  describe('if Contributions is not applicable', () => {
+    it('Contributions is not required', () => {
+      const testData = {
+        ContributionsNotApplicable: { applicable: false },
+      }
+      const expectedErrors = ['Contributions.required']
+
+      expect(validateModel(testData, overthrow))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid overthrow', () => {
+      const testData = {
+        Organization: { value: 'Test Organization' },
+        Dates: {
+          from: { month: 9, day: 10, year: 1990 },
+          to: { month: 10, day: 12, year: 1995 },
+        },
+        ContributionsNotApplicable: { applicable: false },
+        Address: {
+          street: '123 Main St',
+          zipcode: '10002',
+          city: 'New York',
+          state: 'NY',
+          country: 'United States',
+        },
+        Positions: { value: 'Test' },
+        Reasons: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, overthrow)).toEqual(true)
+    })
+  })
+
+  it('passes a valid overthrow', () => {
+    const testData = {
+      Organization: { value: 'Test Organization' },
+      Dates: {
+        from: { month: 9, day: 10, year: 1990 },
+        to: { month: 10, day: 12, year: 1995 },
+      },
+      Positions: { value: 'Test' },
+      Address: {
+        street: '123 Main St',
+        zipcode: '10002',
+        city: 'New York',
+        state: 'NY',
+        country: 'United States',
+      },
+      Contributions: { value: '100' },
+      Reasons: { value: 'Because' },
+    }
+
+    expect(validateModel(testData, overthrow)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/terrorism.test.js
+++ b/src/models/__tests__/terrorism.test.js
@@ -1,0 +1,68 @@
+import { validateModel } from 'models/validate'
+import terrorism from '../terrorism'
+
+describe('The terrorism model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'HasTerrorism.required',
+    ]
+
+    expect(validateModel(testData, terrorism))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Explanation must have a valid value', () => {
+    const testData = {
+      HasTerrorism: { value: 'true' },
+    }
+    const expectedErrors = ['HasTerrorism.hasValue']
+
+    expect(validateModel(testData, terrorism))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if HasTerrorism is "Yes"', () => {
+    it('Explanation must have a value', () => {
+      const testData = {
+        HasTerrorism: { value: 'Yes' },
+      }
+      const expectedErrors = [
+        'Explanation.required',
+        'Explanation.hasValue',
+      ]
+
+      expect(validateModel(testData, terrorism))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid terrorism', () => {
+      const testData = {
+        HasTerrorism: { value: 'Yes' },
+        Explanation: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, terrorism)).toEqual(true)
+    })
+  })
+
+  describe('if HasTerrorism is "No"', () => {
+    it('Explanation is not required', () => {
+      const testData = {
+        HasTerrorism: { value: 'No' },
+      }
+      const expectedErrors = ['Explanation.required']
+
+      expect(validateModel(testData, terrorism))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid terrorism', () => {
+      const testData = {
+        HasTerrorism: { value: 'No' },
+      }
+
+      expect(validateModel(testData, terrorism)).toEqual(true)
+    })
+  })
+})

--- a/src/models/__tests__/terrorismAdvocate.test.js
+++ b/src/models/__tests__/terrorismAdvocate.test.js
@@ -1,0 +1,47 @@
+import { validateModel } from 'models/validate'
+import terrorismAdvocate from '../terrorismAdvocate'
+
+describe('The terrorismAdvocate model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Dates.required',
+      'Reasons.required',
+    ]
+
+    expect(validateModel(testData, terrorismAdvocate))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Dates must be a valid date range', () => {
+    const testData = {
+      Dates: 12345,
+    }
+    const expectedErrors = ['Dates.daterange']
+
+    expect(validateModel(testData, terrorismAdvocate))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Reasons must have a value', () => {
+    const testData = {
+      Reasons: 'test',
+    }
+    const expectedErrors = ['Reasons.hasValue']
+
+    expect(validateModel(testData, terrorismAdvocate))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid terrorismAdvocate', () => {
+    const testData = {
+      Dates: {
+        from: { month: 9, day: 10, year: 1990 },
+        to: { month: 10, day: 12, year: 1995 },
+      },
+      Reasons: { value: 'Because' },
+    }
+
+    expect(validateModel(testData, terrorismAdvocate)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/terrorismEngaged.test.js
+++ b/src/models/__tests__/terrorismEngaged.test.js
@@ -1,0 +1,47 @@
+import { validateModel } from 'models/validate'
+import terrorismEngaged from '../terrorismEngaged'
+
+describe('The terrorismEngaged model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Dates.required',
+      'Reasons.required',
+    ]
+
+    expect(validateModel(testData, terrorismEngaged))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Dates must be a valid date range', () => {
+    const testData = {
+      Dates: 12345,
+    }
+    const expectedErrors = ['Dates.daterange']
+
+    expect(validateModel(testData, terrorismEngaged))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Reasons must have a value', () => {
+    const testData = {
+      Reasons: 'test',
+    }
+    const expectedErrors = ['Reasons.hasValue']
+
+    expect(validateModel(testData, terrorismEngaged))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid terrorismEngaged', () => {
+    const testData = {
+      Dates: {
+        from: { month: 9, day: 10, year: 1990 },
+        to: { month: 10, day: 12, year: 1995 },
+      },
+      Reasons: { value: 'Because' },
+    }
+
+    expect(validateModel(testData, terrorismEngaged)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/terrorist.test.js
+++ b/src/models/__tests__/terrorist.test.js
@@ -1,0 +1,169 @@
+import { validateModel } from 'models/validate'
+import terrorist from '../terrorist'
+
+describe('The terrorist model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Organization.required',
+      'Address.required',
+      'Dates.required',
+      'Positions.required',
+      'Contributions.required',
+      'Reasons.required',
+    ]
+
+    expect(validateModel(testData, terrorist))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Organization must have a value', () => {
+    const testData = {
+      Organization: 'test organization',
+    }
+    const expectedErrors = ['Organization.hasValue']
+
+    expect(validateModel(testData, terrorist))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Address must be a valid address', () => {
+    const testData = {
+      Address: '123 Main St',
+    }
+    const expectedErrors = ['Address.location']
+
+    expect(validateModel(testData, terrorist))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Dates must be a valid date range', () => {
+    const testData = {
+      Dates: 12345,
+    }
+    const expectedErrors = ['Dates.daterange']
+
+    expect(validateModel(testData, terrorist))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Positions must have a value', () => {
+    const testData = {
+      Positions: 'test',
+    }
+    const expectedErrors = ['Positions.hasValue']
+
+    expect(validateModel(testData, terrorist))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Contributions must have a value', () => {
+    const testData = {
+      Contributions: 'test',
+    }
+    const expectedErrors = ['Contributions.hasValue']
+
+    expect(validateModel(testData, terrorist))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Reasons must have a value', () => {
+    const testData = {
+      Reasons: 'test',
+    }
+    const expectedErrors = ['Reasons.hasValue']
+
+    expect(validateModel(testData, terrorist))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if Positions is not applicable', () => {
+    it('Positions is not required', () => {
+      const testData = {
+        PositionsNotApplicable: { applicable: false },
+      }
+      const expectedErrors = ['Positions.required']
+
+      expect(validateModel(testData, terrorist))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid terrorist', () => {
+      const testData = {
+        Organization: { value: 'Test Organization' },
+        Dates: {
+          from: { month: 9, day: 10, year: 1990 },
+          to: { month: 10, day: 12, year: 1995 },
+        },
+        PositionsNotApplicable: { applicable: false },
+        Address: {
+          street: '123 Main St',
+          zipcode: '10002',
+          city: 'New York',
+          state: 'NY',
+          country: 'United States',
+        },
+        Contributions: { value: '100' },
+        Reasons: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, terrorist)).toEqual(true)
+    })
+  })
+
+  describe('if Contributions is not applicable', () => {
+    it('Contributions is not required', () => {
+      const testData = {
+        ContributionsNotApplicable: { applicable: false },
+      }
+      const expectedErrors = ['Contributions.required']
+
+      expect(validateModel(testData, terrorist))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid terrorist', () => {
+      const testData = {
+        Organization: { value: 'Test Organization' },
+        Dates: {
+          from: { month: 9, day: 10, year: 1990 },
+          to: { month: 10, day: 12, year: 1995 },
+        },
+        ContributionsNotApplicable: { applicable: false },
+        Address: {
+          street: '123 Main St',
+          zipcode: '10002',
+          city: 'New York',
+          state: 'NY',
+          country: 'United States',
+        },
+        Positions: { value: 'Test' },
+        Reasons: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, terrorist)).toEqual(true)
+    })
+  })
+
+  it('passes a valid terrorist', () => {
+    const testData = {
+      Organization: { value: 'Test Organization' },
+      Dates: {
+        from: { month: 9, day: 10, year: 1990 },
+        to: { month: 10, day: 12, year: 1995 },
+      },
+      Positions: { value: 'Test' },
+      Address: {
+        street: '123 Main St',
+        zipcode: '10002',
+        city: 'New York',
+        state: 'NY',
+        country: 'United States',
+      },
+      Contributions: { value: '100' },
+      Reasons: { value: 'Because' },
+    }
+
+    expect(validateModel(testData, terrorist)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/unauthorizedTech.test.js
+++ b/src/models/__tests__/unauthorizedTech.test.js
@@ -1,0 +1,74 @@
+import { validateModel } from 'models/validate'
+import unauthorizedTech from '../unauthorizedTech'
+
+describe('The unauthorizedTech model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Date.required',
+      'Incident.required',
+      'Location.required',
+      'Action.required',
+    ]
+
+    expect(validateModel(testData, unauthorizedTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Date must be a valid date', () => {
+    const testData = {
+      Date: 12345,
+    }
+    const expectedErrors = ['Date.date']
+
+    expect(validateModel(testData, unauthorizedTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Incident must have a value', () => {
+    const testData = {
+      Incident: 'test incident',
+    }
+    const expectedErrors = ['Incident.hasValue']
+
+    expect(validateModel(testData, unauthorizedTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Location must be a valid address', () => {
+    const testData = {
+      Location: '123 Main St',
+    }
+    const expectedErrors = ['Location.location']
+
+    expect(validateModel(testData, unauthorizedTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Action must have a value', () => {
+    const testData = {
+      Action: 'test',
+    }
+    const expectedErrors = ['Action.hasValue']
+
+    expect(validateModel(testData, unauthorizedTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid unauthorizedTech', () => {
+    const testData = {
+      Date: { month: 9, day: 10, year: 1990 },
+      Incident: { value: 'Test Court' },
+      Location: {
+        street: '123 Main St',
+        zipcode: '10002',
+        city: 'New York',
+        state: 'NY',
+        country: 'United States',
+      },
+      Action: { value: 'Something I did' },
+    }
+
+    expect(validateModel(testData, unauthorizedTech)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/unlawfulTech.test.js
+++ b/src/models/__tests__/unlawfulTech.test.js
@@ -1,0 +1,74 @@
+import { validateModel } from 'models/validate'
+import unlawfulTech from '../unlawfulTech'
+
+describe('The unlawfulTech model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Date.required',
+      'Incident.required',
+      'Location.required',
+      'Action.required',
+    ]
+
+    expect(validateModel(testData, unlawfulTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Date must be a valid date', () => {
+    const testData = {
+      Date: 12345,
+    }
+    const expectedErrors = ['Date.date']
+
+    expect(validateModel(testData, unlawfulTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Incident must have a value', () => {
+    const testData = {
+      Incident: 'test incident',
+    }
+    const expectedErrors = ['Incident.hasValue']
+
+    expect(validateModel(testData, unlawfulTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Location must be a valid address', () => {
+    const testData = {
+      Location: '123 Main St',
+    }
+    const expectedErrors = ['Location.location']
+
+    expect(validateModel(testData, unlawfulTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Action must have a value', () => {
+    const testData = {
+      Action: 'test',
+    }
+    const expectedErrors = ['Action.hasValue']
+
+    expect(validateModel(testData, unlawfulTech))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid unlawfulTech', () => {
+    const testData = {
+      Date: { month: 9, day: 10, year: 1990 },
+      Incident: { value: 'Test Court' },
+      Location: {
+        street: '123 Main St',
+        zipcode: '10002',
+        city: 'New York',
+        state: 'NY',
+        country: 'United States',
+      },
+      Action: { value: 'Something I did' },
+    }
+
+    expect(validateModel(testData, unlawfulTech)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/violence.test.js
+++ b/src/models/__tests__/violence.test.js
@@ -1,0 +1,169 @@
+import { validateModel } from 'models/validate'
+import violence from '../violence'
+
+describe('The violence model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Organization.required',
+      'Address.required',
+      'Dates.required',
+      'Positions.required',
+      'Contributions.required',
+      'Reasons.required',
+    ]
+
+    expect(validateModel(testData, violence))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Organization must have a value', () => {
+    const testData = {
+      Organization: 'test organization',
+    }
+    const expectedErrors = ['Organization.hasValue']
+
+    expect(validateModel(testData, violence))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Address must be a valid address', () => {
+    const testData = {
+      Address: '123 Main St',
+    }
+    const expectedErrors = ['Address.location']
+
+    expect(validateModel(testData, violence))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Dates must be a valid date range', () => {
+    const testData = {
+      Dates: 12345,
+    }
+    const expectedErrors = ['Dates.daterange']
+
+    expect(validateModel(testData, violence))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Positions must have a value', () => {
+    const testData = {
+      Positions: 'test',
+    }
+    const expectedErrors = ['Positions.hasValue']
+
+    expect(validateModel(testData, violence))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Contributions must have a value', () => {
+    const testData = {
+      Contributions: 'test',
+    }
+    const expectedErrors = ['Contributions.hasValue']
+
+    expect(validateModel(testData, violence))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Reasons must have a value', () => {
+    const testData = {
+      Reasons: 'test',
+    }
+    const expectedErrors = ['Reasons.hasValue']
+
+    expect(validateModel(testData, violence))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if Positions is not applicable', () => {
+    it('Positions is not required', () => {
+      const testData = {
+        PositionsNotApplicable: { applicable: false },
+      }
+      const expectedErrors = ['Positions.required']
+
+      expect(validateModel(testData, violence))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid violence', () => {
+      const testData = {
+        Organization: { value: 'Test Organization' },
+        Dates: {
+          from: { month: 9, day: 10, year: 1990 },
+          to: { month: 10, day: 12, year: 1995 },
+        },
+        PositionsNotApplicable: { applicable: false },
+        Address: {
+          street: '123 Main St',
+          zipcode: '10002',
+          city: 'New York',
+          state: 'NY',
+          country: 'United States',
+        },
+        Contributions: { value: '100' },
+        Reasons: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, violence)).toEqual(true)
+    })
+  })
+
+  describe('if Contributions is not applicable', () => {
+    it('Contributions is not required', () => {
+      const testData = {
+        ContributionsNotApplicable: { applicable: false },
+      }
+      const expectedErrors = ['Contributions.required']
+
+      expect(validateModel(testData, violence))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid violence', () => {
+      const testData = {
+        Organization: { value: 'Test Organization' },
+        Dates: {
+          from: { month: 9, day: 10, year: 1990 },
+          to: { month: 10, day: 12, year: 1995 },
+        },
+        ContributionsNotApplicable: { applicable: false },
+        Address: {
+          street: '123 Main St',
+          zipcode: '10002',
+          city: 'New York',
+          state: 'NY',
+          country: 'United States',
+        },
+        Positions: { value: 'Test' },
+        Reasons: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, violence)).toEqual(true)
+    })
+  })
+
+  it('passes a valid violence', () => {
+    const testData = {
+      Organization: { value: 'Test Organization' },
+      Dates: {
+        from: { month: 9, day: 10, year: 1990 },
+        to: { month: 10, day: 12, year: 1995 },
+      },
+      Positions: { value: 'Test' },
+      Address: {
+        street: '123 Main St',
+        zipcode: '10002',
+        city: 'New York',
+        state: 'NY',
+        country: 'United States',
+      },
+      Contributions: { value: '100' },
+      Reasons: { value: 'Because' },
+    }
+
+    expect(validateModel(testData, violence)).toEqual(true)
+  })
+})

--- a/src/models/activitiesOverthrow.js
+++ b/src/models/activitiesOverthrow.js
@@ -1,0 +1,6 @@
+const activitiesOverthrow = {
+  Dates: { presence: true, daterange: true },
+  Reasons: { presence: true, hasValue: true },
+}
+
+export default activitiesOverthrow

--- a/src/models/debarred.js
+++ b/src/models/debarred.js
@@ -1,0 +1,7 @@
+const debarred = {
+  Agency: { presence: true, hasValue: true },
+  Date: { presence: true, date: true },
+  Explanation: { presence: true, hasValue: true },
+}
+
+export default debarred

--- a/src/models/domesticViolence.js
+++ b/src/models/domesticViolence.js
@@ -1,0 +1,13 @@
+import offense from 'models/shared/locations/offense'
+
+const domesticViolence = {
+  CourtAddress: {
+    presence: true,
+    location: { validator: offense },
+  },
+  CourtName: { presence: true, hasValue: true },
+  Explanation: { presence: true, hasValue: true },
+  Issued: { presence: true, date: { requireDay: false } },
+}
+
+export default domesticViolence

--- a/src/models/investigation.js
+++ b/src/models/investigation.js
@@ -1,0 +1,58 @@
+import { checkValueIncluded } from 'models/validate'
+import {
+  US_DEPT_OF_TREASURY, FOREIGN_GOVT, OTHER,
+} from 'constants/enums/legalOptions'
+
+export const clearanceLevel = {
+  Level: { presence: true, hasValue: true },
+  Explanation: (value, attributes) => {
+    if (attributes.Level && attributes.Level.value === 'Other') {
+      return { presence: true, hasValue: true }
+    }
+    return {}
+  },
+}
+
+const investigation = {
+  Agency: (value, attributes) => {
+    if (attributes.AgencyNotApplicable
+      && attributes.AgencyNotApplicable.applicable === false) {
+      return {}
+    }
+
+    return { presence: true, hasValue: true }
+  },
+  AgencyExplanation: (value, attributes) => {
+    if (checkValueIncluded(attributes.Agency, [US_DEPT_OF_TREASURY, FOREIGN_GOVT, OTHER])) {
+      return { presence: true, hasValue: true }
+    }
+
+    return {}
+  },
+  Completed: (value, attributes) => {
+    if (attributes.CompletedNotApplicable
+      && attributes.CompletedNotApplicable.applicable === false) {
+      return {}
+    }
+
+    return { presence: true, date: true }
+  },
+  Granted: (value, attributes) => {
+    if (attributes.GrantedNotApplicable
+      && attributes.GrantedNotApplicable.applicable === false) {
+      return {}
+    }
+
+    return { presence: true, date: true }
+  },
+  ClearanceLevel: (value, attributes) => {
+    if (attributes.ClearanceLevelNotApplicable
+      && attributes.ClearanceLevelNotApplicable.applicable === false) {
+      return {}
+    }
+
+    return { presence: true, model: { validator: clearanceLevel } }
+  },
+}
+
+export default investigation

--- a/src/models/manipulatingTech.js
+++ b/src/models/manipulatingTech.js
@@ -1,0 +1,10 @@
+import address from 'models/shared/locations/address'
+
+const manipulatingTech = {
+  Date: { presence: true, date: true },
+  Incident: { presence: true, hasValue: true },
+  Location: { presence: true, location: { validator: address } },
+  Action: { presence: true, hasValue: true },
+}
+
+export default manipulatingTech

--- a/src/models/nonCriminalCourtAction.js
+++ b/src/models/nonCriminalCourtAction.js
@@ -1,0 +1,12 @@
+import address from 'models/shared/locations/address'
+
+const nonCriminalCourtAction = {
+  CivilActionDate: { presence: true, date: true },
+  CourtName: { presence: true, hasValue: true },
+  CourtAddress: { presence: true, location: { validator: address } },
+  NatureOfAction: { presence: true, hasValue: true },
+  ResultsOfAction: { presence: true, hasValue: true },
+  PrincipalPartyNames: { presence: true, hasValue: true },
+}
+
+export default nonCriminalCourtAction

--- a/src/models/overthrow.js
+++ b/src/models/overthrow.js
@@ -1,0 +1,26 @@
+import address from 'models/shared/locations/address'
+
+const overthrow = {
+  Organization: { presence: true, hasValue: true },
+  Address: { presence: true, location: { validator: address } },
+  Dates: { presence: true, daterange: true },
+  Positions: (value, attributes) => {
+    if (attributes.PositionsNotApplicable
+      && attributes.PositionsNotApplicable.applicable === false) {
+      return {}
+    }
+
+    return { presence: true, hasValue: true }
+  },
+  Contributions: (value, attributes) => {
+    if (attributes.ContributionsNotApplicable
+      && attributes.ContributionsNotApplicable.applicable === false) {
+      return {}
+    }
+
+    return { presence: true, hasValue: true }
+  },
+  Reasons: { presence: true, hasValue: true },
+}
+
+export default overthrow

--- a/src/models/terrorism.js
+++ b/src/models/terrorism.js
@@ -1,0 +1,17 @@
+import { hasYesOrNo } from 'models/validate'
+
+const terrorism = {
+  HasTerrorism: { presence: true, hasValue: { validator: hasYesOrNo } },
+  Explanation: (value, attributes) => {
+    if (attributes.HasTerrorism && attributes.HasTerrorism.value === 'Yes') {
+      return {
+        presence: true,
+        hasValue: true,
+      }
+    }
+
+    return {}
+  },
+}
+
+export default terrorism

--- a/src/models/terrorismAdvocate.js
+++ b/src/models/terrorismAdvocate.js
@@ -1,0 +1,6 @@
+const terrorismAdvocate = {
+  Dates: { presence: true, daterange: true },
+  Reasons: { presence: true, hasValue: true },
+}
+
+export default terrorismAdvocate

--- a/src/models/terrorismEngaged.js
+++ b/src/models/terrorismEngaged.js
@@ -1,0 +1,6 @@
+const terrorismEngaged = {
+  Dates: { presence: true, daterange: true },
+  Reasons: { presence: true, hasValue: true },
+}
+
+export default terrorismEngaged

--- a/src/models/terrorist.js
+++ b/src/models/terrorist.js
@@ -1,0 +1,26 @@
+import address from 'models/shared/locations/address'
+
+const terrorist = {
+  Organization: { presence: true, hasValue: true },
+  Address: { presence: true, location: { validator: address } },
+  Dates: { presence: true, daterange: true },
+  Positions: (value, attributes) => {
+    if (attributes.PositionsNotApplicable
+      && attributes.PositionsNotApplicable.applicable === false) {
+      return {}
+    }
+
+    return { presence: true, hasValue: true }
+  },
+  Contributions: (value, attributes) => {
+    if (attributes.ContributionsNotApplicable
+      && attributes.ContributionsNotApplicable.applicable === false) {
+      return {}
+    }
+
+    return { presence: true, hasValue: true }
+  },
+  Reasons: { presence: true, hasValue: true },
+}
+
+export default terrorist

--- a/src/models/unauthorizedTech.js
+++ b/src/models/unauthorizedTech.js
@@ -1,0 +1,10 @@
+import address from 'models/shared/locations/address'
+
+const unauthorizedTech = {
+  Date: { presence: true, date: true },
+  Incident: { presence: true, hasValue: true },
+  Location: { presence: true, location: { validator: address } },
+  Action: { presence: true, hasValue: true },
+}
+
+export default unauthorizedTech

--- a/src/models/unlawfulTech.js
+++ b/src/models/unlawfulTech.js
@@ -1,0 +1,10 @@
+import address from 'models/shared/locations/address'
+
+const unlawfulTech = {
+  Date: { presence: true, date: true },
+  Incident: { presence: true, hasValue: true },
+  Location: { presence: true, location: { validator: address } },
+  Action: { presence: true, hasValue: true },
+}
+
+export default unlawfulTech

--- a/src/models/violence.js
+++ b/src/models/violence.js
@@ -1,0 +1,26 @@
+import address from 'models/shared/locations/address'
+
+const violence = {
+  Organization: { presence: true, hasValue: true },
+  Address: { presence: true, location: { validator: address } },
+  Dates: { presence: true, daterange: true },
+  Positions: (value, attributes) => {
+    if (attributes.PositionsNotApplicable
+      && attributes.PositionsNotApplicable.applicable === false) {
+      return {}
+    }
+
+    return { presence: true, hasValue: true }
+  },
+  Contributions: (value, attributes) => {
+    if (attributes.ContributionsNotApplicable
+      && attributes.ContributionsNotApplicable.applicable === false) {
+      return {}
+    }
+
+    return { presence: true, hasValue: true }
+  },
+  Reasons: { presence: true, hasValue: true },
+}
+
+export default violence

--- a/src/validators/domesticviolence.js
+++ b/src/validators/domesticviolence.js
@@ -1,46 +1,44 @@
-import LocationValidator from './location'
-import {
-  validGenericTextfield,
-  validGenericMonthYear,
-  validBranch,
-  validAccordion
-} from './helpers'
+import { validateModel, hasYesOrNo } from 'models/validate'
+import domesticViolence from 'models/domesticViolence'
+
+export const validateDomesticViolenceItem = data => (
+  validateModel(data, domesticViolence) === true
+)
+
+export const validateDomesticViolence = (data) => {
+  const domesticViolenceModel = {
+    HasDomesticViolence: { presence: true, hasValue: { validator: hasYesOrNo } },
+    List: (value, attributes) => {
+      if (attributes.HasDomesticViolence && attributes.HasDomesticViolence.value === 'Yes') {
+        return {
+          presence: true,
+          accordion: { validator: domesticViolence },
+        }
+      }
+
+      return {}
+    },
+  }
+
+  return validateModel(data, domesticViolenceModel) === true
+}
 
 export default class DomesticViolence {
   constructor(data = {}) {
-    this.hasDomesticViolence = (data.HasDomesticViolence || {}).value
-    this.list = data.List || []
-  }
-
-  validItems() {
-    if (this.hasDomesticViolence === 'No') {
-      return true
-    }
-
-    return validAccordion(this.list, item => {
-      return new DomesticViolenceItem(item).isValid()
-    })
+    this.data = data
   }
 
   isValid() {
-    return validBranch(this.hasDomesticViolence) && this.validItems()
+    return validateDomesticViolence(this.data)
   }
 }
 
 export class DomesticViolenceItem {
   constructor(data = {}) {
-    this.courtAddress = data.CourtAddress
-    this.courtName = data.CourtName
-    this.explanation = data.Explanation
-    this.issued = data.Issued
+    this.data = data
   }
 
   isValid() {
-    return (
-      new LocationValidator(this.courtAddress).isValid() &&
-      validGenericTextfield(this.courtName) &&
-      validGenericTextfield(this.explanation) &&
-      validGenericMonthYear(this.issued)
-    )
+    return validateDomesticViolenceItem(this.data)
   }
 }

--- a/src/validators/legalassociationsterrorism.js
+++ b/src/validators/legalassociationsterrorism.js
@@ -1,20 +1,16 @@
-import { validGenericTextfield } from './helpers'
+import { validateModel } from 'models/validate'
+import terrorism from 'models/terrorism'
+
+export const validateLegalAssociationTerrorism = data => (
+  validateModel(data, terrorism) === true
+)
 
 export default class LegalAssociationTerrorismValidator {
   constructor(data = {}) {
-    this.hasTerrorism = (data.HasTerrorism || {}).value
-    this.explanation = data.Explanation
+    this.data = data
   }
 
   isValid() {
-    if (this.hasTerrorism === 'No') {
-      return true
-    }
-
-    if (this.hasTerrorism === 'Yes') {
-      return !!this.explanation && validGenericTextfield(this.explanation)
-    }
-
-    return false
+    return validateLegalAssociationTerrorism(this.data)
   }
 }

--- a/src/validators/legaltechnologymanipulating.js
+++ b/src/validators/legaltechnologymanipulating.js
@@ -1,61 +1,67 @@
-import LocationValidator from './location'
-import {
-  validAccordion,
-  validGenericTextfield,
-  validDateField
-} from './helpers'
+import { validateModel, hasYesOrNo } from 'models/validate'
+import manipulatingTech from 'models/manipulatingTech'
+
+export const validateManipulatingTech = data => (
+  validateModel(data, manipulatingTech) === true
+)
+
+export const validateLegalTechnologyManipulating = (data) => {
+  const legalTechnologyManipulatingModel = {
+    HasManipulating: { presence: true, hasValue: { validator: hasYesOrNo } },
+    List: (value, attributes) => {
+      if (attributes.HasManipulating && attributes.HasManipulating.value === 'Yes') {
+        return {
+          presence: true,
+          accordion: { validator: manipulatingTech },
+        }
+      }
+      return {}
+    },
+  }
+
+  return validateModel(data, legalTechnologyManipulatingModel) === true
+}
 
 export default class LegalTechnologyManipulatingValidator {
   constructor(data = {}) {
-    this.hasManipulating = (data.HasManipulating || {}).value
-    this.list = data.List || {}
-  }
-
-  validList() {
-    if (this.hasManipulating === 'No') {
-      return true
-    }
-
-    return validAccordion(this.list, item => {
-      return new ManipulatingValidator(item).isValid()
-    })
+    this.data = data
   }
 
   isValid() {
-    return this.validList()
+    return validateLegalTechnologyManipulating(this.data)
   }
 }
 
 export class ManipulatingValidator {
   constructor(data = {}) {
-    this.date = data.Date
-    this.incident = data.Incident
-    this.location = data.Location
-    this.action = data.Action
+    this.data = data
   }
 
   validDate() {
-    return !!this.date && validDateField(this.date)
+    return validateModel(this.data, {
+      Date: manipulatingTech.Date,
+    }) === true
   }
 
   validIncident() {
-    return !!this.incident && validGenericTextfield(this.incident)
+    return validateModel(this.data, {
+      Incident: manipulatingTech.Incident,
+    }) === true
   }
 
   validLocation() {
-    return !!this.location && new LocationValidator(this.location).isValid()
+    return validateModel(this.data, {
+      Location: manipulatingTech.Location,
+    }) === true
   }
 
   validAction() {
-    return !!this.action && validGenericTextfield(this.action)
+    return validateModel(this.data, {
+      Action: manipulatingTech.Action,
+    }) === true
   }
 
   isValid() {
-    return (
-      this.validDate() &&
-      this.validIncident() &&
-      this.validLocation() &&
-      this.validAction()
-    )
+    return validateManipulatingTech(this.data)
   }
 }

--- a/src/validators/legaltechnologyunlawful.js
+++ b/src/validators/legaltechnologyunlawful.js
@@ -1,61 +1,67 @@
-import LocationValidator from './location'
-import {
-  validAccordion,
-  validGenericTextfield,
-  validDateField
-} from './helpers'
+import { validateModel, hasYesOrNo } from 'models/validate'
+import unlawfulTech from 'models/unlawfulTech'
+
+export const validateUnlawfulTech = data => (
+  validateModel(data, unlawfulTech) === true
+)
+
+export const validateLegalTechnologyUnlawful = (data) => {
+  const legalTechnologyUnlawfulModel = {
+    HasUnlawful: { presence: true, hasValue: { validator: hasYesOrNo } },
+    List: (value, attributes) => {
+      if (attributes.HasUnlawful && attributes.HasUnlawful.value === 'Yes') {
+        return {
+          presence: true,
+          accordion: { validator: unlawfulTech },
+        }
+      }
+      return {}
+    },
+  }
+
+  return validateModel(data, legalTechnologyUnlawfulModel) === true
+}
 
 export default class LegalTechnologyUnlawfulValidator {
   constructor(data = {}) {
-    this.hasUnlawful = (data.HasUnlawful || {}).value
-    this.list = data.List || {}
-  }
-
-  validList() {
-    if (this.hasUnlawful === 'No') {
-      return true
-    }
-
-    return validAccordion(this.list, item => {
-      return new UnlawfulValidator(item).isValid()
-    })
+    this.data = data
   }
 
   isValid() {
-    return this.validList()
+    return validateLegalTechnologyUnlawful(this.data)
   }
 }
 
 export class UnlawfulValidator {
   constructor(data = {}) {
-    this.date = data.Date
-    this.incident = data.Incident
-    this.location = data.Location
-    this.action = data.Action
+    this.data = data
   }
 
   validDate() {
-    return !!this.date && validDateField(this.date)
+    return validateModel(this.data, {
+      Date: unlawfulTech.Date,
+    }) === true
   }
 
   validIncident() {
-    return !!this.incident && validGenericTextfield(this.incident)
+    return validateModel(this.data, {
+      Incident: unlawfulTech.Incident,
+    }) === true
   }
 
   validLocation() {
-    return !!this.location && new LocationValidator(this.location).isValid()
+    return validateModel(this.data, {
+      Location: unlawfulTech.Location,
+    }) === true
   }
 
   validAction() {
-    return !!this.action && validGenericTextfield(this.action)
+    return validateModel(this.data, {
+      Action: unlawfulTech.Action,
+    }) === true
   }
 
   isValid() {
-    return (
-      this.validDate() &&
-      this.validIncident() &&
-      this.validLocation() &&
-      this.validAction()
-    )
+    return validateUnlawfulTech(this.data)
   }
 }


### PR DESCRIPTION
## Description

- Validation models for entire Legal section
- Includes tickets: EN-3754, EN-3755, EN-3757, EN-3758, EN-3759, EN-3760, EN-3761, EN-3756, EN-3762, EN-3763, EN-3764, EN-3765, EN-3766, EN-3767, EN-3768

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify you are able to validate all subsections in the Legal section
- [ ] Verify if you enter invalid data in the Legal section, it does not pass validation
- [ ] Verify that loading test cases with Legal section data pass validation
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
