### PR TITLE
[EN-3773] Deprecate Validation Classes - part 1

### DIFF
--- a/.eslintrc.dev.yml
+++ b/.eslintrc.dev.yml
@@ -33,6 +33,7 @@ rules:
   react/forbid-prop-types: ['error', {
     forbid: ['any']
   }]
+  react/jsx-boolean-value: ['error', 'always']
 settings:
   import/resolver:
     babel-module:

--- a/src/helpers/validation.js
+++ b/src/helpers/validation.js
@@ -1,245 +1,335 @@
+import { SF86 } from 'constants/formTypes'
 import * as sections from 'constants/sections'
-import * as validators from 'validators'
+
+// IDENTIFICATION
+import { validateIdentificationName } from 'validators/identificationname'
+import { validateIdentificationBirthDate } from 'validators/identificationbirthdate'
+import { validateIdentificationBirthPlace } from 'validators/identificationbirthplace'
+import { validateIdentificationSSN } from 'validators/identificationssn'
+import { validateOtherNames } from 'validators/identificationothernames'
+import { validateIdentificationContactInformation } from 'validators/identificationcontacts'
+import { validateIdentificationPhysical } from 'validators/identificationphysical'
+// HISTORY
+import { validateHistoryResidence } from 'validators/residence'
+import { validateHistoryEmployment } from 'validators/employment'
+import { validateHistoryEducation } from 'validators/education'
+import { validateHistoryFederal } from 'validators/federalservice'
+// RELATIONSHIPS
+import { validateMarital } from 'validators/marital'
+import { validateCohabitants } from 'validators/cohabitant'
+import { validatePeople } from 'validators/people'
+import { validateRelatives } from 'validators/relatives'
+// CITIZENSHIP
+import { validateUsPassport } from 'validators/passport'
+import { validateCitizenshipStatus } from 'validators/citizenship'
+import { validateCitizenshipMultiple } from 'validators/citizenship-multiple'
+import { validateCitizenshipPassports } from 'validators/citizenship-passports'
+// MILITARY
+import { validateSelectiveService } from 'validators/selectiveservice'
+import { validateMilitaryHistory } from 'validators/militaryhistory'
+import { validateMilitaryDisciplinaryProcedures } from 'validators/militarydisciplinary'
+import { validateMilitaryForeign } from 'validators/militaryforeign'
+// FOREIGN
+import { validateForeignContacts } from 'validators/foreigncontacts'
+import { validateForeignDirectActivity } from 'validators/foreigndirectactivity'
+import { validateForeignIndirectActivity } from 'validators/foreignindirectactivity'
+import { validateForeignRealEstateActivity } from 'validators/foreignrealestateactivity'
+import { validateForeignBenefitActivity } from 'validators/foreignbenefitactivity'
+import { validateForeignActivitiesSupport } from 'validators/foreignsupport'
+import { validateForeignBusinessAdvice } from 'validators/foreignbusinessadvice'
+import { validateForeignBusinessFamily } from 'validators/foreignbusinessfamily'
+import { validateForeignBusinessEmployment } from 'validators/foreignbusinessemployment'
+import { validateForeignBusinessVentures } from 'validators/foreignbusinessventures'
+import { validateForeignBusinessConferences } from 'validators/foreignbusinessconferences'
+import { validateForeignBusinessContacts } from 'validators/foreignbusinesscontact'
+import { validateForeignBusinessSponsorship } from 'validators/foreignbusinesssponsorship'
+import { validateForeignBusinessPolitical } from 'validators/foreignbusinesspolitical'
+import { validateForeignBusinessVoting } from 'validators/foreignbusinessvoting'
+import { validateForeignTravel } from 'validators/foreigntravel'
+// FINANCIAL
+import { validateFinancialBankruptcy } from 'validators/bankruptcy'
+import { validateFinancialGambling } from 'validators/gambling'
+import { validateFinancialTaxes } from 'validators/taxes'
+import { validateFinancialCardAbuse } from 'validators/cardabuse'
+import { validateFinancialCredit } from 'validators/credit'
+import { validateFinancialDelinquent } from 'validators/delinquent'
+import { validateFinancialNonpayment } from 'validators/nonpayment'
+// SUBSTANCE
+import { validateDrugUses } from 'validators/druguses'
+import { validateDrugInvolvements } from 'validators/druginvolvements'
+import { validateDrugClearanceUses } from 'validators/drugclearanceuses'
+import { validateDrugSafetyUses } from 'validators/drugpublicsafetyuses'
+import { validateDrugPrescriptionUses } from 'validators/drugprescriptionuses'
+import { validateDrugOrderedTreatments } from 'validators/drugorderedtreatments'
+import { validateDrugVoluntaryTreatments } from 'validators/drugvoluntarytreatments'
+import { validateNegativeImpacts } from 'validators/alcoholnegativeimpact'
+import { validateOrderedCounselings } from 'validators/alcoholorderedcounseling'
+import { validateVoluntaryCounselings } from 'validators/alcoholvoluntarycounseling'
+import { validateReceivedCounselings } from 'validators/alcoholreceivedcounseling'
+// LEGAL
+import { validatePoliceOffenses } from 'validators/policeoffenses'
+import { validatePoliceOtherOffenses } from 'validators/policeotheroffenses'
+import { validateDomesticViolence } from 'validators/domesticviolence'
+import { validateLegalInvestigationsHistory } from 'validators/legalinvestigationshistory'
+import { validateLegalInvestigationsRevoked } from 'validators/legalinvestigationsrevoked'
+import { validateLegalInvestigationsDebarred } from 'validators/legalinvestigationsdebarred'
+import { validateLegalNonCriminalCourtActions } from 'validators/legalnoncriminalcourtactions'
+import { validateLegalTechnologyUnauthorized } from 'validators/legaltechnologyunauthorized'
+import { validateLegalTechnologyManipulating } from 'validators/legaltechnologymanipulating'
+import { validateLegalTechnologyUnlawful } from 'validators/legaltechnologyunlawful'
+import { validateLegalTerrorist } from 'validators/legalassociationsterrorist'
+import { validateLegalAssociationEngaged } from 'validators/legalassociationsengaged'
+import { validateLegalAssociationAdvocate } from 'validators/legalassociationsadvocating'
+import { validateLegalOverthrow } from 'validators/legalassociationsoverthrow'
+import { validateLegalViolence } from 'validators/legalassociationsviolence'
+import { validateLegalAssociationActivities } from 'validators/legalassociationsactivities'
+import { validateLegalAssociationTerrorism } from 'validators/legalassociationsterrorism'
+// PSYCHOLOGICAL
+import { validateCompetence } from 'validators/competence'
+import { validateConsultations } from 'validators/consultation'
+import { validateHospitalizations } from 'validators/hospitalization'
+import { validateDiagnoses } from 'validators/diagnoses'
+import { validateExistingConditions } from 'validators/existingconditions'
 
 // Map sections to their validator classes (temporary)
 export const getValidatorForSection = (section) => {
   switch (section) {
     case sections.IDENTIFICATION_NAME:
-      return validators.IdentificationNameValidator
+      return validateIdentificationName
 
     case sections.IDENTIFICATION_BIRTH_DATE:
-      return validators.IdentificationBirthDateValidator
+      return validateIdentificationBirthDate
 
     case sections.IDENTIFICATION_BIRTH_PLACE:
-      return validators.IdentificationBirthPlaceValidator
+      return validateIdentificationBirthPlace
 
     case sections.IDENTIFICATION_SSN:
-      return validators.IdentificationSSNValidator
+      return validateIdentificationSSN
 
     case sections.IDENTIFICATION_OTHER_NAMES:
-      return validators.IdentificationOtherNamesValidator
+      return validateOtherNames
 
     case sections.IDENTIFICATION_CONTACTS:
-      return validators.IdentificationContactInformationValidator
+      return validateIdentificationContactInformation
 
     case sections.IDENTIFICATION_PHYSICAL:
-      return validators.IdentificationPhysicalValidator
+      return validateIdentificationPhysical
 
     case sections.HISTORY_RESIDENCE:
-      return validators.HistoryResidenceValidator
+      return validateHistoryResidence
 
     case sections.HISTORY_EMPLOYMENT:
-      return validators.HistoryEmploymentValidator
+      return validateHistoryEmployment
 
     case sections.HISTORY_EDUCATION:
-      return validators.HistoryEducationValidator
+      return validateHistoryEducation
 
     case sections.HISTORY_FEDERAL:
-      return validators.FederalServiceValidator
+      return validateHistoryFederal
 
     case sections.RELATIONSHIPS_STATUS_MARITAL:
-      return validators.MaritalValidator
+      return validateMarital
 
     case sections.RELATIONSHIPS_STATUS_COHABITANTS:
-      return validators.CohabitantsValidator
+      return validateCohabitants
 
     case sections.RELATIONSHIPS_PEOPLE:
-      return validators.PeopleValidator
+      return validatePeople
 
     case sections.RELATIONSHIPS_RELATIVES:
-      return validators.RelativesValidator
+      return validateRelatives
 
     case sections.CITIZENSHIP_US_PASSPORT:
-      return validators.PassportValidator
+      return validateUsPassport
 
     case sections.CITIZENSHIP_STATUS:
-      return validators.CitizenshipValidator
+      return validateCitizenshipStatus
 
     case sections.CITIZENSHIP_MULTIPLE:
-      return validators.CitizenshipMultipleValidator
+      return validateCitizenshipMultiple
 
     case sections.CITIZENSHIP_PASSPORTS:
-      return validators.CitizenshipPassportsValidator
+      return validateCitizenshipPassports
 
     case sections.MILITARY_SELECTIVE:
-      return validators.SelectiveServiceValidator
+      return validateSelectiveService
 
     case sections.MILITARY_HISTORY:
-      return validators.MilitaryHistoryValidator
+      return validateMilitaryHistory
 
     case sections.MILITARY_DISCIPLINARY:
-      return validators.MilitaryDisciplinaryValidator
+      return validateMilitaryDisciplinaryProcedures
 
     case sections.MILITARY_FOREIGN:
-      return validators.MilitaryForeignValidator
+      return validateMilitaryForeign
 
     case sections.FOREIGN_CONTACTS:
-      return validators.ForeignContactsValidator
+      return validateForeignContacts
 
     case sections.FOREIGN_ACTIVITIES_DIRECT:
-      return validators.ForeignDirectActivityValidator
+      return validateForeignDirectActivity
 
     case sections.FOREIGN_ACTIVITIES_INDIRECT:
-      return validators.ForeignIndirectActivityValidator
+      return validateForeignIndirectActivity
 
     case sections.FOREIGN_ACTIVITIES_REAL_ESTATE:
-      return validators.ForeignRealEstateActivityValidator
+      return validateForeignRealEstateActivity
 
     case sections.FOREIGN_ACTIVITIES_BENEFITS:
-      return validators.ForeignBenefitActivityValidator
+      return validateForeignBenefitActivity
 
     case sections.FOREIGN_ACTIVITIES_SUPPORT:
-      return validators.ForeignActivitiesSupportValidator
+      return validateForeignActivitiesSupport
 
     case sections.FOREIGN_BUSINESS_ADVICE:
-      return validators.ForeignBusinessAdviceValidator
+      return validateForeignBusinessAdvice
 
     case sections.FOREIGN_BUSINESS_FAMILY:
-      return validators.ForeignBusinessFamilyValidator
+      return validateForeignBusinessFamily
 
     case sections.FOREIGN_BUSINESS_EMPLOYMENT:
-      return validators.ForeignBusinessEmploymentValidator
+      return validateForeignBusinessEmployment
 
     case sections.FOREIGN_BUSINESS_VENTURES:
-      return validators.ForeignBusinessVenturesValidator
+      return validateForeignBusinessVentures
 
     case sections.FOREIGN_BUSINESS_CONFERENCES:
-      return validators.ForeignBusinessConferencesValidator
+      return validateForeignBusinessConferences
 
     case sections.FOREIGN_BUSINESS_CONTACT:
-      return validators.ForeignBusinessContactValidator
+      return validateForeignBusinessContacts
 
     case sections.FOREIGN_BUSINESS_SPONSORSHIP:
-      return validators.ForeignBusinessSponsorshipValidator
+      return validateForeignBusinessSponsorship
 
     case sections.FOREIGN_BUSINESS_POLITICAL:
-      return validators.ForeignBusinessPoliticalValidator
+      return validateForeignBusinessPolitical
 
     case sections.FOREIGN_BUSINESS_VOTING:
-      return validators.ForeignBusinessVotingValidator
+      return validateForeignBusinessVoting
 
     case sections.FOREIGN_TRAVEL:
-      return validators.ForeignTravelValidator
+      return validateForeignTravel
 
     case sections.FINANCIAL_BANKRUPTCY:
-      return validators.BankruptcyValidator
+      return validateFinancialBankruptcy
 
     case sections.FINANCIAL_GAMBLING:
-      return validators.GamblingValidator
+      return validateFinancialGambling
 
     case sections.FINANCIAL_TAXES:
-      return validators.TaxesValidator
+      return validateFinancialTaxes
 
     case sections.FINANCIAL_CARD:
-      return validators.CardAbuseValidator
+      return validateFinancialCardAbuse
 
     case sections.FINANCIAL_CREDIT:
-      return validators.CreditValidator
+      return validateFinancialCredit
 
     case sections.FINANCIAL_DELINQUENT:
-      return validators.DelinquentValidator
+      return validateFinancialDelinquent
 
     case sections.FINANCIAL_NONPAYMENT:
-      return validators.NonpaymentValidator
+      return validateFinancialNonpayment
 
     case sections.SUBSTANCE_USE_DRUGS_USAGE:
-      return validators.DrugUsesValidator
+      return validateDrugUses
 
     case sections.SUBSTANCE_USE_DRUGS_PURCHASE:
-      return validators.DrugInvolvementsValidator
+      return validateDrugInvolvements
 
     case sections.SUBSTANCE_USE_DRUGS_CLEARANCE:
-      return validators.DrugClearanceUsesValidator
+      return validateDrugClearanceUses
 
     case sections.SUBSTANCE_USE_DRUGS_PUBLIC_SAFETY:
-      return validators.DrugPublicSafetyUsesValidator
+      return validateDrugSafetyUses
 
     case sections.SUBSTANCE_USE_DRUGS_MISUSE:
-      return validators.DrugPrescriptionUsesValidator
+      return validateDrugPrescriptionUses
 
     case sections.SUBSTANCE_USE_DRUGS_ORDERED:
-      return validators.DrugOrderedTreatmentsValidator
+      return validateDrugOrderedTreatments
 
     case sections.SUBSTANCE_USE_DRUGS_VOLUNTARY:
-      return validators.DrugVoluntaryTreatmentsValidator
+      return validateDrugVoluntaryTreatments
 
     case sections.SUBSTANCE_USE_ALCOHOL_NEGATIVE:
-      return validators.AlcoholNegativeImpactsValidator
+      return validateNegativeImpacts
 
     case sections.SUBSTANCE_USE_ALCOHOL_ORDERED:
-      return validators.AlcoholOrderedCounselingsValidator
+      return validateOrderedCounselings
 
     case sections.SUBSTANCE_USE_ALCOHOL_VOLUNTARY:
-      return validators.AlcoholVoluntaryCounselingsValidator
+      return validateVoluntaryCounselings
 
     case sections.SUBSTANCE_USE_ALCOHOL_ADDITIONAL:
-      return validators.AlcoholReceivedCounselingsValidator
+      return validateReceivedCounselings
 
     case sections.LEGAL_POLICE_OFFENSES:
-      return validators.PoliceOffensesValidator
+      return validatePoliceOffenses
 
     case sections.LEGAL_POLICE_ADDITIONAL_OFFENSES:
-      return validators.PoliceOtherOffensesValidator
+      return validatePoliceOtherOffenses
 
     case sections.LEGAL_POLICE_DOMESTIC_VIOLENCE:
-      return validators.DomesticViolenceValidator
+      return validateDomesticViolence
 
     case sections.LEGAL_INVESTIGATIONS_HISTORY:
-      return validators.LegalInvestigationsHistoryValidator
+      return validateLegalInvestigationsHistory
 
     case sections.LEGAL_INVESTIGATIONS_REVOKED:
-      return validators.LegalInvestigationsRevokedValidator
+      return validateLegalInvestigationsRevoked
 
     case sections.LEGAL_INVESTIGATIONS_DEBARRED:
-      return validators.LegalInvestigationsDebarredValidator
+      return validateLegalInvestigationsDebarred
 
     case sections.LEGAL_COURT:
-      return validators.LegalNonCriminalCourtActionsValidator
+      return validateLegalNonCriminalCourtActions
 
     case sections.LEGAL_TECHNOLOGY_UNAUTHORIZED:
-      return validators.LegalTechnologyUnauthorizedValidator
+      return validateLegalTechnologyUnauthorized
 
     case sections.LEGAL_TECHNOLOGY_MANIPULATING:
-      return validators.LegalTechnologyManipulatingValidator
+      return validateLegalTechnologyManipulating
 
     case sections.LEGAL_TECHNOLOGY_UNLAWFUL:
-      return validators.LegalTechnologyUnlawfulValidator
+      return validateLegalTechnologyUnlawful
 
     case sections.LEGAL_ASSOCIATIONS_TERRORIST_ORGANIZATION:
-      return validators.LegalAssociationsTerroristValidator
+      return validateLegalTerrorist
 
     case sections.LEGAL_ASSOCIATIONS_ENGAGED_IN_TERRORISM:
-      return validators.LegalAssociationsEngagedValidator
+      return validateLegalAssociationEngaged
 
     case sections.LEGAL_ASSOCIATIONS_ADVOCATING:
-      return validators.LegalAssociationsAdvocatingValidator
+      return validateLegalAssociationAdvocate
 
     case sections.LEGAL_ASSOCIATIONS_MEMBERSHIP_OVERTHROW:
-      return validators.LegalAssociationsOverthrowValidator
+      return validateLegalOverthrow
 
     case sections.LEGAL_ASSOCIATIONS_MEMBERSHIP_VIOLENCE:
-      return validators.LegalAssociationsViolenceValidator
+      return validateLegalViolence
 
     case sections.LEGAL_ASSOCIATIONS_ACTIVITIES_TO_OVERTHROW:
-      return validators.LegalAssociationsActivitiesValidator
+      return validateLegalAssociationActivities
 
     case sections.LEGAL_ASSOCIATIONS_TERRORISM_ASSOCIATION:
-      return validators.LegalAssociationsTerrorismValidator
+      return validateLegalAssociationTerrorism
 
     case sections.PSYCHOLOGICAL_COMPETENCE:
-      return validators.CompetenceValidator
+      return validateCompetence
 
     case sections.PSYCHOLOGICAL_CONSULTATIONS:
-      return validators.ConsultationValidator
+      return validateConsultations
 
     case sections.PSYCHOLOGICAL_HOSPITALIZATIONS:
-      return validators.HospitalizationsValidator
+      return validateHospitalizations
 
     case sections.PSYCHOLOGICAL_DIAGNOSES:
-      return validators.DiagnosesValidator
+      return validateDiagnoses
 
     case sections.PSYCHOLOGICAL_CONDITIONS:
-      return validators.ExistingConditionsValidator
+      return validateExistingConditions
 
     default:
       console.warn(`Validator for ${section} section not found`)
@@ -247,11 +337,15 @@ export const getValidatorForSection = (section) => {
   }
 }
 
-export const validateSection = ({ key, data }) => {
-  const Validator = getValidatorForSection(key)
+export const validateSection = ({ key, data }, formType = SF86) => {
+  const validator = getValidatorForSection(key)
 
-  if (Validator) {
-    return new Validator(data).isValid()
+  if (validator) {
+    try {
+      return validator(data, formType)
+    } catch (e) {
+      console.warn(`Invalid validator for section ${key}`)
+    }
   }
 
   return false

--- a/src/helpers/validation.js
+++ b/src/helpers/validation.js
@@ -337,14 +337,14 @@ export const getValidatorForSection = (section) => {
   }
 }
 
-export const validateSection = ({ key, data }, formType = SF86) => {
+export const validateSection = ({ key = '', data = {} }, formType = SF86) => {
   const validator = getValidatorForSection(key)
 
   if (validator) {
     try {
       return validator(data, formType)
     } catch (e) {
-      console.warn(`Invalid validator for section ${key}`)
+      console.warn(`Invalid validator for section ${key}`, e)
     }
   }
 

--- a/src/sagas/validate.js
+++ b/src/sagas/validate.js
@@ -7,6 +7,7 @@ import * as actionTypes from 'constants/actionTypes'
 import { reportCompletion } from 'actions/ApplicationActions'
 import { validateSection } from 'helpers/validation'
 import { nestedFormSectionsSelector } from 'selectors/navigation'
+import { formTypeSelector } from 'selectors/formType'
 
 import {
   selectState,
@@ -19,6 +20,7 @@ export function* updateSectionStatus(section, store = '', state = {}) {
     const parentStore = store || section.store
     yield all(section.subsections.map(s => call(updateSectionStatus, s, parentStore, state)))
   } else {
+    const formType = yield select(formTypeSelector)
     const { application } = state
 
     let sectionName = store.toLowerCase()
@@ -33,7 +35,7 @@ export function* updateSectionStatus(section, store = '', state = {}) {
       sectionData = application[store][section.storeKey] || {}
     }
 
-    const isValid = yield call(validateSection, { ...section, data: sectionData })
+    const isValid = yield call(validateSection, { ...section, data: sectionData }, formType)
 
     yield put(reportCompletion(
       sectionName,

--- a/src/sagas/validate.test.js
+++ b/src/sagas/validate.test.js
@@ -4,6 +4,7 @@ import {
 
 import * as actionTypes from 'constants/actionTypes'
 import { nestedFormSectionsSelector } from 'selectors/navigation'
+import { formTypeSelector } from 'selectors/formType'
 import { validateSection } from 'helpers/validation'
 import { reportCompletion } from 'actions/ApplicationActions'
 
@@ -120,12 +121,17 @@ describe('updateSectionStatus saga', () => {
       testState
     )
 
-    it('calls validateSection with the section data', () => {
+    it('selects the formType for validation', () => {
       expect(generator.next().value)
+        .toEqual(select(formTypeSelector))
+    })
+
+    it('calls validateSection with the section data', () => {
+      expect(generator.next('SF86').value)
         .toEqual(call(validateSection, {
           ...testSection.subsections[0],
           data: { data: 'my data' },
-        }))
+        }, 'SF86'))
     })
 
     it('dispatches reportCompletion for the subsection', () => {

--- a/src/selectors/formType.js
+++ b/src/selectors/formType.js
@@ -1,2 +1,3 @@
+/* eslint import/prefer-default-export: 0 */
+
 export const formTypeSelector = state => state.application.Settings.formType
-export default 'formTypeSelector'

--- a/src/selectors/validation.js
+++ b/src/selectors/validation.js
@@ -3,9 +3,8 @@ import { createSelector } from 'reselect'
 
 import { validateSection, sectionIsValid } from 'helpers/validation'
 
-import {
-  nestedFormSectionsSelector,
-} from './navigation'
+import { nestedFormSectionsSelector } from 'selectors/navigation'
+import { formTypeSelector } from 'selectors/formType'
 
 /**
  * Recursive function that loops through sections and their subsections, checks
@@ -14,6 +13,7 @@ import {
  */
 const getFormSectionStatuses = (sections = [], store = '', state = {}) => {
   const { application } = state
+  const formType = formTypeSelector(state)
   const newSections = sections
     .filter(s => s.subsections || s.storeKey)
     .map((s) => {
@@ -36,7 +36,7 @@ const getFormSectionStatuses = (sections = [], store = '', state = {}) => {
         sectionData = application[store][s.storeKey] || {}
       }
 
-      const isValid = validateSection({ ...s, data: sectionData })
+      const isValid = validateSection({ ...s, data: sectionData }, formType)
 
       return {
         ...s,

--- a/src/validators/bankruptcy.js
+++ b/src/validators/bankruptcy.js
@@ -15,7 +15,7 @@ const financialBankruptcyModel = {
   },
 }
 
-const validateFinancialBankruptcy = data => (
+export const validateFinancialBankruptcy = data => (
   validateModel(data, financialBankruptcyModel) === true
 )
 
@@ -31,7 +31,9 @@ export default class BankruptcyValidator {
    * Validates the yes/no branching for bankruptcy
    */
   validHasBankruptcy() {
-    return validateModel(this.data, { HasBankruptcy: financialBankruptcyModel.HasBankruptcy }) === true
+    return validateModel(this.data, {
+      HasBankruptcy: financialBankruptcyModel.HasBankruptcy,
+    }) === true
   }
 
   validBankruptcies() {
@@ -87,7 +89,9 @@ export class BankruptcyItemValidator {
   }
 
   validDischargeExplanation() {
-    return validateModel(this.data, { DischargeExplanation: financialBankruptcy.DischargeExplanation }) === true
+    return validateModel(this.data, {
+      DischargeExplanation: financialBankruptcy.DischargeExplanation,
+    }) === true
   }
 
   isValid() {

--- a/src/validators/cardabuse.js
+++ b/src/validators/cardabuse.js
@@ -18,6 +18,10 @@ const cardAbuseModel = {
   },
 }
 
+export const validateFinancialCardAbuse = data => (
+  validateModel(data, cardAbuseModel) === true
+)
+
 export default class CardAbuseValidator {
   constructor(data = {}) {
     this.data = data
@@ -32,7 +36,7 @@ export default class CardAbuseValidator {
   }
 
   isValid() {
-    return validateModel(this.data, cardAbuseModel) === true
+    return validateFinancialCardAbuse(this.data)
   }
 }
 

--- a/src/validators/consultation.js
+++ b/src/validators/consultation.js
@@ -1,7 +1,7 @@
 import { validateModel } from 'models/validate'
 import consultation from 'models/consultation'
 
-export const validateCompetence = data => (
+export const validateConsultations = data => (
   validateModel(data, consultation) === true
 )
 
@@ -11,6 +11,6 @@ export default class ConsultationValidator {
   }
 
   isValid() {
-    return validateCompetence(this.data)
+    return validateConsultations(this.data)
   }
 }

--- a/src/validators/credit.js
+++ b/src/validators/credit.js
@@ -18,13 +18,19 @@ const creditCounselingModel = {
   },
 }
 
+export const validateFinancialCredit = data => (
+  validateModel(data, creditCounselingModel) === true
+)
+
 export default class CreditValidator {
   constructor(data = {}) {
     this.data = data
   }
 
   validHasCreditCounseling() {
-    return validateModel(this.data, { HasCreditCounseling: creditCounselingModel.HasCreditCounseling }) === true
+    return validateModel(this.data, {
+      HasCreditCounseling: creditCounselingModel.HasCreditCounseling,
+    }) === true
   }
 
   validList() {
@@ -32,13 +38,14 @@ export default class CreditValidator {
   }
 
   isValid() {
-    return validateModel(this.data, creditCounselingModel) === true
+    return validateFinancialCredit(this.data)
   }
 }
 
 const validateCreditCounselingItem = data => (
   validateModel(data, financialCreditCounseling) === true
 )
+
 export class CreditItemValidator {
   constructor(data = {}) {
     this.data = data

--- a/src/validators/delinquent.js
+++ b/src/validators/delinquent.js
@@ -26,6 +26,15 @@ const delinquentItemsModel = {
   },
 }
 
+export const validateFinancialDelinquent = (data, formType = formTypes.SF86) => {
+  const requiredFinancialDelinquentName = requireFinancialDelinquentName(formType)
+  const requiredFinancialDelinquentInfraction = requireFinancialDelinquentInfraction(formType)
+  return validateModel(data, delinquentItemsModel, {
+    requiredFinancialDelinquentName,
+    requiredFinancialDelinquentInfraction,
+  }) === true
+}
+
 /** Object Validators (as classes) - legacy */
 export default class DelinquentValidator {
   constructor(data = {}) {
@@ -42,7 +51,10 @@ export default class DelinquentValidator {
 
   validList() {
     const requiredFinancialDelinquentName = requireFinancialDelinquentName(this.formType)
-    const requiredFinancialDelinquentInfraction = requireFinancialDelinquentInfraction(this.formType)
+    const requiredFinancialDelinquentInfraction = requireFinancialDelinquentInfraction(
+      this.formType
+    )
+
     return validateModel(
       this.data,
       { List: delinquentItemsModel.List },
@@ -51,13 +63,7 @@ export default class DelinquentValidator {
   }
 
   isValid() {
-    const requiredFinancialDelinquentName = requireFinancialDelinquentName(this.formType)
-    const requiredFinancialDelinquentInfraction = requireFinancialDelinquentInfraction(this.formType)
-    return validateModel(
-      this.data,
-      delinquentItemsModel,
-      { requiredFinancialDelinquentName, requiredFinancialDelinquentInfraction }
-    ) === true
+    return validateFinancialDelinquent(this.data, this.formType)
   }
 }
 
@@ -91,7 +97,9 @@ export class DelinquentItemValidator {
   }
 
   validInfractions() {
-    const requiredFinancialDelinquentInfraction = requireFinancialDelinquentInfraction(this.formType)
+    const requiredFinancialDelinquentInfraction = requireFinancialDelinquentInfraction(
+      this.formType
+    )
 
     return validateModel(
       this.data,

--- a/src/validators/gambling.js
+++ b/src/validators/gambling.js
@@ -48,7 +48,7 @@ export default class GamblingValidator {
   }
 }
 
-export const validateGamblingItem = data => (
+export const validateFinancialGamblingItem = data => (
   validateModel(data, financialGambling) === true
 )
 
@@ -58,6 +58,6 @@ export class GamblingItemValidator {
   }
 
   isValid() {
-    return validateGamblingItem(this.data)
+    return validateFinancialGamblingItem(this.data)
   }
 }

--- a/src/validators/gambling.js
+++ b/src/validators/gambling.js
@@ -18,13 +18,19 @@ const financialGamblingModel = {
   },
 }
 
+export const validateFinancialGambling = data => (
+  validateModel(data, financialGamblingModel) === true
+)
+
 export default class GamblingValidator {
   constructor(data = {}) {
     this.data = data
   }
 
   validHasGamblingDebt() {
-    return validateModel(this.data, { HasGamblingDebt: financialGamblingModel.HasGamblingDebt }) === true
+    return validateModel(this.data, {
+      HasGamblingDebt: financialGamblingModel.HasGamblingDebt,
+    }) === true
   }
 
   /**
@@ -38,19 +44,20 @@ export default class GamblingValidator {
    * Validates section of gambling debt
    */
   isValid() {
-    return validateModel(this.data, financialGamblingModel) === true
+    return validateFinancialGambling(this.data)
   }
 }
 
-const validateFinancialGambling = data => (
+export const validateGamblingItem = data => (
   validateModel(data, financialGambling) === true
 )
+
 export class GamblingItemValidator {
   constructor(data = {}) {
     this.data = data
   }
 
   isValid() {
-    return validateFinancialGambling(this.data)
+    return validateGamblingItem(this.data)
   }
 }

--- a/src/validators/index.js
+++ b/src/validators/index.js
@@ -1,4 +1,4 @@
-import validate, { walkValidationTree } from './validate'
+import validate from './validate'
 import DateControlValidator from './datecontrol'
 import DateRangeValidator from './daterange'
 import BankruptcyValidator, { BankruptcyItemValidator } from './bankruptcy'
@@ -212,7 +212,6 @@ import { hideHippa, formIsSigned, formIsLocked } from './releases'
 
 export default validate
 export {
-  walkValidationTree,
   DateControlValidator,
   DateRangeValidator,
   IdentificationNameValidator,

--- a/src/validators/militaryforeign.js
+++ b/src/validators/militaryforeign.js
@@ -27,7 +27,7 @@ export class ForeignServiceValidator {
 
   isValid() {
     return validateModel(this.data, militaryForeign, {
-      requireForeignMilitaryMaintainsContact: requireForeignMilitaryMaintainsContact(this.formType)
+      requireForeignMilitaryMaintainsContact: requireForeignMilitaryMaintainsContact(this.formType),
     }) === true
   }
 }
@@ -41,7 +41,7 @@ const militaryForeignModel = {
   },
 }
 
-const validateMilitaryForeign = (data, formType = formTypes.SF86) => (
+export const validateMilitaryForeign = (data, formType = formTypes.SF86) => (
   validateModel(data, militaryForeignModel, {
     requireForeignMilitaryMaintainsContact: requireForeignMilitaryMaintainsContact(formType),
   }) === true

--- a/src/validators/nonpayment.js
+++ b/src/validators/nonpayment.js
@@ -18,6 +18,10 @@ const nonpaymentModel = {
   },
 }
 
+export const validateFinancialNonpayment = data => (
+  validateModel(data, nonpaymentModel) === true
+)
+
 export default class NonpaymentValidator {
   constructor(data = {}) {
     this.data = data
@@ -32,7 +36,7 @@ export default class NonpaymentValidator {
   }
 
   isValid() {
-    return validateModel(this.data, nonpaymentModel) === true
+    return validateFinancialNonpayment(this.data)
   }
 }
 

--- a/src/validators/taxes.js
+++ b/src/validators/taxes.js
@@ -17,6 +17,11 @@ const financialTaxesModel = {
     return {}
   },
 }
+
+export const validateFinancialTaxes = data => (
+  validateModel(data, financialTaxesModel) === true
+)
+
 export default class TaxesValidator {
   constructor(data = {}) {
     this.data = data
@@ -31,7 +36,7 @@ export default class TaxesValidator {
   }
 
   isValid() {
-    return validateModel(this.data, financialTaxesModel) === true
+    return validateFinancialTaxes(this.data)
   }
 }
 

--- a/src/validators/validate.js
+++ b/src/validators/validate.js
@@ -1,14 +1,104 @@
+import store from 'services/store'
+import { formTypeSelector } from 'selectors/formType'
+
+// IDENTIFICATION
+import { validateIdentificationName } from 'validators/identificationname'
+import { validateIdentificationBirthDate } from 'validators/identificationbirthdate'
+import { validateIdentificationBirthPlace } from 'validators/identificationbirthplace'
+import { validateIdentificationSSN } from 'validators/identificationssn'
+import { validateOtherNames } from 'validators/identificationothernames'
+import { validateIdentificationContactInformation } from 'validators/identificationcontacts'
+import { validateIdentificationPhysical } from 'validators/identificationphysical'
+// HISTORY
+import { validateHistoryResidence } from 'validators/residence'
+import { validateHistoryEmployment } from 'validators/employment'
+import { validateHistoryEducation } from 'validators/education'
+import { validateHistoryFederal } from 'validators/federalservice'
+// RELATIONSHIPS
+import { validateMarital } from 'validators/marital'
+import { validateCohabitants } from 'validators/cohabitant'
+import { validatePeople } from 'validators/people'
+import { validateRelatives } from 'validators/relatives'
+// CITIZENSHIP
+import { validateUsPassport } from 'validators/passport'
+import { validateCitizenshipStatus } from 'validators/citizenship'
+import { validateCitizenshipMultiple } from 'validators/citizenship-multiple'
+import { validateCitizenshipPassports } from 'validators/citizenship-passports'
+// MILITARY
+import { validateSelectiveService } from 'validators/selectiveservice'
+import { validateMilitaryHistory } from 'validators/militaryhistory'
+import { validateMilitaryDisciplinaryProcedures } from 'validators/militarydisciplinary'
+import { validateMilitaryForeign } from 'validators/militaryforeign'
+// FOREIGN
+import { validateForeignContacts } from 'validators/foreigncontacts'
+import { validateForeignDirectActivity } from 'validators/foreigndirectactivity'
+import { validateForeignIndirectActivity } from 'validators/foreignindirectactivity'
+import { validateForeignRealEstateActivity } from 'validators/foreignrealestateactivity'
+import { validateForeignBenefitActivity } from 'validators/foreignbenefitactivity'
+import { validateForeignActivitiesSupport } from 'validators/foreignsupport'
+import { validateForeignBusinessAdvice } from 'validators/foreignbusinessadvice'
+import { validateForeignBusinessFamily } from 'validators/foreignbusinessfamily'
+import { validateForeignBusinessEmployment } from 'validators/foreignbusinessemployment'
+import { validateForeignBusinessVentures } from 'validators/foreignbusinessventures'
+import { validateForeignBusinessConferences } from 'validators/foreignbusinessconferences'
+import { validateForeignBusinessContacts } from 'validators/foreignbusinesscontact'
+import { validateForeignBusinessSponsorship } from 'validators/foreignbusinesssponsorship'
+import { validateForeignBusinessPolitical } from 'validators/foreignbusinesspolitical'
+import { validateForeignBusinessVoting } from 'validators/foreignbusinessvoting'
+import { validateForeignTravel } from 'validators/foreigntravel'
+// FINANCIAL
+import { validateFinancialBankruptcy } from 'validators/bankruptcy'
+import { validateFinancialGambling } from 'validators/gambling'
+import { validateFinancialTaxes } from 'validators/taxes'
+import { validateFinancialCardAbuse } from 'validators/cardabuse'
+import { validateFinancialCredit } from 'validators/credit'
+import { validateFinancialDelinquent } from 'validators/delinquent'
+import { validateFinancialNonpayment } from 'validators/nonpayment'
+// SUBSTANCE
+import { validateDrugUses } from 'validators/druguses'
+import { validateDrugInvolvements } from 'validators/druginvolvements'
+import { validateDrugClearanceUses } from 'validators/drugclearanceuses'
+import { validateDrugSafetyUses } from 'validators/drugpublicsafetyuses'
+import { validateDrugPrescriptionUses } from 'validators/drugprescriptionuses'
+import { validateDrugOrderedTreatments } from 'validators/drugorderedtreatments'
+import { validateDrugVoluntaryTreatments } from 'validators/drugvoluntarytreatments'
+import { validateNegativeImpacts } from 'validators/alcoholnegativeimpact'
+import { validateOrderedCounselings } from 'validators/alcoholorderedcounseling'
+import { validateVoluntaryCounselings } from 'validators/alcoholvoluntarycounseling'
+import { validateReceivedCounselings } from 'validators/alcoholreceivedcounseling'
+// LEGAL
+import { validatePoliceOffenses } from 'validators/policeoffenses'
+import { validatePoliceOtherOffenses } from 'validators/policeotheroffenses'
+import { validateDomesticViolence } from 'validators/domesticviolence'
+import { validateLegalInvestigationsHistory } from 'validators/legalinvestigationshistory'
+import { validateLegalInvestigationsRevoked } from 'validators/legalinvestigationsrevoked'
+import { validateLegalInvestigationsDebarred } from 'validators/legalinvestigationsdebarred'
+import { validateLegalNonCriminalCourtActions } from 'validators/legalnoncriminalcourtactions'
+import { validateLegalTechnologyUnauthorized } from 'validators/legaltechnologyunauthorized'
+import { validateLegalTechnologyManipulating } from 'validators/legaltechnologymanipulating'
+import { validateLegalTechnologyUnlawful } from 'validators/legaltechnologyunlawful'
+import { validateLegalTerrorist } from 'validators/legalassociationsterrorist'
+import { validateLegalAssociationEngaged } from 'validators/legalassociationsengaged'
+import { validateLegalAssociationAdvocate } from 'validators/legalassociationsadvocating'
+import { validateLegalOverthrow } from 'validators/legalassociationsoverthrow'
+import { validateLegalViolence } from 'validators/legalassociationsviolence'
+import { validateLegalAssociationActivities } from 'validators/legalassociationsactivities'
+import { validateLegalAssociationTerrorism } from 'validators/legalassociationsterrorism'
+// PSYCHOLOGICAL
+import { validateCompetence } from 'validators/competence'
+import { validateConsultations } from 'validators/consultation'
+import { validateHospitalizations } from 'validators/hospitalization'
+import { validateDiagnoses } from 'validators/diagnoses'
+import { validateExistingConditions } from 'validators/existingconditions'
+
 import * as logic from '.'
 
-const validate = (payload) => {
-  if (payload && payload.type) {
-    return validators[payload.type](payload.props)
-  }
-  return false
-}
-export default validate
+/**
+ * The plan is to deprecate this file and replace with helpers/validation.js
+ */
 
 const validators = {
+  // GENERIC
   benefit: () => false,
   branch: data => logic.validBranch(data),
   checkbox: data => logic.validGenericTextfield(data),
@@ -37,118 +127,100 @@ const validators = {
   telephone: data => logic.validPhoneNumber(data),
   text: data => logic.validGenericTextfield(data),
   textarea: data => logic.validGenericTextfield(data),
-  'identification.birthdate': data => new logic.IdentificationBirthDateValidator(data).isValid(),
-  'identification.birthplace': data => new logic.IdentificationBirthPlaceValidator(data).isValid(),
-  'identification.contacts': data => new logic.IdentificationContactInformationValidator(data).isValid(),
-  'identification.name': data => new logic.IdentificationNameValidator(data).isValid(),
-  'identification.othernames': data => new logic.IdentificationOtherNamesValidator(data).isValid(),
-  'identification.physical': data => new logic.IdentificationPhysicalValidator(data).isValid(),
-  'identification.ssn': data => new logic.IdentificationSSNValidator(data).isValid(),
-  'financial.bankruptcy': data => new logic.BankruptcyValidator(data).isValid(),
-  'financial.gambling': data => new logic.GamblingValidator(data).isValid(),
-  'financial.taxes': data => new logic.TaxesValidator(data).isValid(),
-  'financial.card': data => new logic.CardAbuseValidator(data).isValid(),
-  'financial.credit': data => new logic.CreditValidator(data).isValid(),
-  'financial.delinquent': data => new logic.DelinquentValidator(data).isValid(),
-  'financial.nonpayment': data => new logic.NonpaymentValidator(data).isValid(),
-  'history.education': data => new logic.HistoryEducationValidator(data).isValid(),
-  'history.employment': data => new logic.HistoryEmploymentValidator(data).isValid(),
-  'history.federal': data => new logic.FederalServiceValidator(data).isValid(),
-  'history.residence': data => new logic.HistoryResidenceValidator(data).isValid(),
-  'relationships.status.cohabitant': data => new logic.CohabitantsValidator(data).isValid(),
-  'relationships.status.marital': data => new logic.MaritalValidator(data).isValid(),
-  'relationships.people': data => new logic.PeopleValidator(data).isValid(),
-  'relationships.relatives': data => new logic.RelativesValidator(data).isValid(),
-  'citizenship.multiple': data => new logic.CitizenshipMultipleValidator(data).isValid(),
-  'citizenship.passports': data => new logic.CitizenshipPassportsValidator(data).isValid(),
-  'citizenship.status': data => new logic.CitizenshipValidator(data).isValid(),
-  'military.selective': data => new logic.SelectiveServiceValidator(data).isValid(),
-  'military.history': data => new logic.MilitaryHistoryValidator(data).isValid(),
-  'military.disciplinary': data => new logic.MilitaryDisciplinaryValidator(data).isValid(),
-  'military.foreign': data => new logic.MilitaryForeignValidator(data).isValid(),
-  'foreign.activities.benefits': data => new logic.ForeignBenefitActivityValidator(data).isValid(),
-  'foreign.activities.direct': data => new logic.ForeignDirectActivityValidator(data).isValid(),
-  'foreign.activities.indirect': data => new logic.ForeignIndirectActivityValidator(data).isValid(),
-  'foreign.activities.realestate': data => new logic.ForeignRealEstateActivityValidator(data).isValid(),
-  'foreign.activities.support': data => new logic.ForeignActivitiesSupportValidator(data).isValid(),
-  'foreign.business.advice': data => new logic.ForeignBusinessAdviceValidator(data).isValid(),
-  'foreign.business.conferences': data => new logic.ForeignBusinessConferencesValidator(data).isValid(),
-  'foreign.business.contact': data => new logic.ForeignBusinessContactValidator(data).isValid(),
-  'foreign.business.employment': data => new logic.ForeignBusinessEmploymentValidator(data).isValid(),
-  'foreign.business.family': data => new logic.ForeignBusinessFamilyValidator(data).isValid(),
-  'foreign.business.political': data => new logic.ForeignBusinessPoliticalValidator(data).isValid(),
-  'foreign.business.sponsorship': data => new logic.ForeignBusinessSponsorshipValidator(data).isValid(),
-  'foreign.business.ventures': data => new logic.ForeignBusinessVenturesValidator(data).isValid(),
-  'foreign.business.voting': data => new logic.ForeignBusinessVotingValidator(data).isValid(),
-  'foreign.contacts': data => new logic.ForeignContactsValidator(data).isValid(),
-  'foreign.passport': data => new logic.PassportValidator(data).isValid(),
-  'foreign.travel': data => new logic.ForeignTravelValidator(data).isValid(),
-  'substance.alcohol.additional': data => new logic.AlcoholReceivedCounselingsValidator(data).isValid(),
-  'substance.alcohol.negative': data => new logic.AlcoholNegativeImpactsValidator(data).isValid(),
-  'substance.alcohol.ordered': data => new logic.AlcoholOrderedCounselingsValidator(data).isValid(),
-  'substance.alcohol.voluntary': data => new logic.AlcoholVoluntaryCounselingsValidator(data).isValid(),
-  'substance.drugs.clearance': data => new logic.DrugClearanceUsesValidator(data).isValid(),
-  'substance.drugs.misuse': data => new logic.DrugPrescriptionUsesValidator(data).isValid(),
-  'substance.drugs.ordered': data => new logic.DrugOrderedTreatmentsValidator(data).isValid(),
-  'substance.drugs.publicsafety': data => new logic.DrugPublicSafetyUsesValidator(data).isValid(),
-  'substance.drugs.purchase': data => new logic.DrugInvolvementsValidator(data).isValid(),
-  'substance.drugs.usage': data => new logic.DrugUsesValidator(data).isValid(),
-  'substance.drugs.voluntary': data => new logic.DrugVoluntaryTreatmentsValidator(data).isValid(),
-  'legal.associations.activities-to-overthrow': data => new logic.LegalAssociationsActivitiesValidator(data).isValid(),
-  'legal.associations.advocating': data => new logic.LegalAssociationsAdvocatingValidator(data).isValid(),
-  'legal.associations.engaged-in-terrorism': data => new logic.LegalAssociationsEngagedValidator(data).isValid(),
-  'legal.associations.membership-overthrow': data => new logic.LegalAssociationsOverthrowValidator(data).isValid(),
-  'legal.associations.membership-violence-or-force': data => new logic.LegalAssociationsViolenceValidator(data).isValid(),
-  'legal.associations.terrorism-association': data => new logic.LegalAssociationsTerrorismValidator(data).isValid(),
-  'legal.associations.terrorist-organization': data => new logic.LegalAssociationsTerroristValidator(data).isValid(),
-  'legal.court': data => new logic.LegalNonCriminalCourtActionsValidator(data).isValid(),
-  'legal.investigations.debarred': data => new logic.LegalInvestigationsDebarredValidator(data).isValid(),
-  'legal.investigations.history': data => new logic.LegalInvestigationsHistoryValidator(data).isValid(),
-  'legal.investigations.revoked': data => new logic.LegalInvestigationsRevokedValidator(data).isValid(),
-  'legal.police.additionaloffenses': data => new logic.PoliceOtherOffensesValidator(data).isValid(),
-  'legal.police.domesticviolence': data => new logic.DomesticViolenceValidator(data).isValid(),
-  'legal.police.offenses': data => new logic.PoliceOffensesValidator(data).isValid(),
-  'legal.technology.manipulating': data => new logic.LegalTechnologyManipulatingValidator(data).isValid(),
-  'legal.technology.unauthorized': data => new logic.LegalTechnologyUnauthorizedValidator(data).isValid(),
-  'legal.technology.unlawful': data => new logic.LegalTechnologyUnlawfulValidator(data).isValid(),
-  'psychological.competence': data => new logic.CompetenceValidator(data).isValid(),
-  'psychological.conditions': data => new logic.ExistingConditionsValidator(data).isValid(),
-  'psychological.consultations': data => new logic.ConsultationValidator(data).isValid(),
-  'psychological.diagnoses': data => new logic.DiagnosesValidator(data).isValid(),
-  'psychological.hospitalizations': data => new logic.HospitalizationsValidator(data).isValid(),
+
+  // SECTIONS
+  'identification.birthdate': validateIdentificationBirthDate,
+  'identification.birthplace': validateIdentificationBirthPlace,
+  'identification.contacts': validateIdentificationContactInformation,
+  'identification.name': validateIdentificationName,
+  'identification.othernames': validateOtherNames,
+  'identification.physical': validateIdentificationPhysical,
+  'identification.ssn': validateIdentificationSSN,
+  'financial.bankruptcy': validateFinancialBankruptcy,
+  'financial.gambling': validateFinancialGambling,
+  'financial.taxes': validateFinancialTaxes,
+  'financial.card': validateFinancialCardAbuse,
+  'financial.credit': validateFinancialCredit,
+  'financial.delinquent': validateFinancialDelinquent,
+  'financial.nonpayment': validateFinancialNonpayment,
+  'history.education': validateHistoryEducation,
+  'history.employment': validateHistoryEmployment,
+  'history.federal': validateHistoryFederal,
+  'history.residence': validateHistoryResidence,
+  'relationships.status.cohabitant': validateCohabitants,
+  'relationships.status.marital': validateMarital,
+  'relationships.people': validatePeople,
+  'relationships.relatives': validateRelatives,
+  'citizenship.multiple': validateCitizenshipMultiple,
+  'citizenship.passports': validateCitizenshipPassports,
+  'citizenship.status': validateCitizenshipStatus,
+  'military.selective': validateSelectiveService,
+  'military.history': validateMilitaryHistory,
+  'military.disciplinary': validateMilitaryDisciplinaryProcedures,
+  'military.foreign': validateMilitaryForeign,
+  'foreign.activities.benefits': validateForeignBenefitActivity,
+  'foreign.activities.direct': validateForeignDirectActivity,
+  'foreign.activities.indirect': validateForeignIndirectActivity,
+  'foreign.activities.realestate': validateForeignRealEstateActivity,
+  'foreign.activities.support': validateForeignActivitiesSupport,
+  'foreign.business.advice': validateForeignBusinessAdvice,
+  'foreign.business.conferences': validateForeignBusinessConferences,
+  'foreign.business.contact': validateForeignBusinessContacts,
+  'foreign.business.employment': validateForeignBusinessEmployment,
+  'foreign.business.family': validateForeignBusinessFamily,
+  'foreign.business.political': validateForeignBusinessPolitical,
+  'foreign.business.sponsorship': validateForeignBusinessSponsorship,
+  'foreign.business.ventures': validateForeignBusinessVentures,
+  'foreign.business.voting': validateForeignBusinessVoting,
+  'foreign.contacts': validateForeignContacts,
+  'foreign.passport': validateUsPassport,
+  'foreign.travel': validateForeignTravel,
+  'substance.alcohol.additional': validateReceivedCounselings,
+  'substance.alcohol.negative': validateNegativeImpacts,
+  'substance.alcohol.ordered': validateOrderedCounselings,
+  'substance.alcohol.voluntary': validateVoluntaryCounselings,
+  'substance.drugs.clearance': validateDrugClearanceUses,
+  'substance.drugs.misuse': validateDrugPrescriptionUses,
+  'substance.drugs.ordered': validateDrugOrderedTreatments,
+  'substance.drugs.publicsafety': validateDrugSafetyUses,
+  'substance.drugs.purchase': validateDrugInvolvements,
+  'substance.drugs.usage': validateDrugUses,
+  'substance.drugs.voluntary': validateDrugVoluntaryTreatments,
+  'legal.associations.activities-to-overthrow': validateLegalAssociationActivities,
+  'legal.associations.advocating': validateLegalAssociationAdvocate,
+  'legal.associations.engaged-in-terrorism': validateLegalAssociationEngaged,
+  'legal.associations.membership-overthrow': validateLegalOverthrow,
+  'legal.associations.membership-violence-or-force': validateLegalViolence,
+  'legal.associations.terrorism-association': validateLegalAssociationTerrorism,
+  'legal.associations.terrorist-organization': validateLegalTerrorist,
+  'legal.court': validateLegalNonCriminalCourtActions,
+  'legal.investigations.debarred': validateLegalInvestigationsDebarred,
+  'legal.investigations.history': validateLegalInvestigationsHistory,
+  'legal.investigations.revoked': validateLegalInvestigationsRevoked,
+  'legal.police.additionaloffenses': validatePoliceOtherOffenses,
+  'legal.police.domesticviolence': validateDomesticViolence,
+  'legal.police.offenses': validatePoliceOffenses,
+  'legal.technology.manipulating': validateLegalTechnologyManipulating,
+  'legal.technology.unauthorized': validateLegalTechnologyUnauthorized,
+  'legal.technology.unlawful': validateLegalTechnologyUnlawful,
+  'psychological.competence': validateCompetence,
+  'psychological.conditions': validateExistingConditions,
+  'psychological.consultations': validateConsultations,
+  'psychological.diagnoses': validateDiagnoses,
+  'psychological.hospitalizations': validateHospitalizations,
   'psychological.treatment': () => false,
 }
 
-// Walk through the validation tree of a piece of information.
-// This is useful when all values within a particular chunk of
-// data does not contain validations based on branching.
-export const walkValidationTree = (data) => {
-  // No data, no love.
-  if (!data) {
-    return false
+const validate = (payload) => {
+  // Temporary because we need formType to pass to validation fns
+  const state = store.getState()
+  const formType = formTypeSelector(state)
+
+  if (payload && payload.type) {
+    return validators[payload.type](payload.props, formType)
   }
 
-  // If the data matches the signature of a payload we know
-  // how to proceed with normal validation logic.
-  if (data.type && data.props) {
-    return validators(data)
-  }
-
-  // The data may be an object with named properties
-  // potentially containing payload. We want to "mine"
-  // for these and extract their results.
-  for (const property in data) {
-    // When the property is not specific to this instance
-    // skip it and go to the next.
-    if (!data.hasOwnProperty(property)) {
-      continue
-    }
-
-    const result = walkValidationTree(data[property])
-    if (!result) {
-      return false
-    }
-  }
-
-  return true
+  return false
 }
+
+export default validate


### PR DESCRIPTION
## Description

This PR accomplishes the first 2 steps (listed below) needed to delete the legacy validation classes. Changes include:
- Export `validate` functions from validator files that were missing it
- Replace use of validation classes with new functions in `helpers/validation.js`
- Replace use of validation classes with new functions in `validators/validate.js` (this file is marked for deprecation)
- Ensure the `formType` is passed from state into `validateSection` function call (since some validators require the `formType` param)

---

Requirements to delete validation classes:
- [x] Replace validation class with function in validation helper
- [x] Replace validation class with function in legacy validate file (`this.props.validator`)
- [ ] Replace validation class with functions in Accordion components
- [ ] Replace validation class with functions in other misc instances
- [ ] Ensure test coverage in functions before removing classes & their tests
- [ ] Delete classes & tests

LATER:
- [ ] Add section key to all section components
- [ ] Remove validator prop from section components
- [ ] Section-level validation functions
- [ ] Remove other misc. validator classes

## Checklist for Reviewer

- [ ] Click through & fill out sections, verify that the valid status in the sidebar updates appropriately
- [ ] Load test data and log in, verify the sidebar and score card show the correct valid sections
- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
