### PR TITLE
Validation Refactor - Substance Use

### DIFF
--- a/src/models/__tests__/alcoholNegativeImpact.test.js
+++ b/src/models/__tests__/alcoholNegativeImpact.test.js
@@ -1,0 +1,75 @@
+import { validateModel } from 'models/validate'
+import alcoholNegativeImpact from '../alcoholNegativeImpact'
+
+describe('The alcoholNegativeImpact model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Occurred.required',
+      'Circumstances.required',
+      'NegativeImpact.required',
+      'Used.required',
+    ]
+
+    expect(validateModel(testData, alcoholNegativeImpact))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Occurred must be a valid month/year', () => {
+    const testData = {
+      Occurred: 'invalid',
+    }
+    const expectedErrors = [
+      'Occurred.date',
+    ]
+
+    expect(validateModel(testData, alcoholNegativeImpact))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Circumstances must have a value', () => {
+    const testData = { Circumstances: 'testing' }
+    const expectedErrors = [
+      'Circumstances.hasValue',
+    ]
+
+    expect(validateModel(testData, alcoholNegativeImpact))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('NegativeImpact must have a value', () => {
+    const testData = { NegativeImpact: 'testing' }
+    const expectedErrors = [
+      'NegativeImpact.hasValue',
+    ]
+
+    expect(validateModel(testData, alcoholNegativeImpact))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Used must be a valid date range', () => {
+    const testData = {
+      Used: false,
+    }
+    const expectedErrors = [
+      'Used.daterange',
+    ]
+
+    expect(validateModel(testData, alcoholNegativeImpact))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid alcoholNegativeImpact', () => {
+    const testData = {
+      Occurred: { month: 5, year: 2003 },
+      Circumstances: { value: 'Testing' },
+      NegativeImpact: { value: 'Something bad happened' },
+      Used: {
+        from: { month: 8, day: 20, year: 2010 },
+        to: { month: 10, day: 23, year: 2012 },
+      },
+    }
+
+    expect(validateModel(testData, alcoholNegativeImpact)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/alcoholOrderedCounseling.test.js
+++ b/src/models/__tests__/alcoholOrderedCounseling.test.js
@@ -1,0 +1,234 @@
+import { validateModel } from 'models/validate'
+import alcoholOrderedCounseling from '../alcoholOrderedCounseling'
+
+describe('The alcoholOrderedCounseling model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'ActionTaken.required',
+    ]
+
+    expect(validateModel(testData, alcoholOrderedCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if Seekers includes "Other"', () => {
+    it('OtherSeeker must have a value', () => {
+      const testData = {
+        Seekers: { values: ['Other'] },
+        OtherSeeker: 'test',
+      }
+      const expectedErrors = [
+        'OtherSeeker.hasValue',
+      ]
+
+      expect(validateModel(testData, alcoholOrderedCounseling))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid alcoholOrderedCounseling', () => {
+      const testData = {
+        Seekers: { values: ['Other'] },
+        OtherSeeker: { value: 'Someone else' },
+        ActionTaken: { value: 'Yes' },
+        TreatmentProviderName: { value: 'Testing' },
+        TreatmentProviderAddress: {
+          street: '50 Provider ST',
+          city: 'New York',
+          state: 'NY',
+          zipcode: '10023',
+          country: 'United States',
+        },
+        TreatmentProviderTelephone: {
+          number: '1234567890',
+          type: 'Domestic',
+          timeOfDay: 'Both',
+        },
+        CounselingDates: {
+          from: { month: 8, day: 20, year: 2010 },
+          to: { month: 10, day: 23, year: 2012 },
+        },
+        CompletedTreatment: { value: 'No' },
+        NoCompletedTreatmentExplanation: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, alcoholOrderedCounseling)).toEqual(true)
+    })
+  })
+
+  it('ActionTaken must have a valid value', () => {
+    const testData = {
+      ActionTaken: { value: true },
+    }
+    const expectedErrors = [
+      'ActionTaken.hasValue',
+    ]
+
+    expect(validateModel(testData, alcoholOrderedCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if ActionTaken is "Yes"', () => {
+    it('TreatmentProviderName must have a value', () => {
+      const testData = {
+        ActionTaken: { value: 'Yes' },
+      }
+      const expectedErrors = [
+        'TreatmentProviderName.required',
+        'TreatmentProviderName.hasValue',
+      ]
+
+      expect(validateModel(testData, alcoholOrderedCounseling))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('TreatmentProviderAddress must be a valid location', () => {
+      const testData = {
+        ActionTaken: { value: 'Yes' },
+        TreatmentProviderAddress: 'invalid address',
+      }
+      const expectedErrors = [
+        'TreatmentProviderAddress.location',
+      ]
+
+      expect(validateModel(testData, alcoholOrderedCounseling))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('TreatmentProviderTelephone must be a valid phone', () => {
+      const testData = {
+        ActionTaken: { value: 'Yes' },
+        TreatmentProviderTelephone: '1234567890',
+      }
+      const expectedErrors = [
+        'TreatmentProviderTelephone.model',
+      ]
+
+      expect(validateModel(testData, alcoholOrderedCounseling))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('CounselingDates must be a valid date range', () => {
+      const testData = {
+        ActionTaken: { value: 'Yes' },
+        CounselingDates: false,
+      }
+      const expectedErrors = [
+        'CounselingDates.daterange',
+      ]
+
+      expect(validateModel(testData, alcoholOrderedCounseling))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('CompletedTreatment must have a valid value', () => {
+      const testData = {
+        ActionTaken: { value: 'Yes' },
+        CompletedTreatment: true,
+      }
+      const expectedErrors = [
+        'CompletedTreatment.hasValue',
+      ]
+
+      expect(validateModel(testData, alcoholOrderedCounseling))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    describe('if CompletedTreatment is "Yes"', () => {
+      it('passes a valid alcoholOrderedCounseling', () => {
+        const testData = {
+          Seekers: { values: ['Test', 'Test 2'] },
+          ActionTaken: { value: 'Yes' },
+          TreatmentProviderName: { value: 'Testing' },
+          TreatmentProviderAddress: {
+            street: '50 Provider ST',
+            city: 'New York',
+            state: 'NY',
+            zipcode: '10023',
+            country: 'United States',
+          },
+          TreatmentProviderTelephone: {
+            number: '1234567890',
+            type: 'Domestic',
+            timeOfDay: 'Both',
+          },
+          CounselingDates: {
+            from: { month: 8, day: 20, year: 2010 },
+            to: { month: 10, day: 23, year: 2012 },
+          },
+          CompletedTreatment: { value: 'Yes' },
+        }
+
+        expect(validateModel(testData, alcoholOrderedCounseling)).toEqual(true)
+      })
+    })
+
+    describe('if CompletedTreatment is "No', () => {
+      it('NoCompletedTreatmentExplanation must have a value', () => {
+        const testData = {
+          ActionTaken: { value: 'Yes' },
+          CompletedTreatment: { value: 'No' },
+        }
+        const expectedErrors = [
+          'NoCompletedTreatmentExplanation.required',
+          'NoCompletedTreatmentExplanation.hasValue',
+        ]
+
+        expect(validateModel(testData, alcoholOrderedCounseling))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('passes a valid alcoholOrderedCounseling', () => {
+        const testData = {
+          Seekers: { values: [] },
+          ActionTaken: { value: 'Yes' },
+          TreatmentProviderName: { value: 'Testing' },
+          TreatmentProviderAddress: {
+            street: '50 Provider ST',
+            city: 'New York',
+            state: 'NY',
+            zipcode: '10023',
+            country: 'United States',
+          },
+          TreatmentProviderTelephone: {
+            number: '1234567890',
+            type: 'Domestic',
+            timeOfDay: 'Both',
+          },
+          CounselingDates: {
+            from: { month: 8, day: 20, year: 2010 },
+            to: { month: 10, day: 23, year: 2012 },
+          },
+          CompletedTreatment: { value: 'No' },
+          NoCompletedTreatmentExplanation: { value: 'Because' },
+        }
+
+        expect(validateModel(testData, alcoholOrderedCounseling)).toEqual(true)
+      })
+    })
+  })
+
+  describe('if ActionTaken is "No"', () => {
+    it('NoActionTakenExplanation must have a value', () => {
+      const testData = {
+        ActionTaken: { value: 'No' },
+      }
+      const expectedErrors = [
+        'NoActionTakenExplanation.required',
+        'NoActionTakenExplanation.hasValue',
+      ]
+
+      expect(validateModel(testData, alcoholOrderedCounseling))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid alcoholOrderedCounseling', () => {
+      const testData = {
+        ActionTaken: { value: 'No' },
+        NoActionTakenExplanation: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, alcoholOrderedCounseling)).toEqual(true)
+    })
+  })
+})

--- a/src/models/__tests__/alcoholReceivedCounseling.test.js
+++ b/src/models/__tests__/alcoholReceivedCounseling.test.js
@@ -1,0 +1,234 @@
+import { validateModel } from 'models/validate'
+import alcoholReceivedCounseling from '../alcoholReceivedCounseling'
+
+describe('The alcoholReceivedCounseling model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'TreatmentProviderName.required',
+      'UseSameAddress.required',
+      'TreatmentProviderAddress.required',
+      'AgencyName.required',
+      'CompletedTreatment.required',
+      'TreatmentBeganDate.required',
+      'TreatmentEndDate.required',
+      'TreatmentDates.required',
+      'NoCompletedTreatmentExplanation.required',
+    ]
+
+    expect(validateModel(testData, alcoholReceivedCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('TreatmentProviderName must have a value', () => {
+    const testData = {
+      TreatmentProviderName: { value: '' },
+    }
+    const expectedErrors = [
+      'TreatmentProviderName.hasValue',
+    ]
+
+    expect(validateModel(testData, alcoholReceivedCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('UseSameAddress must have a valid value', () => {
+    const testData = {
+      UseSameAddress: { value: true },
+    }
+    const expectedErrors = [
+      'UseSameAddress.hasValue',
+    ]
+
+    expect(validateModel(testData, alcoholReceivedCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('TreatmentProviderAddress must be a valid location', () => {
+    const testData = {
+      TreatmentProviderAddress: 'invalid address',
+    }
+    const expectedErrors = [
+      'TreatmentProviderAddress.location',
+    ]
+
+    expect(validateModel(testData, alcoholReceivedCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if UseSameAddress is "Yes"', () => {
+    it('AgencyAddress is not required', () => {
+      const testData = {
+        UseSameAddress: { value: 'Yes' },
+      }
+      const expectedErrors = [
+        'AgencyAddress.required',
+      ]
+
+      expect(validateModel(testData, alcoholReceivedCounseling))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid alcoholReceivedCounseling', () => {
+      const testData = {
+        TreatmentProviderName: { value: 'Testing' },
+        TreatmentProviderAddress: {
+          street: '50 Provider ST',
+          city: 'New York',
+          state: 'NY',
+          zipcode: '10023',
+          country: 'United States',
+        },
+        AgencyName: { value: 'Testing' },
+        UseSameAddress: { value: 'Yes' },
+        TreatmentBeganDate: { month: 8, day: 20, year: 2010 },
+        TreatmentEndDate: { month: 10, day: 23, year: 2012 },
+        TreatmentDates: {
+          from: { month: 8, day: 20, year: 2010 },
+          to: { month: 10, day: 23, year: 2012 },
+        },
+        CompletedTreatment: { value: 'Yes' },
+        NoCompletedTreatmentExplanation: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, alcoholReceivedCounseling)).toEqual(true)
+    })
+  })
+
+  describe('if UseSameAddress is "No"', () => {
+    it('AgencyAddress is required', () => {
+      const testData = {
+        UseSameAddress: { value: 'No' },
+      }
+      const expectedErrors = [
+        'AgencyAddress.required',
+      ]
+
+      expect(validateModel(testData, alcoholReceivedCounseling))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('AgencyAddress must be a valid location', () => {
+      const testData = {
+        UseSameAddress: { value: 'No' },
+        AgencyAddress: 'invalid address',
+      }
+      const expectedErrors = [
+        'AgencyAddress.location',
+      ]
+
+      expect(validateModel(testData, alcoholReceivedCounseling))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid alcoholReceivedCounseling', () => {
+      const testData = {
+        TreatmentProviderName: { value: 'Testing' },
+        TreatmentProviderAddress: {
+          street: '50 Provider ST',
+          city: 'New York',
+          state: 'NY',
+          zipcode: '10023',
+          country: 'United States',
+        },
+        AgencyName: { value: 'Testing' },
+        AgencyAddress: {
+          street: '50 Agency ST',
+          city: 'New York',
+          state: 'NY',
+          zipcode: '10023',
+          country: 'United States',
+        },
+        UseSameAddress: { value: 'No' },
+        TreatmentBeganDate: { month: 8, day: 20, year: 2010 },
+        TreatmentEndDate: { month: 10, day: 23, year: 2012 },
+        TreatmentDates: {
+          from: { month: 8, day: 20, year: 2010 },
+          to: { month: 10, day: 23, year: 2012 },
+        },
+        CompletedTreatment: { value: 'No' },
+        NoCompletedTreatmentExplanation: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, alcoholReceivedCounseling)).toEqual(true)
+    })
+  })
+
+  it('AgencyName must have a value', () => {
+    const testData = {
+      AgencyName: { value: '' },
+    }
+    const expectedErrors = [
+      'AgencyName.hasValue',
+    ]
+
+    expect(validateModel(testData, alcoholReceivedCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('TreatmentDates must be a valid date range', () => {
+    const testData = {
+      TreatmentDates: false,
+    }
+    const expectedErrors = [
+      'TreatmentDates.daterange',
+    ]
+
+    expect(validateModel(testData, alcoholReceivedCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('CompletedTreatment must have a valid value', () => {
+    const testData = {
+      CompletedTreatment: true,
+    }
+    const expectedErrors = [
+      'CompletedTreatment.hasValue',
+    ]
+
+    expect(validateModel(testData, alcoholReceivedCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('NoCompletedTreatmentExplanation must have a value', () => {
+    const testData = {}
+    const expectedErrors = [
+      'NoCompletedTreatmentExplanation.hasValue',
+    ]
+
+    expect(validateModel(testData, alcoholReceivedCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid alcoholReceivedCounseling', () => {
+    const testData = {
+      TreatmentProviderName: { value: 'Testing' },
+      TreatmentProviderAddress: {
+        street: '50 Provider ST',
+        city: 'New York',
+        state: 'NY',
+        zipcode: '10023',
+        country: 'United States',
+      },
+      AgencyName: { value: 'Testing' },
+      AgencyAddress: {
+        street: '50 Agency ST',
+        city: 'New York',
+        state: 'NY',
+        zipcode: '10023',
+        country: 'United States',
+      },
+      UseSameAddress: { value: 'No' },
+      TreatmentBeganDate: { month: 8, day: 20, year: 2010 },
+      TreatmentEndDate: { month: 10, day: 23, year: 2012 },
+      TreatmentDates: {
+        from: { month: 8, day: 20, year: 2010 },
+        to: { month: 10, day: 23, year: 2012 },
+      },
+      CompletedTreatment: { value: 'Yes' },
+      NoCompletedTreatmentExplanation: { value: 'Because' },
+    }
+
+    expect(validateModel(testData, alcoholReceivedCounseling)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/alcoholVoluntaryCounseling.test.js
+++ b/src/models/__tests__/alcoholVoluntaryCounseling.test.js
@@ -1,0 +1,146 @@
+import { validateModel } from 'models/validate'
+import alcoholVoluntaryCounseling from '../alcoholVoluntaryCounseling'
+
+describe('The alcoholVoluntaryCounseling model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'CounselingDates.required',
+      'TreatmentProviderName.required',
+      'TreatmentProviderAddress.required',
+      'TreatmentProviderTelephone.required',
+      'CompletedTreatment.required',
+    ]
+
+    expect(validateModel(testData, alcoholVoluntaryCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('TreatmentProviderName must have a value', () => {
+    const testData = {
+      TreatmentProviderName: { value: '' },
+    }
+    const expectedErrors = [
+      'TreatmentProviderName.hasValue',
+    ]
+
+    expect(validateModel(testData, alcoholVoluntaryCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('TreatmentProviderAddress must be a valid location', () => {
+    const testData = {
+      TreatmentProviderAddress: 'invalid address',
+    }
+    const expectedErrors = [
+      'TreatmentProviderAddress.location',
+    ]
+
+    expect(validateModel(testData, alcoholVoluntaryCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('TreatmentProviderTelephone must be a valid phone', () => {
+    const testData = {
+      TreatmentProviderTelephone: '1234567890',
+    }
+    const expectedErrors = [
+      'TreatmentProviderTelephone.model',
+    ]
+
+    expect(validateModel(testData, alcoholVoluntaryCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('CounselingDates must be a valid date range', () => {
+    const testData = {
+      CounselingDates: false,
+    }
+    const expectedErrors = [
+      'CounselingDates.daterange',
+    ]
+
+    expect(validateModel(testData, alcoholVoluntaryCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('CompletedTreatment must have a valid value', () => {
+    const testData = {
+      CompletedTreatment: true,
+    }
+    const expectedErrors = [
+      'CompletedTreatment.hasValue',
+    ]
+
+    expect(validateModel(testData, alcoholVoluntaryCounseling))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if CompletedTreatment is "Yes"', () => {
+    it('passes a valid alcoholVoluntaryCounseling', () => {
+      const testData = {
+        TreatmentProviderName: { value: 'Testing' },
+        TreatmentProviderAddress: {
+          street: '50 Provider ST',
+          city: 'New York',
+          state: 'NY',
+          zipcode: '10023',
+          country: 'United States',
+        },
+        TreatmentProviderTelephone: {
+          number: '1234567890',
+          type: 'Domestic',
+          timeOfDay: 'Both',
+        },
+        CounselingDates: {
+          from: { month: 8, day: 20, year: 2010 },
+          to: { month: 10, day: 23, year: 2012 },
+        },
+        CompletedTreatment: { value: 'Yes' },
+      }
+
+      expect(validateModel(testData, alcoholVoluntaryCounseling)).toEqual(true)
+    })
+  })
+
+  describe('if CompletedTreatment is "No', () => {
+    it('NoCompletedTreatmentExplanation must have a value', () => {
+      const testData = {
+        CompletedTreatment: { value: 'No' },
+      }
+      const expectedErrors = [
+        'NoCompletedTreatmentExplanation.required',
+        'NoCompletedTreatmentExplanation.hasValue',
+      ]
+
+      expect(validateModel(testData, alcoholVoluntaryCounseling))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid alcoholVoluntaryCounseling', () => {
+      const testData = {
+        TreatmentProviderName: { value: 'Testing' },
+        TreatmentProviderAddress: {
+          street: '50 Provider ST',
+          city: 'New York',
+          state: 'NY',
+          zipcode: '10023',
+          country: 'United States',
+        },
+        TreatmentProviderTelephone: {
+          number: '1234567890',
+          type: 'Domestic',
+          timeOfDay: 'Both',
+        },
+        CounselingDates: {
+          from: { month: 8, day: 20, year: 2010 },
+          to: { month: 10, day: 23, year: 2012 },
+        },
+        CompletedTreatment: { value: 'No' },
+        NoCompletedTreatmentExplanation: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, alcoholVoluntaryCounseling)).toEqual(true)
+    })
+  })
+})

--- a/src/models/__tests__/drugClearanceUse.test.js
+++ b/src/models/__tests__/drugClearanceUse.test.js
@@ -1,0 +1,65 @@
+import { validateModel } from 'models/validate'
+import drugClearanceUse from '../drugClearanceUse'
+
+describe('The drugClearanceUse model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Description.required',
+      'InvolvementDates.required',
+      'EstimatedUse.required',
+    ]
+
+    expect(validateModel(testData, drugClearanceUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Description must have a value', () => {
+    const testData = {
+      Description: 'testing',
+    }
+    const expectedErrors = [
+      'Description.hasValue',
+    ]
+
+    expect(validateModel(testData, drugClearanceUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('InvolvementDates must be a valid date range', () => {
+    const testData = {
+      InvolvementDates: { day: 5, month: 10 },
+    }
+    const expectedErrors = [
+      'InvolvementDates.daterange',
+    ]
+
+    expect(validateModel(testData, drugClearanceUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('EstimatedUse must have a value', () => {
+    const testData = {
+      EstimatedUse: 'testing',
+    }
+    const expectedErrors = [
+      'EstimatedUse.hasValue',
+    ]
+
+    expect(validateModel(testData, drugClearanceUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid drugClearanceUse', () => {
+    const testData = {
+      InvolvementDates: {
+        from: { day: 2, month: 2, year: 1999 },
+        to: { day: 5, month: 5, year: 2001 },
+      },
+      Description: { value: 'Testing' },
+      EstimatedUse: { value: 'testing' },
+    }
+
+    expect(validateModel(testData, drugClearanceUse)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/drugInvolvement.test.js
+++ b/src/models/__tests__/drugInvolvement.test.js
@@ -1,0 +1,225 @@
+import { validateModel } from 'models/validate'
+import drugInvolvement from '../drugInvolvement'
+
+describe('The drugInvolvement model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'FirstInvolvement.required',
+      'RecentInvolvement.required',
+      'NatureOfInvolvement.required',
+      'Reasons.required',
+      'InvolvementWhileEmployed.required',
+      'InvolvementWithClearance.required',
+      'InvolvementInFuture.required',
+    ]
+
+    expect(validateModel(testData, drugInvolvement))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('FirstInvolvement must be a valid month/year', () => {
+    const testData = {
+      FirstInvolvement: { day: 5, month: 10 },
+    }
+    const expectedErrors = [
+      'FirstInvolvement.date',
+    ]
+
+    expect(validateModel(testData, drugInvolvement))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('RecentInvolvement must be a valid month/year', () => {
+    const testData = {
+      RecentInvolvement: { day: 5, month: 10 },
+    }
+    const expectedErrors = [
+      'RecentInvolvement.date',
+    ]
+
+    expect(validateModel(testData, drugInvolvement))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('NatureOfInvolvement must have a value', () => {
+    const testData = {
+      NatureOfInvolvement: 'testing',
+    }
+    const expectedErrors = [
+      'NatureOfInvolvement.hasValue',
+    ]
+
+    expect(validateModel(testData, drugInvolvement))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Reasons must have a value', () => {
+    const testData = {
+      Reasons: 'testing',
+    }
+    const expectedErrors = [
+      'Reasons.hasValue',
+    ]
+
+    expect(validateModel(testData, drugInvolvement))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('InvolvementWhileEmployed must have a valid value', () => {
+    const testData = {
+      InvolvementWhileEmployed: { value: 'nope' },
+    }
+    const expectedErrors = [
+      'InvolvementWhileEmployed.hasValue',
+    ]
+
+    expect(validateModel(testData, drugInvolvement))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('InvolvementWithClearance must have a valid value', () => {
+    const testData = {
+      InvolvementWithClearance: { value: 'nope' },
+    }
+    const expectedErrors = [
+      'InvolvementWithClearance.hasValue',
+    ]
+
+    expect(validateModel(testData, drugInvolvement))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('InvolvementInFuture must have a valid value', () => {
+    const testData = {
+      InvolvementInFuture: { value: 'nope' },
+    }
+    const expectedErrors = [
+      'InvolvementInFuture.hasValue',
+    ]
+
+    expect(validateModel(testData, drugInvolvement))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if InvolvementInFuture is "Yes"', () => {
+    it('Explanation must have a value', () => {
+      const testData = {
+        InvolvementInFuture: { value: 'Yes' },
+      }
+      const expectedErrors = [
+        'Explanation.hasValue',
+      ]
+
+      expect(validateModel(testData, drugInvolvement))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid drugInvolvement', () => {
+      const testData = {
+        FirstInvolvement: { month: 2, year: 1999 },
+        RecentInvolvement: { month: 5, year: 2001 },
+        NatureOfInvolvement: { value: 'Testing' },
+        Reasons: { value: 'testing' },
+        InvolvementWhileEmployed: { value: 'No' },
+        InvolvementWithClearance: { value: 'No' },
+        InvolvementInFuture: { value: 'Yes' },
+        Explanation: { value: 'testing' },
+      }
+
+      expect(validateModel(testData, drugInvolvement)).toEqual(true)
+    })
+  })
+
+  describe('if InvolvementWhileEmployed is not required', () => {
+    it('InvolvementWhileEmployed is not required', () => {
+      const testData = {}
+      const expectedErrors = [
+        'InvolvementWhileEmployed.required',
+      ]
+
+      expect(validateModel(testData, drugInvolvement, { requireInvolvementWhileEmployed: false }))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid drugInvolvement', () => {
+      const testData = {
+        FirstInvolvement: { month: 2, year: 1999 },
+        RecentInvolvement: { month: 5, year: 2001 },
+        NatureOfInvolvement: { value: 'Testing' },
+        InvolvementWithClearance: { value: 'No' },
+        InvolvementInFuture: { value: 'No' },
+        Reasons: { value: 'testing' },
+      }
+
+      expect(validateModel(testData, drugInvolvement, { requireInvolvementWhileEmployed: false }))
+        .toEqual(true)
+    })
+  })
+
+  describe('if InvolvementWithClearance is not required', () => {
+    it('InvolvementWithClearance is not required', () => {
+      const testData = {}
+      const expectedErrors = [
+        'InvolvementWithClearance.required',
+      ]
+
+      expect(validateModel(testData, drugInvolvement, { requireInvolvementWithClearance: false }))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid drugInvolvement', () => {
+      const testData = {
+        FirstInvolvement: { month: 2, year: 1999 },
+        RecentInvolvement: { month: 5, year: 2001 },
+        NatureOfInvolvement: { value: 'Testing' },
+        InvolvementWhileEmployed: { value: 'No' },
+        InvolvementInFuture: { value: 'No' },
+        Reasons: { value: 'testing' },
+      }
+
+      expect(validateModel(testData, drugInvolvement, { requireInvolvementWithClearance: false }))
+        .toEqual(true)
+    })
+  })
+
+  describe('if InvolvementInFuture is not required', () => {
+    it('InvolvementInFuture is not required', () => {
+      const testData = {}
+      const expectedErrors = [
+        'InvolvementInFuture.required',
+      ]
+
+      expect(validateModel(testData, drugInvolvement, { requireInvolvementInFuture: false }))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid drugInvolvement', () => {
+      const testData = {
+        FirstInvolvement: { month: 2, year: 1999 },
+        RecentInvolvement: { month: 5, year: 2001 },
+        NatureOfInvolvement: { value: 'Testing' },
+        InvolvementWithClearance: { value: 'No' },
+        InvolvementWhileEmployed: { value: 'Yes' },
+        Reasons: { value: 'testing' },
+      }
+
+      expect(validateModel(testData, drugInvolvement, { requireInvolvementInFuture: false }))
+        .toEqual(true)
+    })
+  })
+
+  it('passes a valid drugInvolvement', () => {
+    const testData = {
+      FirstInvolvement: { month: 2, year: 1999 },
+      RecentInvolvement: { month: 5, year: 2001 },
+      NatureOfInvolvement: { value: 'Testing' },
+      Reasons: { value: 'testing' },
+      InvolvementWhileEmployed: { value: 'No' },
+      InvolvementWithClearance: { value: 'No' },
+      InvolvementInFuture: { value: 'No' },
+    }
+
+    expect(validateModel(testData, drugInvolvement)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/drugOrderedTreatment.test.js
+++ b/src/models/__tests__/drugOrderedTreatment.test.js
@@ -1,0 +1,245 @@
+import { validateModel } from 'models/validate'
+import drugOrderedTreatment from '../drugOrderedTreatment'
+
+describe('The drugOrderedTreatment model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Explanation.required',
+      'ActionTaken.required',
+      'OrderedBy.required',
+    ]
+
+    expect(validateModel(testData, drugOrderedTreatment))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Explanation must have a value', () => {
+    const testData = {
+      Explanation: 'testing',
+    }
+    const expectedErrors = [
+      'Explanation.hasValue',
+    ]
+
+    expect(validateModel(testData, drugOrderedTreatment))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('OrderedBy must have at least one value', () => {
+    const testData = {
+      OrderedBy: 'testing',
+    }
+    const expectedErrors = [
+      'OrderedBy.array',
+    ]
+
+    expect(validateModel(testData, drugOrderedTreatment))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if OrderedBy includes "None"', () => {
+    it('OrderedBy must have only one value', () => {
+      const testData = {
+        OrderedBy: { values: ['None', 'Something else'] },
+      }
+      const expectedErrors = [
+        'OrderedBy.array',
+      ]
+
+      expect(validateModel(testData, drugOrderedTreatment))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid drugOrderedTreatment', () => {
+      const testData = {
+        Explanation: { value: 'Testing' },
+        OrderedBy: { values: ['None'] },
+        ActionTaken: { value: 'No' },
+        NoActionTakenExplanation: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, drugOrderedTreatment)).toEqual(true)
+    })
+  })
+
+  it('ActionTaken must have a valid value', () => {
+    const testData = {
+      ActionTaken: { value: true },
+    }
+    const expectedErrors = [
+      'ActionTaken.hasValue',
+    ]
+
+    expect(validateModel(testData, drugOrderedTreatment))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if ActionTaken is "Yes"', () => {
+    it('TreatmentProvider must have a value', () => {
+      const testData = {
+        ActionTaken: { value: 'Yes' },
+      }
+      const expectedErrors = [
+        'TreatmentProvider.required',
+        'TreatmentProvider.hasValue',
+      ]
+
+      expect(validateModel(testData, drugOrderedTreatment))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('TreatmentProviderAddress must be a valid location', () => {
+      const testData = {
+        ActionTaken: { value: 'Yes' },
+        TreatmentProviderAddress: 'invalid address',
+      }
+      const expectedErrors = [
+        'TreatmentProviderAddress.location',
+      ]
+
+      expect(validateModel(testData, drugOrderedTreatment))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('TreatmentProviderTelephone must be a valid phone', () => {
+      const testData = {
+        ActionTaken: { value: 'Yes' },
+        TreatmentProviderTelephone: '1234567890',
+      }
+      const expectedErrors = [
+        'TreatmentProviderTelephone.model',
+      ]
+
+      expect(validateModel(testData, drugOrderedTreatment))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('TreatmentDates must be a valid date range', () => {
+      const testData = {
+        ActionTaken: { value: 'Yes' },
+        TreatmentDates: false,
+      }
+      const expectedErrors = [
+        'TreatmentDates.daterange',
+      ]
+
+      expect(validateModel(testData, drugOrderedTreatment))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('TreatmentCompleted must have a valid value', () => {
+      const testData = {
+        ActionTaken: { value: 'Yes' },
+        TreatmentCompleted: true,
+      }
+      const expectedErrors = [
+        'TreatmentCompleted.hasValue',
+      ]
+
+      expect(validateModel(testData, drugOrderedTreatment))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    describe('if TreatmentCompleted is "Yes"', () => {
+      it('passes a valid drugOrderedTreatment', () => {
+        const testData = {
+          Explanation: { value: 'Testing' },
+          OrderedBy: { values: ['Test 1', 'Test 2'] },
+          ActionTaken: { value: 'Yes' },
+          TreatmentProvider: { value: 'Testing' },
+          TreatmentProviderAddress: {
+            street: '50 Provider ST',
+            city: 'New York',
+            state: 'NY',
+            zipcode: '10023',
+            country: 'United States',
+          },
+          TreatmentProviderTelephone: {
+            number: '1234567890',
+            type: 'Domestic',
+            timeOfDay: 'Both',
+          },
+          TreatmentDates: {
+            from: { month: 8, day: 20, year: 2010 },
+            to: { month: 10, day: 23, year: 2012 },
+          },
+          TreatmentCompleted: { value: 'Yes' },
+        }
+
+        expect(validateModel(testData, drugOrderedTreatment)).toEqual(true)
+      })
+    })
+
+    describe('if TreatmentCompleted is "No', () => {
+      it('NoTreatmentExplanation must have a value', () => {
+        const testData = {
+          ActionTaken: { value: 'Yes' },
+          TreatmentCompleted: { value: 'No' },
+        }
+        const expectedErrors = [
+          'NoTreatmentExplanation.required',
+          'NoTreatmentExplanation.hasValue',
+        ]
+
+        expect(validateModel(testData, drugOrderedTreatment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('passes a valid drugOrderedTreatment', () => {
+        const testData = {
+          Explanation: { value: 'Testing' },
+          OrderedBy: { values: ['Test 1', 'Test 2'] },
+          ActionTaken: { value: 'Yes' },
+          TreatmentProvider: { value: 'Testing' },
+          TreatmentProviderAddress: {
+            street: '50 Provider ST',
+            city: 'New York',
+            state: 'NY',
+            zipcode: '10023',
+            country: 'United States',
+          },
+          TreatmentProviderTelephone: {
+            number: '1234567890',
+            type: 'Domestic',
+            timeOfDay: 'Both',
+          },
+          TreatmentDates: {
+            from: { month: 8, day: 20, year: 2010 },
+            to: { month: 10, day: 23, year: 2012 },
+          },
+          TreatmentCompleted: { value: 'No' },
+          NoTreatmentExplanation: { value: 'Because' },
+        }
+
+        expect(validateModel(testData, drugOrderedTreatment)).toEqual(true)
+      })
+    })
+  })
+
+  describe('if ActionTaken is "No"', () => {
+    it('NoActionTakenExplanation must have a value', () => {
+      const testData = {
+        ActionTaken: { value: 'No' },
+      }
+      const expectedErrors = [
+        'NoActionTakenExplanation.required',
+        'NoActionTakenExplanation.hasValue',
+      ]
+
+      expect(validateModel(testData, drugOrderedTreatment))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid drugOrderedTreatment', () => {
+      const testData = {
+        Explanation: { value: 'Testing' },
+        OrderedBy: { values: ['Test 1', 'Test 2'] },
+        ActionTaken: { value: 'No' },
+        NoActionTakenExplanation: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, drugOrderedTreatment)).toEqual(true)
+    })
+  })
+})

--- a/src/models/__tests__/drugPrescriptionUse.test.js
+++ b/src/models/__tests__/drugPrescriptionUse.test.js
@@ -1,0 +1,147 @@
+import { validateModel } from 'models/validate'
+import drugPrescriptionUse from '../drugPrescriptionUse'
+
+describe('The drugPrescriptionUse model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'PrescriptionName.required',
+      'InvolvementDates.required',
+      'Reason.required',
+      'UseWhileEmployed.required',
+      'UseWithClearance.required',
+    ]
+
+    expect(validateModel(testData, drugPrescriptionUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('PrescriptionName must have a value', () => {
+    const testData = {
+      PrescriptionName: 'testing',
+    }
+    const expectedErrors = [
+      'PrescriptionName.hasValue',
+    ]
+
+    expect(validateModel(testData, drugPrescriptionUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('InvolvementDates must be a valid date range', () => {
+    const testData = {
+      InvolvementDates: { day: 5, month: 10 },
+    }
+    const expectedErrors = [
+      'InvolvementDates.daterange',
+    ]
+
+    expect(validateModel(testData, drugPrescriptionUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Reason must have a value', () => {
+    const testData = {
+      Reason: 'testing',
+    }
+    const expectedErrors = [
+      'Reason.hasValue',
+    ]
+
+    expect(validateModel(testData, drugPrescriptionUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('UseWhileEmployed must have a valid value', () => {
+    const testData = {
+      UseWhileEmployed: { value: 'nope' },
+    }
+    const expectedErrors = [
+      'UseWhileEmployed.hasValue',
+    ]
+
+    expect(validateModel(testData, drugPrescriptionUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('UseWithClearance must have a valid value', () => {
+    const testData = {
+      UseWithClearance: { value: 'nope' },
+    }
+    const expectedErrors = [
+      'UseWithClearance.hasValue',
+    ]
+
+    expect(validateModel(testData, drugPrescriptionUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if UseWhileEmployed is not required', () => {
+    it('UseWhileEmployed is not required', () => {
+      const testData = {}
+      const expectedErrors = [
+        'UseWhileEmployed.required',
+      ]
+
+      expect(validateModel(testData, drugPrescriptionUse, { requireUseWhileEmployed: false }))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid drugPrescriptionUse', () => {
+      const testData = {
+        PrescriptionName: { value: 'test drug' },
+        InvolvementDates: {
+          from: { day: 2, month: 5, year: 2000 },
+          to: { day: 6, month: 10, year: 2000 },
+        },
+        Reason: { value: 'testing' },
+        UseWithClearance: { value: 'No' },
+      }
+
+      expect(validateModel(testData, drugPrescriptionUse, { requireUseWhileEmployed: false }))
+        .toEqual(true)
+    })
+  })
+
+  describe('if UseWithClearance is not required', () => {
+    it('UseWithClearance is not required', () => {
+      const testData = {}
+      const expectedErrors = [
+        'UseWithClearance.required',
+      ]
+
+      expect(validateModel(testData, drugPrescriptionUse, { requireUseWithClearance: false }))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid drugPrescriptionUse', () => {
+      const testData = {
+        PrescriptionName: { value: 'test drug' },
+        InvolvementDates: {
+          from: { day: 2, month: 5, year: 2000 },
+          to: { day: 6, month: 10, year: 2000 },
+        },
+        Reason: { value: 'testing' },
+        UseWhileEmployed: { value: 'No' },
+      }
+
+      expect(validateModel(testData, drugPrescriptionUse, { requireUseWithClearance: false }))
+        .toEqual(true)
+    })
+  })
+
+  it('passes a valid drugPrescriptionUse', () => {
+    const testData = {
+      PrescriptionName: { value: 'test drug' },
+      InvolvementDates: {
+        from: { day: 2, month: 5, year: 2000 },
+        to: { day: 6, month: 10, year: 2000 },
+      },
+      Reason: { value: 'testing' },
+      UseWhileEmployed: { value: 'No' },
+      UseWithClearance: { value: 'No' },
+    }
+
+    expect(validateModel(testData, drugPrescriptionUse)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/drugSafetyUse.test.js
+++ b/src/models/__tests__/drugSafetyUse.test.js
@@ -1,0 +1,65 @@
+import { validateModel } from 'models/validate'
+import drugSafetyUse from '../drugSafetyUse'
+
+describe('The drugSafetyUse model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Description.required',
+      'InvolvementDates.required',
+      'EstimatedUse.required',
+    ]
+
+    expect(validateModel(testData, drugSafetyUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Description must have a value', () => {
+    const testData = {
+      Description: 'testing',
+    }
+    const expectedErrors = [
+      'Description.hasValue',
+    ]
+
+    expect(validateModel(testData, drugSafetyUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('InvolvementDates must be a valid date range', () => {
+    const testData = {
+      InvolvementDates: { day: 5, month: 10 },
+    }
+    const expectedErrors = [
+      'InvolvementDates.daterange',
+    ]
+
+    expect(validateModel(testData, drugSafetyUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('EstimatedUse must have a value', () => {
+    const testData = {
+      EstimatedUse: 'testing',
+    }
+    const expectedErrors = [
+      'EstimatedUse.hasValue',
+    ]
+
+    expect(validateModel(testData, drugSafetyUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid drugSafetyUse', () => {
+    const testData = {
+      InvolvementDates: {
+        from: { day: 2, month: 2, year: 1999 },
+        to: { day: 5, month: 5, year: 2001 },
+      },
+      Description: { value: 'Testing' },
+      EstimatedUse: { value: 'testing' },
+    }
+
+    expect(validateModel(testData, drugSafetyUse)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/drugUse.test.js
+++ b/src/models/__tests__/drugUse.test.js
@@ -1,0 +1,196 @@
+import { validateModel } from 'models/validate'
+import drugUse from '../drugUse'
+
+describe('The drugUse model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'FirstUse.required',
+      'RecentUse.required',
+      'NatureOfUse.required',
+      'UseWhileEmployed.required',
+      'UseWithClearance.required',
+      'UseInFuture.required',
+      'Explanation.required',
+    ]
+
+    expect(validateModel(testData, drugUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('FirstUse must be a valid month/year', () => {
+    const testData = {
+      FirstUse: { day: 5, month: 10 },
+    }
+    const expectedErrors = [
+      'FirstUse.date',
+    ]
+
+    expect(validateModel(testData, drugUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('RecentUse must be a valid month/year', () => {
+    const testData = {
+      RecentUse: { day: 5, month: 10 },
+    }
+    const expectedErrors = [
+      'RecentUse.date',
+    ]
+
+    expect(validateModel(testData, drugUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('NatureOfUse must have a value', () => {
+    const testData = {
+      NatureOfUse: 'testing',
+    }
+    const expectedErrors = [
+      'NatureOfUse.hasValue',
+    ]
+
+    expect(validateModel(testData, drugUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('UseWhileEmployed must have a valid value', () => {
+    const testData = {
+      UseWhileEmployed: { value: 'nope' },
+    }
+    const expectedErrors = [
+      'UseWhileEmployed.hasValue',
+    ]
+
+    expect(validateModel(testData, drugUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('UseWithClearance must have a valid value', () => {
+    const testData = {
+      UseWithClearance: { value: 'nope' },
+    }
+    const expectedErrors = [
+      'UseWithClearance.hasValue',
+    ]
+
+    expect(validateModel(testData, drugUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('UseInFuture must have a valid value', () => {
+    const testData = {
+      UseInFuture: { value: 'nope' },
+    }
+    const expectedErrors = [
+      'UseInFuture.hasValue',
+    ]
+
+    expect(validateModel(testData, drugUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Explanation must have a value', () => {
+    const testData = {
+      Explanation: 'testing',
+    }
+    const expectedErrors = [
+      'Explanation.hasValue',
+    ]
+
+    expect(validateModel(testData, drugUse))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if UseWhileEmployed is not required', () => {
+    it('UseWhileEmployed is not required', () => {
+      const testData = {}
+      const expectedErrors = [
+        'UseWhileEmployed.required',
+      ]
+
+      expect(validateModel(testData, drugUse, { requireUseWhileEmployed: false }))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid drugUse', () => {
+      const testData = {
+        FirstUse: { month: 2, year: 1999 },
+        RecentUse: { month: 5, year: 2001 },
+        NatureOfUse: { value: 'Testing' },
+        UseWithClearance: { value: 'No' },
+        UseInFuture: { value: 'Yes' },
+        Explanation: { value: 'testing' },
+      }
+
+      expect(validateModel(testData, drugUse, { requireUseWhileEmployed: false }))
+        .toEqual(true)
+    })
+  })
+
+  describe('if UseWithClearance is not required', () => {
+    it('UseWithClearance is not required', () => {
+      const testData = {}
+      const expectedErrors = [
+        'UseWithClearance.required',
+      ]
+
+      expect(validateModel(testData, drugUse, { requireUseWithClearance: false }))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid drugUse', () => {
+      const testData = {
+        FirstUse: { month: 2, year: 1999 },
+        RecentUse: { month: 5, year: 2001 },
+        NatureOfUse: { value: 'Testing' },
+        UseWhileEmployed: { value: 'No' },
+        UseInFuture: { value: 'Yes' },
+        Explanation: { value: 'testing' },
+      }
+
+      expect(validateModel(testData, drugUse, { requireUseWithClearance: false }))
+        .toEqual(true)
+    })
+  })
+
+  describe('if UseInFuture is not required', () => {
+    it('UseInFuture is not required', () => {
+      const testData = {}
+      const expectedErrors = [
+        'UseInFuture.required',
+      ]
+
+      expect(validateModel(testData, drugUse, { requireUseInFuture: false }))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid drugUse', () => {
+      const testData = {
+        FirstUse: { month: 2, year: 1999 },
+        RecentUse: { month: 5, year: 2001 },
+        NatureOfUse: { value: 'Testing' },
+        UseWithClearance: { value: 'No' },
+        UseWhileEmployed: { value: 'Yes' },
+        Explanation: { value: 'testing' },
+      }
+
+      expect(validateModel(testData, drugUse, { requireUseInFuture: false }))
+        .toEqual(true)
+    })
+  })
+
+  it('passes a valid drugUse', () => {
+    const testData = {
+      FirstUse: { month: 2, year: 1999 },
+      RecentUse: { month: 5, year: 2001 },
+      NatureOfUse: { value: 'Testing' },
+      UseWhileEmployed: { value: 'No' },
+      UseWithClearance: { value: 'No' },
+      UseInFuture: { value: 'Yes' },
+      Explanation: { value: 'testing' },
+    }
+
+    expect(validateModel(testData, drugUse)).toEqual(true)
+  })
+})

--- a/src/models/__tests__/drugVoluntaryTreatment.test.js
+++ b/src/models/__tests__/drugVoluntaryTreatment.test.js
@@ -1,0 +1,143 @@
+import { validateModel } from 'models/validate'
+import drugVoluntaryTreatment from '../drugVoluntaryTreatment'
+
+describe('The drugVoluntaryTreatment model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'TreatmentProvider.required',
+      'TreatmentProviderAddress.required',
+      'TreatmentProviderTelephone.required',
+      'TreatmentDates.required',
+      'TreatmentCompleted.required',
+    ]
+
+    expect(validateModel(testData, drugVoluntaryTreatment))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('TreatmentProvider must have a value', () => {
+    const testData = {}
+    const expectedErrors = [
+      'TreatmentProvider.hasValue',
+    ]
+
+    expect(validateModel(testData, drugVoluntaryTreatment))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('TreatmentProviderAddress must be a valid location', () => {
+    const testData = {
+      TreatmentProviderAddress: 'invalid address',
+    }
+    const expectedErrors = [
+      'TreatmentProviderAddress.location',
+    ]
+
+    expect(validateModel(testData, drugVoluntaryTreatment))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('TreatmentProviderTelephone must be a valid phone', () => {
+    const testData = {
+      TreatmentProviderTelephone: '1234567890',
+    }
+    const expectedErrors = [
+      'TreatmentProviderTelephone.model',
+    ]
+
+    expect(validateModel(testData, drugVoluntaryTreatment))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('TreatmentDates must be a valid date range', () => {
+    const testData = {
+      TreatmentDates: false,
+    }
+    const expectedErrors = [
+      'TreatmentDates.daterange',
+    ]
+
+    expect(validateModel(testData, drugVoluntaryTreatment))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('TreatmentCompleted must have a valid value', () => {
+    const testData = {
+      TreatmentCompleted: { value: 'maybe' },
+    }
+    const expectedErrors = [
+      'TreatmentCompleted.hasValue',
+    ]
+
+    expect(validateModel(testData, drugVoluntaryTreatment))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  describe('if TreatmentCompleted is "Yes"', () => {
+    it('passes a valid drugVoluntaryTreatment', () => {
+      const testData = {
+        TreatmentProvider: { value: 'Testing' },
+        TreatmentProviderAddress: {
+          street: '50 Provider ST',
+          city: 'New York',
+          state: 'NY',
+          zipcode: '10023',
+          country: 'United States',
+        },
+        TreatmentProviderTelephone: {
+          number: '1234567890',
+          type: 'Domestic',
+          timeOfDay: 'Both',
+        },
+        TreatmentDates: {
+          from: { month: 8, day: 20, year: 2010 },
+          to: { month: 10, day: 23, year: 2012 },
+        },
+        TreatmentCompleted: { value: 'Yes' },
+      }
+
+      expect(validateModel(testData, drugVoluntaryTreatment)).toEqual(true)
+    })
+  })
+
+  describe('if TreatmentCompleted is "No', () => {
+    it('NoTreatmentExplanation must have a value', () => {
+      const testData = {
+        TreatmentCompleted: { value: 'No' },
+      }
+      const expectedErrors = [
+        'NoTreatmentExplanation.hasValue',
+      ]
+
+      expect(validateModel(testData, drugVoluntaryTreatment))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid drugVoluntaryTreatment', () => {
+      const testData = {
+        TreatmentProvider: { value: 'Testing' },
+        TreatmentProviderAddress: {
+          street: '50 Provider ST',
+          city: 'New York',
+          state: 'NY',
+          zipcode: '10023',
+          country: 'United States',
+        },
+        TreatmentProviderTelephone: {
+          number: '1234567890',
+          type: 'Domestic',
+          timeOfDay: 'Both',
+        },
+        TreatmentDates: {
+          from: { month: 8, day: 20, year: 2010 },
+          to: { month: 10, day: 23, year: 2012 },
+        },
+        TreatmentCompleted: { value: 'No' },
+        NoTreatmentExplanation: { value: 'Because' },
+      }
+
+      expect(validateModel(testData, drugVoluntaryTreatment)).toEqual(true)
+    })
+  })
+})

--- a/src/models/alcoholNegativeImpact.js
+++ b/src/models/alcoholNegativeImpact.js
@@ -1,0 +1,8 @@
+const alcoholNegativeImpact = {
+  Occurred: { presence: true, date: { requireDay: false } },
+  Circumstances: { presence: true, hasValue: true },
+  NegativeImpact: { presence: true, hasValue: true },
+  Used: { presence: true, daterange: true },
+}
+
+export default alcoholNegativeImpact

--- a/src/models/alcoholOrderedCounseling.js
+++ b/src/models/alcoholOrderedCounseling.js
@@ -1,0 +1,60 @@
+import { hasYesOrNo, checkValue } from 'models/validate'
+import address from 'models/shared/locations/address'
+import phone from 'models/shared/phone'
+
+const alcoholOrderedCounseling = {
+  Seekers: {},
+  OtherSeeker: (value, attributes) => {
+    if (attributes.Seekers
+      && attributes.Seekers.values
+      && attributes.Seekers.values.includes('Other')) {
+      return { presence: true, hasValue: true }
+    }
+    return {}
+  },
+  ActionTaken: { presence: true, hasValue: { validator: hasYesOrNo } },
+  TreatmentProviderName: (value, attributes) => {
+    if (checkValue(attributes.ActionTaken, 'Yes')) {
+      return { presence: true, hasValue: true }
+    }
+    return {}
+  },
+  TreatmentProviderAddress: (value, attributes) => {
+    if (checkValue(attributes.ActionTaken, 'Yes')) {
+      return { presence: true, location: { validator: address } }
+    }
+    return {}
+  },
+  TreatmentProviderTelephone: (value, attributes) => {
+    if (checkValue(attributes.ActionTaken, 'Yes')) {
+      return { presence: true, model: { validator: phone } }
+    }
+    return {}
+  },
+  CounselingDates: (value, attributes) => {
+    if (checkValue(attributes.ActionTaken, 'Yes')) {
+      return { presence: true, daterange: true }
+    }
+    return {}
+  },
+  CompletedTreatment: (value, attributes) => {
+    if (checkValue(attributes.ActionTaken, 'Yes')) {
+      return { presence: true, hasValue: { validator: hasYesOrNo } }
+    }
+    return {}
+  },
+  NoCompletedTreatmentExplanation: (value, attributes) => {
+    if (checkValue(attributes.CompletedTreatment, 'No')) {
+      return { presence: true, hasValue: true }
+    }
+    return {}
+  },
+  NoActionTakenExplanation: (value, attributes) => {
+    if (checkValue(attributes.ActionTaken, 'No')) {
+      return { presence: true, hasValue: true }
+    }
+    return {}
+  },
+}
+
+export default alcoholOrderedCounseling

--- a/src/models/alcoholReceivedCounseling.js
+++ b/src/models/alcoholReceivedCounseling.js
@@ -1,0 +1,22 @@
+import { hasYesOrNo } from 'models/validate'
+import address from 'models/shared/locations/address'
+
+const alcoholReceivedCounseling = {
+  TreatmentProviderName: { presence: true, hasValue: true },
+  UseSameAddress: { presence: true, hasValue: { validator: hasYesOrNo } },
+  TreatmentProviderAddress: { presence: true, location: { validator: address } },
+  AgencyAddress: (value, attributes) => {
+    if (attributes.UseSameAddress && attributes.UseSameAddress.value === 'Yes') {
+      return {}
+    }
+    return { presence: true, location: { validator: address } }
+  },
+  AgencyName: { presence: true, hasValue: true },
+  TreatmentBeganDate: { presence: true, date: true },
+  TreatmentEndDate: { presence: true, date: true },
+  TreatmentDates: { presence: true, daterange: true },
+  CompletedTreatment: { presence: true, hasValue: { validator: hasYesOrNo } },
+  NoCompletedTreatmentExplanation: { presence: true, hasValue: true },
+}
+
+export default alcoholReceivedCounseling

--- a/src/models/alcoholVoluntaryCounseling.js
+++ b/src/models/alcoholVoluntaryCounseling.js
@@ -1,0 +1,19 @@
+import { hasYesOrNo, checkValue } from 'models/validate'
+import address from 'models/shared/locations/address'
+import phone from 'models/shared/phone'
+
+const alcoholVoluntaryCounseling = {
+  TreatmentProviderName: { presence: true, hasValue: true },
+  TreatmentProviderAddress: { presence: true, location: { validator: address } },
+  TreatmentProviderTelephone: { presence: true, model: { validator: phone } },
+  CounselingDates: { presence: true, daterange: true },
+  CompletedTreatment: { presence: true, hasValue: { validator: hasYesOrNo } },
+  NoCompletedTreatmentExplanation: (value, attributes) => {
+    if (checkValue(attributes.CompletedTreatment, 'No')) {
+      return { presence: true, hasValue: true }
+    }
+    return {}
+  },
+}
+
+export default alcoholVoluntaryCounseling

--- a/src/models/drugClearanceUse.js
+++ b/src/models/drugClearanceUse.js
@@ -1,0 +1,7 @@
+const drugClearanceUse = {
+  Description: { presence: true, hasValue: true },
+  InvolvementDates: { presence: true, daterange: true },
+  EstimatedUse: { presence: true, hasValue: true },
+}
+
+export default drugClearanceUse

--- a/src/models/drugInvolvement.js
+++ b/src/models/drugInvolvement.js
@@ -1,0 +1,29 @@
+import { hasYesOrNo } from 'models/validate'
+
+const drugInvolvement = {
+  FirstInvolvement: { presence: true, date: { requireDay: false } },
+  RecentInvolvement: { presence: true, date: { requireDay: false } },
+  NatureOfInvolvement: { presence: true, hasValue: true },
+  Reasons: { presence: true, hasValue: true },
+  InvolvementWhileEmployed: (value, attributes, attributeName, options) => {
+    if (options && options.requireInvolvementWhileEmployed === false) return {}
+    return { presence: true, hasValue: { validator: hasYesOrNo } }
+  },
+  InvolvementWithClearance: (value, attributes, attributeName, options) => {
+    if (options && options.requireInvolvementWithClearance === false) return {}
+    return { presence: true, hasValue: { validator: hasYesOrNo } }
+  },
+  InvolvementInFuture: (value, attributes, attributeName, options) => {
+    if (options && options.requireInvolvementInFuture === false) return {}
+    return { presence: true, hasValue: { validator: hasYesOrNo } }
+  },
+  Explanation: (value, attributes) => {
+    if (attributes.InvolvementInFuture
+      && attributes.InvolvementInFuture.value === 'Yes') {
+      return { presence: true, hasValue: true }
+    }
+    return {}
+  },
+}
+
+export default drugInvolvement

--- a/src/models/drugOrderedTreatment.js
+++ b/src/models/drugOrderedTreatment.js
@@ -1,0 +1,67 @@
+import { hasYesOrNo, checkValue } from 'models/validate'
+import address from 'models/shared/locations/address'
+import phone from 'models/shared/phone'
+
+const drugOrderedTreatment = {
+  Explanation: { presence: true, hasValue: true },
+  ActionTaken: { presence: true, hasValue: { validator: hasYesOrNo } },
+  OrderedBy: (value) => {
+    const length = { minimum: 1 }
+
+    if (value && value.values && value.values.includes('None')) {
+      length.maximum = 1
+    }
+
+    return {
+      presence: true,
+      array: {
+        validator: { presence: true },
+        length,
+      },
+    }
+  },
+  TreatmentProvider: (value, attributes) => {
+    if (checkValue(attributes.ActionTaken, 'Yes')) {
+      return { presence: true, hasValue: true }
+    }
+    return {}
+  },
+  TreatmentProviderAddress: (value, attributes) => {
+    if (checkValue(attributes.ActionTaken, 'Yes')) {
+      return { presence: true, location: { validator: address } }
+    }
+    return {}
+  },
+  TreatmentProviderTelephone: (value, attributes) => {
+    if (checkValue(attributes.ActionTaken, 'Yes')) {
+      return { presence: true, model: { validator: phone } }
+    }
+    return {}
+  },
+  TreatmentDates: (value, attributes) => {
+    if (checkValue(attributes.ActionTaken, 'Yes')) {
+      return { presence: true, daterange: true }
+    }
+    return {}
+  },
+  TreatmentCompleted: (value, attributes) => {
+    if (checkValue(attributes.ActionTaken, 'Yes')) {
+      return { presence: true, hasValue: { validator: hasYesOrNo } }
+    }
+    return {}
+  },
+  NoTreatmentExplanation: (value, attributes) => {
+    if (checkValue(attributes.TreatmentCompleted, 'No')) {
+      return { presence: true, hasValue: true }
+    }
+    return {}
+  },
+  NoActionTakenExplanation: (value, attributes) => {
+    if (checkValue(attributes.ActionTaken, 'No')) {
+      return { presence: true, hasValue: true }
+    }
+    return {}
+  },
+}
+
+export default drugOrderedTreatment

--- a/src/models/drugPrescriptionUse.js
+++ b/src/models/drugPrescriptionUse.js
@@ -1,0 +1,17 @@
+import { hasYesOrNo } from 'models/validate'
+
+const drugPrescriptionUse = {
+  PrescriptionName: { presence: true, hasValue: true },
+  InvolvementDates: { presence: true, daterange: true },
+  Reason: { presence: true, hasValue: true },
+  UseWhileEmployed: (value, attributes, attributeName, options) => {
+    if (options && options.requireUseWhileEmployed === false) return {}
+    return { presence: true, hasValue: { validator: hasYesOrNo } }
+  },
+  UseWithClearance: (value, attributes, attributeName, options) => {
+    if (options && options.requireUseWithClearance === false) return {}
+    return { presence: true, hasValue: { validator: hasYesOrNo } }
+  },
+}
+
+export default drugPrescriptionUse

--- a/src/models/drugSafetyUse.js
+++ b/src/models/drugSafetyUse.js
@@ -1,0 +1,7 @@
+const drugSafetyUse = {
+  Description: { presence: true, hasValue: true },
+  InvolvementDates: { presence: true, daterange: true },
+  EstimatedUse: { presence: true, hasValue: true },
+}
+
+export default drugSafetyUse

--- a/src/models/drugUse.js
+++ b/src/models/drugUse.js
@@ -1,0 +1,22 @@
+import { hasYesOrNo } from 'models/validate'
+
+const drugUse = {
+  FirstUse: { presence: true, date: { requireDay: false } },
+  RecentUse: { presence: true, date: { requireDay: false } },
+  NatureOfUse: { presence: true, hasValue: true },
+  Explanation: { presence: true, hasValue: true },
+  UseWhileEmployed: (value, attributes, attributeName, options) => {
+    if (options && options.requireUseWhileEmployed === false) return {}
+    return { presence: true, hasValue: { validator: hasYesOrNo } }
+  },
+  UseWithClearance: (value, attributes, attributeName, options) => {
+    if (options && options.requireUseWithClearance === false) return {}
+    return { presence: true, hasValue: { validator: hasYesOrNo } }
+  },
+  UseInFuture: (value, attributes, attributeName, options) => {
+    if (options && options.requireUseInFuture === false) return {}
+    return { presence: true, hasValue: { validator: hasYesOrNo } }
+  },
+}
+
+export default drugUse

--- a/src/models/drugVoluntaryTreatment.js
+++ b/src/models/drugVoluntaryTreatment.js
@@ -1,0 +1,19 @@
+import { hasYesOrNo, checkValue } from 'models/validate'
+import address from 'models/shared/locations/address'
+import phone from 'models/shared/phone'
+
+const drugVoluntaryTreatment = {
+  TreatmentProvider: { presence: true, hasValue: true },
+  TreatmentProviderAddress: { presence: true, location: { validator: address } },
+  TreatmentProviderTelephone: { presence: true, model: { validator: phone } },
+  TreatmentDates: { presence: true, daterange: true },
+  TreatmentCompleted: { presence: true, hasValue: { validator: hasYesOrNo } },
+  NoTreatmentExplanation: (value, attributes) => {
+    if (checkValue(attributes.TreatmentCompleted, 'No')) {
+      return { presence: true, hasValue: true }
+    }
+    return {}
+  },
+}
+
+export default drugVoluntaryTreatment

--- a/src/validators/alcoholorderedcounseling.js
+++ b/src/validators/alcoholorderedcounseling.js
@@ -1,94 +1,48 @@
-import DateRangeValidator from './daterange'
-import LocationValidator from './location'
-import {
-  validAccordion,
-  validBranch,
-  validGenericTextfield,
-  validPhoneNumber
-} from './helpers'
+import { validateModel, hasYesOrNo } from 'models/validate'
+import alcoholOrderedCounseling from 'models/alcoholOrderedCounseling'
+
+export const validateOrderedCounseling = data => (
+  validateModel(data, alcoholOrderedCounseling) === true
+)
+
+export const validateOrderedCounselings = (data) => {
+  const orderedCounselingsModel = {
+    HasBeenOrdered: { presence: true, hasValue: { validator: hasYesOrNo } },
+    List: (value, attributes) => {
+      if (attributes.HasBeenOrdered
+        && attributes.HasBeenOrdered.value === 'Yes') {
+        return { presence: true, accordion: { validator: alcoholOrderedCounseling } }
+      }
+      return {}
+    },
+  }
+
+  return validateModel(data, orderedCounselingsModel) === true
+}
 
 export default class OrderedCounselingsValidator {
   constructor(data = {}) {
-    this.hasBeenOrdered = (data.HasBeenOrdered || {}).value
-    this.list = data.List || {}
-  }
-
-  validHasBeenOrdered() {
-    return validBranch(this.hasBeenOrdered)
-  }
-
-  validOrderedCounselings() {
-    if (this.validHasBeenOrdered() && this.hasBeenOrdered === 'No') {
-      return true
-    }
-
-    return validAccordion(this.list, item => {
-      return new OrderedCounselingValidator(item).isValid()
-    })
+    this.data = data
   }
 
   isValid() {
-    return this.validHasBeenOrdered() && this.validOrderedCounselings()
+    return validateOrderedCounselings(this.data)
   }
 }
 
 export class OrderedCounselingValidator {
   constructor(data = {}) {
-    this.seekers = (data.Seekers || {}).values || []
-    this.otherSeeker = data.OtherSeeker
-    this.actionTaken = (data.ActionTaken || {}).value
-    this.noActionTakenExplanation = data.NoActionTakenExplanation
-    this.counselingDates = data.CounselingDates
-    this.treatmentProviderName = data.TreatmentProviderName
-    this.treatmentProviderAddress = data.TreatmentProviderAddress
-    this.treatmentProviderTelephone = data.TreatmentProviderTelephone
-    this.completedTreatment = (data.CompletedTreatment || {}).value
-    this.noCompletedTreatmentExplanation = data.NoCompletedTreatmentExplanation
-  }
-
-  validSeekers() {
-    if (this.seekers && this.seekers.includes('Other')) {
-      return validGenericTextfield(this.otherSeeker)
-    }
-    return true
-  }
-
-  validActionTaken() {
-    if (!validBranch(this.actionTaken)) {
-      return false
-    }
-    switch (this.actionTaken) {
-      case 'Yes':
-        return this.validActionTakenYes()
-      case 'No':
-        return validGenericTextfield(this.noActionTakenExplanation)
-      default:
-        return false
-    }
+    this.data = data
   }
 
   validCompletedTreatment() {
-    switch (this.completedTreatment) {
-      case 'Yes':
-        return true
-      case 'No':
-        return validGenericTextfield(this.noCompletedTreatmentExplanation)
-      default:
-        return false
-    }
-  }
-
-  validActionTakenYes() {
-    return (
-      new DateRangeValidator(this.counselingDates).isValid() &&
-      validGenericTextfield(this.treatmentProviderName) &&
-      new LocationValidator(this.treatmentProviderAddress).isValid() &&
-      validPhoneNumber(this.treatmentProviderTelephone) &&
-      this.validCompletedTreatment()
-    )
+    return validateModel(this.data, {
+      CompletedTreatment: alcoholOrderedCounseling.CompletedTreatment,
+      NoCompletedTreatmentExplanation: alcoholOrderedCounseling.NoCompletedTreatmentExplanation,
+    }) === true
   }
 
   isValid() {
-    return this.validSeekers() && this.validActionTaken()
+    return validateOrderedCounseling(this.data)
   }
 }

--- a/src/validators/alcoholorderedcounseling.test.js
+++ b/src/validators/alcoholorderedcounseling.test.js
@@ -1,48 +1,48 @@
 import OrderedCounselingsValidator, {
-  OrderedCounselingValidator
+  OrderedCounselingValidator,
 } from './alcoholorderedcounseling'
 import Location from '../components/Form/Location'
 
-describe('ordered counseling component validation', function() {
+describe('ordered counseling component validation', () => {
   it('can validate ordered counseling', () => {
     const tests = [
       {
         state: {
           ActionTaken: { value: 'No' },
           NoActionTakenExplanation: {
-            value: 'Foo'
-          }
+            value: 'Foo',
+          },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
-          ActionTaken: { value: 'Nope' }
+          ActionTaken: { value: 'Nope' },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
           Seekers: { values: ['Other'] },
           OtherSeeker: {
-            value: 'Other'
+            value: 'Other',
           },
           ActionTaken: { value: 'Yes' },
           CounselingDates: {
             from: {
               month: '1',
               day: '1',
-              year: '2010'
+              year: '2010',
             },
             to: {
               month: '1',
               day: '1',
-              year: '2012'
+              year: '2012',
             },
-            present: false
+            present: false,
           },
           TreatmentProviderName: {
-            value: 'The name'
+            value: 'The name',
           },
           TreatmentProviderAddress: {
             country: { value: 'United States' },
@@ -50,7 +50,7 @@ describe('ordered counseling component validation', function() {
             city: 'Arlington',
             state: 'VA',
             zipcode: '22202',
-            layout: Location.ADDRESS
+            layout: Location.ADDRESS,
           },
           TreatmentProviderTelephone: {
             noNumber: '',
@@ -58,14 +58,14 @@ describe('ordered counseling component validation', function() {
             numberType: 'Home',
             timeOfDay: 'Both',
             type: 'Domestic',
-            extension: ''
+            extension: '',
           },
-          CompletedTreatment: { value: 'Yes' }
+          CompletedTreatment: { value: 'Yes' },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new OrderedCounselingValidator(test.state, null).isValid()).toBe(
         test.expected
       )
@@ -76,27 +76,30 @@ describe('ordered counseling component validation', function() {
     const tests = [
       {
         state: {
-          CompletedTreatment: { value: 'Yes' }
+          ActionTaken: { value: 'Yes' },
+          CompletedTreatment: { value: 'Yes' },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
+          ActionTaken: { value: 'Yes' },
           CompletedTreatment: { value: 'No' },
           NoCompletedTreatmentExplanation: {
-            value: 'Foo'
-          }
+            value: 'Foo',
+          },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
-          CompletedTreatment: { value: 'Nope' }
+          ActionTaken: { value: 'Yes' },
+          CompletedTreatment: { value: 'Nope' },
         },
-        expected: false
-      }
+        expected: false,
+      },
     ]
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(
         new OrderedCounselingValidator(test.state).validCompletedTreatment()
       ).toBe(test.expected)
@@ -118,17 +121,17 @@ describe('ordered counseling component validation', function() {
                     from: {
                       month: '1',
                       day: '1',
-                      year: '2010'
+                      year: '2010',
                     },
                     to: {
                       month: '1',
                       day: '1',
-                      year: '2012'
+                      year: '2012',
                     },
-                    present: false
+                    present: false,
                   },
                   TreatmentProviderName: {
-                    value: 'The name'
+                    value: 'The name',
                   },
                   TreatmentProviderAddress: {
                     country: { value: 'United States' },
@@ -136,7 +139,7 @@ describe('ordered counseling component validation', function() {
                     city: 'Arlington',
                     state: 'VA',
                     zipcode: '22202',
-                    layout: Location.ADDRESS
+                    layout: Location.ADDRESS,
                   },
                   TreatmentProviderTelephone: {
                     noNumber: '',
@@ -144,54 +147,54 @@ describe('ordered counseling component validation', function() {
                     numberType: 'Home',
                     timeOfDay: 'Both',
                     type: 'Domestic',
-                    extension: ''
+                    extension: '',
                   },
-                  CompletedTreatment: { value: 'Yes' }
-                }
-              }
-            ]
-          }
+                  CompletedTreatment: { value: 'Yes' },
+                },
+              },
+            ],
+          },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
-          HasBeenOrdered: { value: 'No' }
+          HasBeenOrdered: { value: 'No' },
         },
-        expected: true
-      },
-      {
-        state: {
-          HasBeenOrdered: { value: 'Yes' },
-          List: {
-            branch: { value: '' },
-            items: []
-          }
-        },
-        expected: false
+        expected: true,
       },
       {
         state: {
           HasBeenOrdered: { value: 'Yes' },
           List: {
             branch: { value: '' },
-            items: [{}]
-          }
+            items: [],
+          },
         },
-        expected: false
+        expected: false,
+      },
+      {
+        state: {
+          HasBeenOrdered: { value: 'Yes' },
+          List: {
+            branch: { value: '' },
+            items: [{}],
+          },
+        },
+        expected: false,
       },
       {
         state: {
           HasBeenOrdered: { value: 'Yes' },
           List: {
             branch: { value: 'No' },
-            items: [{ Item: {} }]
-          }
+            items: [{ Item: {} }],
+          },
         },
-        expected: false
-      }
+        expected: false,
+      },
     ]
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new OrderedCounselingsValidator(test.state).isValid()).toBe(
         test.expected
       )

--- a/src/validators/drugclearanceuses.js
+++ b/src/validators/drugclearanceuses.js
@@ -1,43 +1,43 @@
-import DateRangeValidator from './daterange'
-import { validAccordion, validBranch, validGenericTextfield } from './helpers'
+import { validateModel, hasYesOrNo } from 'models/validate'
+import drugClearanceUse from 'models/drugClearanceUse'
+
+export const validateDrugClearanceUse = data => (
+  validateModel(data, drugClearanceUse) === true
+)
+
+export const validateDrugClearanceUses = (data) => {
+  const drugClearanceUsesModel = {
+    UsedDrugs: { presence: true, hasValue: { validator: hasYesOrNo } },
+    List: (value, attributes) => {
+      if (attributes.UsedDrugs && attributes.UsedDrugs.value === 'Yes') {
+        return {
+          presence: true,
+          accordion: { validator: drugClearanceUse },
+        }
+      }
+      return {}
+    },
+  }
+
+  return validateModel(data, drugClearanceUsesModel) === true
+}
 
 export default class DrugClearanceUsesValidator {
   constructor(data = {}) {
-    this.usedDrugs = (data.UsedDrugs || {}).value
-    this.list = data.List
-  }
-
-  validUsedDrugs() {
-    return validBranch(this.usedDrugs)
-  }
-
-  validDrugClearanceUses() {
-    if (this.validUsedDrugs() && this.usedDrugs === 'No') {
-      return true
-    }
-
-    return validAccordion(this.list, item => {
-      return new DrugClearanceUseValidator(item).isValid()
-    })
+    this.data = data
   }
 
   isValid() {
-    return this.validUsedDrugs() && this.validDrugClearanceUses()
+    return validateDrugClearanceUses(this.data)
   }
 }
 
 export class DrugClearanceUseValidator {
   constructor(data = {}) {
-    this.description = data.Description
-    this.involvementDates = data.InvolvementDates
-    this.estimatedUse = data.EstimatedUse
+    this.data = data
   }
 
   isValid() {
-    return (
-      new DateRangeValidator(this.involvementDates).isValid() &&
-      validGenericTextfield(this.description) &&
-      validGenericTextfield(this.estimatedUse)
-    )
+    return validateDrugClearanceUse(this.data)
   }
 }

--- a/src/validators/druginvolvements.test.js
+++ b/src/validators/druginvolvements.test.js
@@ -1,51 +1,208 @@
 import DrugInvolvementsValidator, {
-  DrugInvolvementValidator
+  DrugInvolvementValidator,
+  validateDrugInvolvements,
 } from './druginvolvements'
 
-describe('Drug Involvement Validation', function() {
-  it('should validate drug usage', function() {
+describe('validateDrugInvolvements function', () => {
+  describe('for the SF-86', () => {
+    it('fails if missing required fields', () => {
+      const testData = {
+        Involved: { value: 'Yes' },
+        List: {
+          branch: { value: 'No' },
+          items: [
+            {
+              Item: {
+                DrugType: {
+                  DrugType: 'Cocaine',
+                  DrugTypeOther: null,
+                },
+                FirstInvolvement: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                RecentInvolvement: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                NatureOfInvolvement: {
+                  value: 'Some involvement',
+                },
+                Reasons: {
+                  value: 'Some reason',
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      expect(validateDrugInvolvements(testData, 'SF86')).toEqual(false)
+    })
+
+    it('passes valid data', () => {
+      const testData = {
+        Involved: { value: 'Yes' },
+        List: {
+          branch: { value: 'No' },
+          items: [
+            {
+              Item: {
+                DrugType: {
+                  DrugType: 'Cocaine',
+                  DrugTypeOther: null,
+                },
+                FirstInvolvement: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                RecentInvolvement: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                NatureOfInvolvement: {
+                  value: 'Some involvement',
+                },
+                Reasons: {
+                  value: 'Some reason',
+                },
+                InvolvementWhileEmployed: { value: 'Yes' },
+                InvolvementWithClearance: { value: 'Yes' },
+                InvolvementInFuture: { value: 'No' },
+              },
+            },
+          ],
+        },
+      }
+
+      expect(validateDrugInvolvements(testData, 'SF86')).toEqual(true)
+    })
+  })
+
+  describe('for the SF-85', () => {
+    it('fails if missing required fields', () => {
+      const testData = {
+        Involved: { value: 'Yes' },
+        List: {
+          items: [
+            {
+              Item: {
+                DrugType: {
+                  DrugType: 'Cocaine',
+                  DrugTypeOther: null,
+                },
+                FirstInvolvement: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                RecentInvolvement: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                NatureOfInvolvement: {
+                  value: 'Some involvement',
+                },
+                InvolvementWhileEmployed: { value: 'Yes' },
+                InvolvementWithClearance: { value: 'Yes' },
+                InvolvementInFuture: { value: 'No' },
+              },
+            },
+          ],
+        },
+      }
+
+      expect(validateDrugInvolvements(testData, 'SF85')).toEqual(false)
+    })
+
+    it('passes valid data', () => {
+      const testData = {
+        Involved: { value: 'Yes' },
+        List: {
+          branch: { value: 'No' },
+          items: [
+            {
+              Item: {
+                DrugType: {
+                  DrugType: 'Cocaine',
+                  DrugTypeOther: null,
+                },
+                FirstInvolvement: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                RecentInvolvement: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                NatureOfInvolvement: {
+                  value: 'Some involvement',
+                },
+                Reasons: {
+                  value: 'Some reason',
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      expect(validateDrugInvolvements(testData, 'SF85')).toEqual(true)
+    })
+  })
+})
+
+describe('Drug Involvement Validation', () => {
+  it('should validate drug usage', () => {
     const tests = [
       {
         state: {
-          Involved: { value: 'Nope' }
+          Involved: { value: 'Nope' },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
-          Involved: { value: 'No' }
+          Involved: { value: 'No' },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
           Involved: { value: 'Yes' },
           List: {
             branch: { value: '' },
-            items: []
-          }
+            items: [],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
           Involved: { value: 'Yes' },
           List: {
             branch: { value: 'Nope' },
-            items: [{ DrugInvolvement: {} }]
-          }
+            items: [{ DrugInvolvement: {} }],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
           Involved: { value: 'Yes' },
           List: {
             branch: { value: 'No' },
-            items: [{ DrugInvolvement: {} }]
-          }
+            items: [{ DrugInvolvement: {} }],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
@@ -57,67 +214,67 @@ describe('Drug Involvement Validation', function() {
                 Item: {
                   DrugType: {
                     DrugType: 'Cocaine',
-                    DrugTypeOther: null
+                    DrugTypeOther: null,
                   },
                   FirstInvolvement: {
                     day: '1',
                     month: '1',
-                    year: '2016'
+                    year: '2016',
                   },
                   RecentInvolvement: {
                     day: '1',
                     month: '1',
-                    year: '2016'
+                    year: '2016',
                   },
                   NatureOfInvolvement: {
-                    value: 'Some involvement'
+                    value: 'Some involvement',
                   },
                   Reasons: {
-                    value: 'Some reason'
+                    value: 'Some reason',
                   },
                   InvolvementWhileEmployed: { value: 'Yes' },
                   InvolvementWithClearance: { value: 'Yes' },
-                  InvolvementInFuture: { value: 'No' }
-                }
-              }
-            ]
-          }
+                  InvolvementInFuture: { value: 'No' },
+                },
+              },
+            ],
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new DrugInvolvementsValidator(test.state).isValid()).toBe(
         test.expected
       )
     })
   })
 
-  it('should validate future use', function() {
+  it('should validate future use', () => {
     const tests = [
       {
         state: {
           InvolvementInFuture: { value: 'Yes' },
           Explanation: {
-            value: 'Because'
-          }
+            value: 'Because',
+          },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
-          InvolvementInFuture: { value: 'No' }
+          InvolvementInFuture: { value: 'No' },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
-          InvolvementInFuture: { value: 'Nope' }
+          InvolvementInFuture: { value: 'Nope' },
         },
-        expected: false
-      }
+        expected: false,
+      },
     ]
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new DrugInvolvementValidator(test.state).validFuture()).toBe(
         test.expected
       )

--- a/src/validators/drugorderedtreatments.test.js
+++ b/src/validators/drugorderedtreatments.test.js
@@ -1,107 +1,52 @@
 import DrugOrderedTreatmentsValidator, {
-  DrugOrderedTreatmentValidator
+  DrugOrderedTreatmentValidator,
 } from './drugorderedtreatments'
 import Location from '../components/Form/Location'
 
-describe('Drug Ordered Treatment Validation', function() {
-  it('should validate drug ordered treatments', function() {
+describe('Drug Ordered Treatment Validation', () => {
+  it('should validate drug ordered treatments', () => {
     const tests = [
       {
         state: {
-          TreatmentOrdered: { value: 'Nope' }
+          TreatmentOrdered: { value: 'Nope' },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
-          TreatmentOrdered: { value: 'No' }
+          TreatmentOrdered: { value: 'No' },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
           TreatmentOrdered: { value: 'Yes' },
           List: {
             branch: { value: '' },
-            items: []
-          }
+            items: [],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
           TreatmentOrdered: { value: 'Yes' },
           List: {
             branch: { value: 'Nope' },
-            items: [{ OrderedTreatment: {} }]
-          }
+            items: [{ OrderedTreatment: {} }],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
           TreatmentOrdered: { value: 'Yes' },
           List: {
             branch: { value: 'No' },
-            items: [{ OrderedTreatment: {} }]
-          }
+            items: [{ OrderedTreatment: {} }],
+          },
         },
-        expected: false
-      },
-      {
-        state: {
-          TreatmentOrdered: { value: 'Yes' },
-          List: {
-            branch: { value: 'No' },
-            items: [
-              {
-                Item: {
-                  OrderedBy: {
-                    values: ['Employer']
-                  },
-                  Explanation: {
-                    value: 'The explanation'
-                  },
-                  ActionTaken: { value: 'Yes' },
-                  DrugType: 'Cocaine',
-                  TreatmentProvider: {
-                    value: 'Provider'
-                  },
-                  TreatmentProviderAddress: {
-                    country: { value: 'United States' },
-                    street: '1234 Some Rd',
-                    city: 'Arlington',
-                    state: 'VA',
-                    zipcode: '22202',
-                    layout: Location.ADDRESS
-                  },
-                  TreatmentProviderTelephone: {
-                    noNumber: '',
-                    number: '7031112222',
-                    numberType: 'Home',
-                    timeOfDay: 'Both',
-                    type: 'Domestic',
-                    extension: ''
-                  },
-                  TreatmentDates: {
-                    from: {
-                      month: '1',
-                      day: '1',
-                      year: '2010'
-                    },
-                    to: {
-                      month: '1',
-                      day: '1',
-                      year: '2012'
-                    }
-                  },
-                  TreatmentCompleted: { value: 'Yes' }
-                }
-              }
-            ]
-          }
-        },
-        expected: true
+        expected: false,
       },
       {
         state: {
@@ -112,15 +57,15 @@ describe('Drug Ordered Treatment Validation', function() {
               {
                 Item: {
                   OrderedBy: {
-                    values: ['Employer']
+                    values: ['Employer'],
                   },
                   Explanation: {
-                    value: 'The explanation'
+                    value: 'The explanation',
                   },
                   ActionTaken: { value: 'Yes' },
                   DrugType: 'Cocaine',
                   TreatmentProvider: {
-                    value: 'Provider'
+                    value: 'Provider',
                   },
                   TreatmentProviderAddress: {
                     country: { value: 'United States' },
@@ -128,7 +73,62 @@ describe('Drug Ordered Treatment Validation', function() {
                     city: 'Arlington',
                     state: 'VA',
                     zipcode: '22202',
-                    layout: Location.ADDRESS
+                    layout: Location.ADDRESS,
+                  },
+                  TreatmentProviderTelephone: {
+                    noNumber: '',
+                    number: '7031112222',
+                    numberType: 'Home',
+                    timeOfDay: 'Both',
+                    type: 'Domestic',
+                    extension: '',
+                  },
+                  TreatmentDates: {
+                    from: {
+                      month: '1',
+                      day: '1',
+                      year: '2010',
+                    },
+                    to: {
+                      month: '1',
+                      day: '1',
+                      year: '2012',
+                    },
+                  },
+                  TreatmentCompleted: { value: 'Yes' },
+                },
+              },
+            ],
+          },
+        },
+        expected: true,
+      },
+      {
+        state: {
+          TreatmentOrdered: { value: 'Yes' },
+          List: {
+            branch: { value: 'No' },
+            items: [
+              {
+                Item: {
+                  OrderedBy: {
+                    values: ['Employer'],
+                  },
+                  Explanation: {
+                    value: 'The explanation',
+                  },
+                  ActionTaken: { value: 'Yes' },
+                  DrugType: 'Cocaine',
+                  TreatmentProvider: {
+                    value: 'Provider',
+                  },
+                  TreatmentProviderAddress: {
+                    country: { value: 'United States' },
+                    street: '1234 Some Rd',
+                    city: 'Arlington',
+                    state: 'VA',
+                    zipcode: '22202',
+                    layout: Location.ADDRESS,
                   },
                   TreatmentProviderTelephone: {
                     noNumber: '',
@@ -136,30 +136,30 @@ describe('Drug Ordered Treatment Validation', function() {
                     numberType: 'Home',
                     type: 'Domestic',
                     timeOfDay: 'Both',
-                    extension: ''
+                    extension: '',
                   },
                   TreatmentDates: {
                     from: {
                       month: '1',
                       day: '1',
-                      year: '2010'
+                      year: '2010',
                     },
                     to: {
                       month: '1',
                       day: '1',
-                      year: '2012'
-                    }
+                      year: '2012',
+                    },
                   },
                   TreatmentCompleted: { value: 'No' },
                   NoTreatmentExplanation: {
-                    value: 'No treatment'
-                  }
-                }
-              }
-            ]
-          }
+                    value: 'No treatment',
+                  },
+                },
+              },
+            ],
+          },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
@@ -170,21 +170,21 @@ describe('Drug Ordered Treatment Validation', function() {
               {
                 Item: {
                   OrderedBy: {
-                    values: ['Employer']
+                    values: ['Employer'],
                   },
                   Explanation: {
-                    value: 'The explanation'
+                    value: 'The explanation',
                   },
                   ActionTaken: { value: 'No' },
                   NoActionTakenExplanation: {
-                    value: 'No action taken'
-                  }
-                }
-              }
-            ]
-          }
+                    value: 'No action taken',
+                  },
+                },
+              },
+            ],
+          },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
@@ -195,21 +195,21 @@ describe('Drug Ordered Treatment Validation', function() {
               {
                 Item: {
                   OrderedBy: {
-                    values: ['Employer', 'None']
+                    values: ['Employer', 'None'],
                   },
                   Explanation: {
-                    value: 'The explanation'
+                    value: 'The explanation',
                   },
                   ActionTaken: { value: 'No' },
                   NoActionTakenExplanation: {
-                    value: 'No action taken'
-                  }
-                }
-              }
-            ]
-          }
+                    value: 'No action taken',
+                  },
+                },
+              },
+            ],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
@@ -220,53 +220,56 @@ describe('Drug Ordered Treatment Validation', function() {
               {
                 Item: {
                   OrderedBy: {
-                    values: ['Employer']
+                    values: ['Employer'],
                   },
                   Explanation: {
-                    value: 'The explanation'
+                    value: 'The explanation',
                   },
-                  ActionTaken: { value: 'Nope' }
-                }
-              }
-            ]
-          }
+                  ActionTaken: { value: 'Nope' },
+                },
+              },
+            ],
+          },
         },
-        expected: false
-      }
+        expected: false,
+      },
     ]
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new DrugOrderedTreatmentsValidator(test.state).isValid()).toBe(
         test.expected
       )
     })
   })
 
-  it('should validate treatment completed', function() {
+  it('should validate treatment completed', () => {
     const tests = [
       {
         state: {
-          TreatmentCompleted: { value: 'Nope' }
+          ActionTaken: { value: 'Yes' },
+          TreatmentCompleted: { value: 'Nope' },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
+          ActionTaken: { value: 'Yes' },
           TreatmentCompleted: { value: 'No' },
           NoTreatmentExplanation: {
-            value: 'Nothing'
-          }
+            value: 'Nothing',
+          },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
-          TreatmentCompleted: { value: 'Yes' }
+          ActionTaken: { value: 'Yes' },
+          TreatmentCompleted: { value: 'Yes' },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(
         new DrugOrderedTreatmentValidator(test.state).validTreatmentCompleted()
       ).toBe(test.expected)

--- a/src/validators/drugprescriptionuses.js
+++ b/src/validators/drugprescriptionuses.js
@@ -6,49 +6,35 @@ import {
   requireDrugWithClearance,
 } from 'helpers/branches'
 
-import DateRangeValidator from './daterange'
-import { validAccordion, validBranch, validGenericTextfield } from './helpers'
+import { validateModel, hasYesOrNo } from 'models/validate'
+import drugPrescriptionUse from 'models/drugPrescriptionUse'
 
-/** Attribute Validators */
-const validateMisusedDrugs = usedDrugs => validBranch(usedDrugs)
-
-const validateInvolvementDates = dates => new DateRangeValidator(dates).isValid()
-
-/** Object Validators (as functions) */
-export const validateDrugPrescriptionUse = (data = {}, formType = formTypes.SF86) => {
-  const prescriptionName = data.PrescriptionName
-  const involvementDates = data.InvolvementDates
-  const reason = data.Reason
-  const useWhileEmployed = (data.UseWhileEmployed || {}).value
-  const useWithClearance = (data.UseWithClearance || {}).value
-
-  const validUseWhileEmployed = !requireDrugWhileSafety(formType) || validBranch(useWhileEmployed)
-  const validUseWithClearance = !requireDrugWithClearance(formType) || validBranch(useWithClearance)
-
-  return validateInvolvementDates(involvementDates)
-    && validGenericTextfield(prescriptionName)
-    && validGenericTextfield(reason)
-    && validUseWhileEmployed
-    && validUseWithClearance
-}
-
-const validateDrugPrescriptionUseItems = (items, formType) => (
-  validAccordion(items, i => validateDrugPrescriptionUse(i, formType))
+export const validateDrugPrescriptionUse = (data = {}, formType = formTypes.SF86) => (
+  validateModel(data, drugPrescriptionUse, {
+    requireUseWhileEmployed: requireDrugWhileSafety(formType),
+    requireUseWithClearance: requireDrugWithClearance(formType),
+  }) === true
 )
 
 export const validateDrugPrescriptionUses = (data = {}, formType = formTypes.SF86) => {
-  const usedDrugs = (data.MisusedDrugs || {}).value
-  const list = data.List
-
-  const validMisusedDrugs = validateMisusedDrugs(usedDrugs)
-
-  if (!validMisusedDrugs) return false
-
-  if (validMisusedDrugs && usedDrugs === 'No') {
-    return true
+  const drugUsesModel = {
+    MisusedDrugs: { presence: true, hasValue: { validator: hasYesOrNo } },
+    List: (value, attributes) => {
+      if (attributes.MisusedDrugs && attributes.MisusedDrugs.value === 'Yes') {
+        return {
+          presence: true,
+          accordion: {
+            validator: drugPrescriptionUse,
+            requireUseWhileEmployed: requireDrugWhileSafety(formType),
+            requireUseWithClearance: requireDrugWithClearance(formType),
+          },
+        }
+      }
+      return {}
+    },
   }
 
-  return validateDrugPrescriptionUseItems(list, formType)
+  return validateModel(data, drugUsesModel) === true
 }
 
 /** Object Validators (as classes) - legacy */
@@ -56,24 +42,8 @@ export default class DrugPrescriptionUsesValidator {
   constructor(data = {}) {
     const state = store.getState()
     const { formType } = state.application.Settings
-
     this.data = data
     this.formType = formType
-
-    this.usedDrugs = (data.MisusedDrugs || {}).value
-    this.list = data.List
-  }
-
-  validMisusedDrugs() {
-    return validateMisusedDrugs(this.usedDrugs)
-  }
-
-  validDrugPrescriptionUses() {
-    if (this.validMisusedDrugs() && this.usedDrugs === 'No') {
-      return true
-    }
-
-    return validateDrugPrescriptionUseItems(this.list, this.formType)
   }
 
   isValid() {
@@ -85,18 +55,8 @@ export class DrugPrescriptionUseValidator {
   constructor(data = {}) {
     const state = store.getState()
     const { formType } = state.application.Settings
-
     this.data = data
     this.formType = formType
-
-    this.usedDrugs = (data.MisusedDrugs || {}).value
-    this.list = data.List
-
-    this.prescriptionName = data.PrescriptionName
-    this.involvementDates = data.InvolvementDates
-    this.reason = data.Reason
-    this.useWhileEmployed = (data.UseWhileEmployed || {}).value
-    this.useWithClearance = (data.UseWithClearance || {}).value
   }
 
   isValid() {

--- a/src/validators/drugprescriptionuses.test.js
+++ b/src/validators/drugprescriptionuses.test.js
@@ -1,49 +1,200 @@
-import DrugPrescriptionUsesValidator from './drugprescriptionuses'
+import DrugPrescriptionUsesValidator, {
+  validateDrugPrescriptionUses,
+} from './drugprescriptionuses'
 
-describe('Drug Prescription Validation', function() {
-  it('should validate drug prescription misuse', function() {
+describe('validateDrugPrescriptionUses function', () => {
+  describe('for the SF-86', () => {
+    it('fails if missing required fields', () => {
+      const testData = {
+        MisusedDrugs: { value: 'Yes' },
+        List: {
+          branch: { value: 'No' },
+          items: [
+            {
+              Item: {
+                InvolvementDates: {
+                  from: {
+                    month: '1',
+                    day: '1',
+                    year: '2010',
+                  },
+                  to: {
+                    month: '1',
+                    day: '1',
+                    year: '2012',
+                  },
+                  present: false,
+                },
+                PrescriptionName: {
+                  value: 'Foo',
+                },
+                Reason: {
+                  value: 'The reason',
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      expect(validateDrugPrescriptionUses(testData, 'SF86')).toEqual(false)
+    })
+
+    it('passes valid data', () => {
+      const testData = {
+        MisusedDrugs: { value: 'Yes' },
+        List: {
+          branch: { value: 'No' },
+          items: [
+            {
+              Item: {
+                InvolvementDates: {
+                  from: {
+                    month: '1',
+                    day: '1',
+                    year: '2010',
+                  },
+                  to: {
+                    month: '1',
+                    day: '1',
+                    year: '2012',
+                  },
+                  present: false,
+                },
+                PrescriptionName: {
+                  value: 'Foo',
+                },
+                Reason: {
+                  value: 'The reason',
+                },
+                UseWhileEmployed: { value: 'Yes' },
+                UseWithClearance: { value: 'Yes' },
+              },
+            },
+          ],
+        },
+      }
+
+      expect(validateDrugPrescriptionUses(testData, 'SF86')).toEqual(true)
+    })
+  })
+
+  describe('for the SF-85', () => {
+    it('fails if missing required fields', () => {
+      const testData = {
+        MisusedDrugs: { value: 'Yes' },
+        List: {
+          branch: { value: 'No' },
+          items: [
+            {
+              Item: {
+                InvolvementDates: {
+                  from: {
+                    month: '1',
+                    day: '1',
+                    year: '2010',
+                  },
+                  to: {
+                    month: '1',
+                    day: '1',
+                    year: '2012',
+                  },
+                  present: false,
+                },
+                PrescriptionName: {
+                  value: 'Foo',
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      expect(validateDrugPrescriptionUses(testData, 'SF85')).toEqual(false)
+    })
+
+    it('passes valid data', () => {
+      const testData = {
+        MisusedDrugs: { value: 'Yes' },
+        List: {
+          branch: { value: 'No' },
+          items: [
+            {
+              Item: {
+                InvolvementDates: {
+                  from: {
+                    month: '1',
+                    day: '1',
+                    year: '2010',
+                  },
+                  to: {
+                    month: '1',
+                    day: '1',
+                    year: '2012',
+                  },
+                  present: false,
+                },
+                PrescriptionName: {
+                  value: 'Foo',
+                },
+                Reason: {
+                  value: 'The reason',
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      expect(validateDrugPrescriptionUses(testData, 'SF85')).toEqual(true)
+    })
+  })
+})
+
+describe('Drug Prescription Validation', () => {
+  it('should validate drug prescription misuse', () => {
     const tests = [
       {
         data: {
-          MisusedDrugs: { value: 'Nope' }
+          MisusedDrugs: { value: 'Nope' },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
-          MisusedDrugs: { value: 'No' }
+          MisusedDrugs: { value: 'No' },
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
           MisusedDrugs: { value: 'Yes' },
           List: {
             branch: { value: '' },
-            items: []
-          }
+            items: [],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
           MisusedDrugs: { value: 'Yes' },
           List: {
             branch: { value: 'Nope' },
-            items: [{ DrugUse: {} }]
-          }
+            items: [{ DrugUse: {} }],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
           MisusedDrugs: { value: 'Yes' },
           List: {
             branch: { value: 'No' },
-            items: [{ DrugUse: {} }]
-          }
+            items: [{ DrugUse: {} }],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
@@ -57,32 +208,32 @@ describe('Drug Prescription Validation', function() {
                     from: {
                       month: '1',
                       day: '1',
-                      year: '2010'
+                      year: '2010',
                     },
                     to: {
                       month: '1',
                       day: '1',
-                      year: '2012'
+                      year: '2012',
                     },
-                    present: false
+                    present: false,
                   },
                   PrescriptionName: {
-                    value: 'Foo'
+                    value: 'Foo',
                   },
                   Reason: {
-                    value: 'The reason'
+                    value: 'The reason',
                   },
                   UseWhileEmployed: { value: 'Yes' },
-                  UseWithClearance: { value: 'Yes' }
-                }
-              }
-            ]
-          }
+                  UseWithClearance: { value: 'Yes' },
+                },
+              },
+            ],
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new DrugPrescriptionUsesValidator(test.data).isValid()).toBe(
         test.expected
       )

--- a/src/validators/drugpublicsafetyuses.js
+++ b/src/validators/drugpublicsafetyuses.js
@@ -1,43 +1,43 @@
-import DateRangeValidator from './daterange'
-import { validAccordion, validBranch, validGenericTextfield } from './helpers'
+import { validateModel, hasYesOrNo } from 'models/validate'
+import drugSafetyUse from 'models/drugSafetyUse'
+
+export const validateDrugSafetyUse = data => (
+  validateModel(data, drugSafetyUse) === true
+)
+
+export const validateDrugSafetyUses = (data) => {
+  const drugSafetyUsesModel = {
+    UsedDrugs: { presence: true, hasValue: { validator: hasYesOrNo } },
+    List: (value, attributes) => {
+      if (attributes.UsedDrugs && attributes.UsedDrugs.value === 'Yes') {
+        return {
+          presence: true,
+          accordion: { validator: drugSafetyUse },
+        }
+      }
+      return {}
+    },
+  }
+
+  return validateModel(data, drugSafetyUsesModel) === true
+}
 
 export default class DrugPublicSafetyUsesValidator {
   constructor(data = {}) {
-    this.usedDrugs = (data.UsedDrugs || {}).value
-    this.list = data.List
-  }
-
-  validUsedDrugs() {
-    return validBranch(this.usedDrugs)
-  }
-
-  validDrugPublicSafetyUses() {
-    if (this.validUsedDrugs() && this.usedDrugs === 'No') {
-      return true
-    }
-
-    return validAccordion(this.list, item => {
-      return new DrugPublicSafetyUseValidator(item).isValid()
-    })
+    this.data = data
   }
 
   isValid() {
-    return this.validUsedDrugs() && this.validDrugPublicSafetyUses()
+    return validateDrugSafetyUses(this.data)
   }
 }
 
 export class DrugPublicSafetyUseValidator {
   constructor(data = {}) {
-    this.description = data.Description
-    this.involvementDates = data.InvolvementDates
-    this.estimatedUse = data.EstimatedUse
+    this.data = data
   }
 
   isValid() {
-    return (
-      new DateRangeValidator(this.involvementDates).isValid() &&
-      validGenericTextfield(this.description) &&
-      validGenericTextfield(this.estimatedUse)
-    )
+    return validateDrugSafetyUse(this.data)
   }
 }

--- a/src/validators/druguses.test.js
+++ b/src/validators/druguses.test.js
@@ -1,49 +1,199 @@
-import DrugUsesValidator from './druguses'
+import DrugUsesValidator, {
+  validateDrugUses,
+} from './druguses'
 
-describe('Drug Use Validation', function() {
-  it('should validate drug usage', function() {
+describe('validateDrugUses function', () => {
+  describe('for the SF-86', () => {
+    it('fails if missing required fields', () => {
+      const testData = {
+        UsedDrugs: { value: 'Yes' },
+        List: {
+          branch: { value: 'No' },
+          items: [
+            {
+              Item: {
+                DrugType: {
+                  DrugType: 'Cocaine',
+                  DrugTypeOther: null,
+                },
+                FirstUse: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                RecentUse: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                NatureOfUse: {
+                  value: 'Some use',
+                },
+                Explanation: {
+                  value: 'Foo',
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      expect(validateDrugUses(testData, 'SF86')).toEqual(false)
+    })
+
+    it('passes valid data', () => {
+      const testData = {
+        UsedDrugs: { value: 'Yes' },
+        List: {
+          branch: { value: 'No' },
+          items: [
+            {
+              Item: {
+                DrugType: {
+                  DrugType: 'Cocaine',
+                  DrugTypeOther: null,
+                },
+                FirstUse: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                RecentUse: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                NatureOfUse: {
+                  value: 'Some use',
+                },
+                UseWhileEmployed: { value: 'Yes' },
+                UseWithClearance: { value: 'Yes' },
+                UseInFuture: { value: 'No' },
+                Explanation: {
+                  value: 'Foo',
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      expect(validateDrugUses(testData, 'SF86')).toEqual(true)
+    })
+  })
+
+  describe('for the SF-85', () => {
+    it('fails if missing required fields', () => {
+      const testData = {
+        UsedDrugs: { value: 'Yes' },
+        List: {
+          branch: { value: 'No' },
+          items: [
+            {
+              Item: {
+                RecentUse: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                NatureOfUse: {
+                  value: 'Some use',
+                },
+                Explanation: {
+                  value: 'Foo',
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      expect(validateDrugUses(testData, 'SF85')).toEqual(false)
+    })
+
+    it('passes valid data', () => {
+      const testData = {
+        UsedDrugs: { value: 'Yes' },
+        List: {
+          branch: { value: 'No' },
+          items: [
+            {
+              Item: {
+                DrugType: {
+                  DrugType: 'Cocaine',
+                  DrugTypeOther: null,
+                },
+                FirstUse: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                RecentUse: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                },
+                NatureOfUse: {
+                  value: 'Some use',
+                },
+                Explanation: {
+                  value: 'Foo',
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      expect(validateDrugUses(testData, 'SF85')).toEqual(true)
+    })
+  })
+})
+
+describe('Drug Use Validation', () => {
+  it('should validate drug usage', () => {
     const tests = [
       {
         state: {
-          UsedDrugs: { value: 'Nope' }
+          UsedDrugs: { value: 'Nope' },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
-          UsedDrugs: { value: 'No' }
+          UsedDrugs: { value: 'No' },
         },
-        expected: true
+        expected: true,
       },
       {
         state: {
           UsedDrugs: { value: 'Yes' },
           List: {
             branch: { value: '' },
-            items: []
-          }
+            items: [],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
           UsedDrugs: { value: 'Yes' },
           List: {
             branch: { value: 'Nope' },
-            items: [{ DrugUse: {} }]
-          }
+            items: [{ DrugUse: {} }],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
           UsedDrugs: { value: 'Yes' },
           List: {
             branch: { value: 'No' },
-            items: [{ DrugUse: {} }]
-          }
+            items: [{ DrugUse: {} }],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         state: {
@@ -55,36 +205,36 @@ describe('Drug Use Validation', function() {
                 Item: {
                   DrugType: {
                     DrugType: 'Cocaine',
-                    DrugTypeOther: null
+                    DrugTypeOther: null,
                   },
                   FirstUse: {
                     day: '1',
                     month: '1',
-                    year: '2016'
+                    year: '2016',
                   },
                   RecentUse: {
                     day: '1',
                     month: '1',
-                    year: '2016'
+                    year: '2016',
                   },
                   NatureOfUse: {
-                    value: 'Some use'
+                    value: 'Some use',
                   },
                   UseWhileEmployed: { value: 'Yes' },
                   UseWithClearance: { value: 'Yes' },
                   UseInFuture: { value: 'No' },
                   Explanation: {
-                    value: 'Foo'
-                  }
-                }
-              }
-            ]
-          }
+                    value: 'Foo',
+                  },
+                },
+              },
+            ],
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
-    tests.forEach(test => {
+    tests.forEach((test) => {
       expect(new DrugUsesValidator(test.state).isValid()).toBe(test.expected)
     })
   })


### PR DESCRIPTION
## Description

- Validation models for the entire Substance Use section
- Includes tickets: EN-3741, EN-3742, EN-3743, EN-3744, EN-3745, EN-3746, EN-3747, EN-3748, EN-3749, EN-3750, EN-3751

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify you are able to validate all subsections in the Substance Use section
- [ ] Verify if you enter invalid data in the Substance Use section, it does not pass validation
- [ ] Verify that loading test cases with Substance Use section data pass validation
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
