### PR TITLE
delete attachments on kickback

### DIFF
--- a/api/admin/reject.go
+++ b/api/admin/reject.go
@@ -1,9 +1,12 @@
 package admin
 
 import (
+	"fmt"
 	"github.com/pkg/errors"
+	"strings"
 
 	"github.com/18F/e-QIP-prototype/api"
+	"github.com/18F/e-QIP-prototype/api/pdf"
 )
 
 // Rejecter is used to reject/kickback an application
@@ -29,12 +32,7 @@ func (r Rejecter) Reject(account api.Account) error {
 		return errors.Wrap(err, "Reject failed to unlock account")
 	}
 
-	// TODO: port over PDF.RemovePdfs.
-	// err = r.PDF.RemovePdfs(account)
-	// if err != nil {
-	// 	return errors.Wrap(err, "Reject failed to remove PDFs")
-	// }
-
+	// Load the application, clear the nos, save the application.
 	app, loadErr := r.store.LoadApplication(account.ID)
 	if loadErr != nil {
 		if loadErr == api.ErrApplicationDoesNotExist {
@@ -51,6 +49,38 @@ func (r Rejecter) Reject(account api.Account) error {
 	saveErr := r.store.UpdateApplication(app)
 	if saveErr != nil {
 		return errors.Wrap(saveErr, "Unable to save application after rejecting it")
+	}
+
+	// load the pfds, remove the signature pdfs.
+	attachmentsMetadata, listErr := r.store.ListAttachmentsMetadata(account.ID)
+	if listErr != nil {
+		return errors.Wrap(listErr, "Failed to load the current attachments in order to delete them")
+	}
+
+	// Get the list of PDF Types that correspond to the signed releases
+	releaseTypeSet := make(map[string]bool)
+	for _, release := range pdf.ReleasePDFs {
+		releaseTypeSet[release.DocType] = true
+	}
+
+	var deletionErrors []error
+	for _, attachment := range attachmentsMetadata {
+		if _, ok := releaseTypeSet[attachment.DocType]; ok {
+			delErr := r.store.DeleteAttachment(account.ID, attachment.ID)
+			if delErr != nil {
+				deletionErrors = append(deletionErrors, delErr)
+			}
+		}
+	}
+
+	if len(deletionErrors) != 0 {
+		var errStrings []string
+		for _, err := range deletionErrors {
+			errStrings = append(errStrings, err.Error())
+		}
+		joinedErrs := strings.Join(errStrings, ", ")
+
+		return errors.New(fmt.Sprintf("Got an error deleting %d documents: [%s]", len(deletionErrors), joinedErrs))
 	}
 
 	return nil

--- a/api/admin/reject.go
+++ b/api/admin/reject.go
@@ -13,15 +13,13 @@ import (
 type Rejecter struct {
 	db    api.DatabaseService
 	store api.StorageService
-	pdf   api.PdfService
 }
 
 // NewRejecter returns a configured Rejecter
-func NewRejecter(db api.DatabaseService, store api.StorageService, pdf api.PdfService) Rejecter {
+func NewRejecter(db api.DatabaseService, store api.StorageService) Rejecter {
 	return Rejecter{
 		db,
 		store,
-		pdf,
 	}
 }
 

--- a/api/integration/clear_yes_no_test.go
+++ b/api/integration/clear_yes_no_test.go
@@ -21,7 +21,7 @@ func TestClearEmptyAccount(t *testing.T) {
 	services := cleanTestServices(t)
 	account := createTestAccount(t, services.db)
 
-	rejector := admin.NewRejecter(services.db, services.store, nil)
+	rejector := admin.NewRejecter(services.db, services.store)
 
 	err := rejector.Reject(account)
 	if err != nil {
@@ -107,7 +107,7 @@ func rejectSection(t *testing.T, services serviceSet, json []byte, sectionName s
 		t.Fatal("Failed to save JSON", resp.StatusCode)
 	}
 
-	rejector := admin.NewRejecter(services.db, services.store, nil)
+	rejector := admin.NewRejecter(services.db, services.store)
 	err := rejector.Reject(account)
 	if err != nil {
 		t.Fatal("Failed to reject account: ", err)
@@ -1036,7 +1036,7 @@ func TestClearComplexSectionNos(t *testing.T) {
 				t.Fatal("Failed to save JSON", resp.StatusCode)
 			}
 
-			rejector := admin.NewRejecter(services.db, services.store, nil)
+			rejector := admin.NewRejecter(services.db, services.store)
 			err := rejector.Reject(account)
 			if err != nil {
 				t.Fatal("Failed to reject account: ", err)

--- a/api/integration/reject_test.go
+++ b/api/integration/reject_test.go
@@ -1,0 +1,123 @@
+package integration
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/18F/e-QIP-prototype/api"
+	"github.com/18F/e-QIP-prototype/api/admin"
+	"github.com/18F/e-QIP-prototype/api/http"
+	"github.com/18F/e-QIP-prototype/api/pdf"
+	"github.com/18F/e-QIP-prototype/api/xml"
+)
+
+func TestDeleteSingaturePDFs(t *testing.T) {
+
+	services := cleanTestServices(t)
+	account := createTestAccount(t, services.db)
+
+	xmlService := xml.NewXMLService("../templates/")
+	pdfService := pdf.NewPDFService("../pdf/templates/")
+	submitter := admin.NewSubmitter(services.db, services.store, xmlService, pdfService)
+
+	submitHandler := http.SubmitHandler{
+		Env:       services.env,
+		Log:       services.log,
+		Database:  services.db,
+		Store:     services.store,
+		Submitter: submitter,
+	}
+
+	// First, upload an attachment.
+	certificationPath := "../testdata/attachments/signature-form.pdf"
+
+	certificationBytes := readTestData(t, certificationPath)
+
+	req := postAttachmentRequest(t, "signature-form.pdf", certificationBytes, account.ID)
+
+	w := httptest.NewRecorder()
+
+	createAttachmentHandler := http.AttachmentSaveHandler{
+		Env:      services.env,
+		Log:      services.log,
+		Database: services.db,
+		Store:    services.store,
+	}
+
+	createAttachmentHandler.ServeHTTP(w, req)
+
+	resp := w.Result()
+
+	if resp.StatusCode != 200 {
+		t.Fatal("Got an error back from CreateAttachment")
+	}
+
+	// Created an uploaded attachment.
+
+	// Now submit, which will generate signatures.
+	// Setup a test scenario
+	form := readTestData(t, "../testdata/complete-scenarios/test1.json")
+	saveFormJSON(t, services, form, account.ID)
+	// in addition to the base form data, we need submission data to get the date signed
+	submissionJSON := readTestData(t, "../testdata/submission-test1.json")
+	saveResp := saveJSON(services, submissionJSON, account.ID)
+	if saveResp.StatusCode != 200 {
+		t.Fatal("Didn't save the submission section")
+	}
+
+	// call the /form/submit handler. It's a dummy handler that just returns
+	// the XML on success.
+	w, submitReq := standardResponseAndRequest("POST", "/me/form/submit", nil, account.ID)
+	submitHandler.ServeHTTP(w, submitReq)
+
+	submitResp := w.Result()
+
+	if submitResp.StatusCode != 200 {
+		t.Fatal("submit didn't succeed")
+	}
+
+	// Reject this submission
+	rejector := admin.NewRejecter(services.db, services.store, nil)
+	err := rejector.Reject(account)
+	if err != nil {
+		t.Fatal("Failed to reject account: ", err)
+	}
+
+	// Finally, check that only the orignally uploaded attachment remains
+	listAttachmentHandler := http.AttachmentListHandler{
+		Env:      services.env,
+		Log:      services.log,
+		Database: services.db,
+		Store:    services.store,
+	}
+
+	w, indexReq := standardResponseAndRequest("GET", "/me/attachments/", nil, account.ID)
+
+	listAttachmentHandler.ServeHTTP(w, indexReq)
+
+	indexResp := w.Result()
+
+	if indexResp.StatusCode != 200 {
+		t.Log("Got an error back from ListAttachments")
+		t.Fail()
+	}
+
+	body, readErr := ioutil.ReadAll(indexResp.Body)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+
+	retrievedAttachments := []api.Attachment{}
+
+	jsonErr := json.Unmarshal(body, &retrievedAttachments)
+	if jsonErr != nil {
+		t.Fatal(jsonErr)
+	}
+
+	if len(retrievedAttachments) != 1 {
+		t.Fatal("Got back too many attachments: ", len(retrievedAttachments))
+	}
+
+}

--- a/api/integration/reject_test.go
+++ b/api/integration/reject_test.go
@@ -79,7 +79,7 @@ func TestDeleteSingaturePDFs(t *testing.T) {
 	}
 
 	// Reject this submission
-	rejector := admin.NewRejecter(services.db, services.store, nil)
+	rejector := admin.NewRejecter(services.db, services.store)
 	err := rejector.Reject(account)
 	if err != nil {
 		t.Fatal("Failed to reject account: ", err)

--- a/api/integration/save_attachment_test.go
+++ b/api/integration/save_attachment_test.go
@@ -137,12 +137,7 @@ func TestListNoAttachments(t *testing.T) {
 		Store:    services.store,
 	}
 
-	indexReq := httptest.NewRequest("GET", "/me/attachments/", nil)
-
-	getAuthCtx := http.SetAccountIDInRequestContext(indexReq, account.ID)
-	indexReq = indexReq.WithContext(getAuthCtx)
-
-	w := httptest.NewRecorder()
+	w, indexReq := standardResponseAndRequest("GET", "/me/attachments/", nil, account.ID)
 
 	listAttachmentHandler.ServeHTTP(w, indexReq)
 

--- a/api/integration/submission_test.go
+++ b/api/integration/submission_test.go
@@ -117,7 +117,7 @@ func TestSubmitter(t *testing.T) {
 
 	// call the /form/submit handler. It's a dummy handler that just returns
 	// the XML on success.
-	w, req := standardResponseAndRequest("GET", "/me/form/submit", nil, account.ID)
+	w, req := standardResponseAndRequest("POST", "/me/form/submit", nil, account.ID)
 	submitHandler.ServeHTTP(w, req)
 
 	submitResp := w.Result()


### PR DESCRIPTION
## Description

This PR modifies the Reject service to delete the old Signed Release PDFs from the previous submission. This fixes the ticket for making sure we don't submit multiple copies of each PDF on re-submission. 

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)