### PR TITLE
[EN-2967] Education Review errors not displaying

### DIFF
--- a/src/components/Section/History/Education/Education.jsx
+++ b/src/components/Section/History/Education/Education.jsx
@@ -74,11 +74,7 @@ export class Education extends Subsection {
     const { totalYears } = this.props
 
     return (
-      <div
-        className="section-content education"
-        data-section={HISTORY.key}
-        data-subsection={HISTORY_EDUCATION.key}
-      >
+      <div>
         <Accordion
           scrollToTop={this.props.scrollToTop}
           defaultState={this.props.defaultState}

--- a/src/components/Section/History/Education/Education.test.jsx
+++ b/src/components/Section/History/Education/Education.test.jsx
@@ -25,7 +25,7 @@ describe('The Education component', () => {
     }
 
     const component = createComponent(expected)
-    expect(component.find('.education').length).toEqual(1)
+    expect(component.find('.education').length).toEqual(0)
   })
 
   it('no error on with items', () => {
@@ -40,6 +40,6 @@ describe('The Education component', () => {
       },
     }
     const component = createComponent(expected)
-    expect(component.find('.education').length).toEqual(2)
+    expect(component.find('.education').length).toEqual(1)
   })
 })

--- a/src/components/Section/History/Education/EducationWrapper.jsx
+++ b/src/components/Section/History/Education/EducationWrapper.jsx
@@ -85,7 +85,11 @@ class EducationWrapper extends React.Component {
     }
 
     return (
-      <div>
+      <div
+        className="section-content education"
+        data-section={HISTORY.key}
+        data-subsection={HISTORY_EDUCATION.key}
+      >
         {!inReview && (
           <h1 className="section-header">
             {i18n.t('history.education.summary.title')}
@@ -110,6 +114,7 @@ class EducationWrapper extends React.Component {
           labelSize={inReview ? 'h3' : 'h4'}
           warning
           onUpdate={this.updateBranchAttendance}
+          required={inReview}
         />
 
         <Show when={Education.HasAttended.value === 'No'}>
@@ -121,6 +126,7 @@ class EducationWrapper extends React.Component {
             labelSize={inReview ? 'h3' : 'h4'}
             warning
             onUpdate={this.updateBranchDegree10}
+            required={inReview}
           />
         </Show>
 

--- a/src/components/Section/History/Federal/FederalWrapper.jsx
+++ b/src/components/Section/History/Federal/FederalWrapper.jsx
@@ -1,17 +1,26 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import i18n from 'util/i18n'
 
 import ConnectedFederal from './Federal'
 
-const FederalWrapper = () => (
+const FederalWrapper = ({ inReview }) => (
   <div>
     <h1 className="section-header">
       {i18n.t('history.destination.federal')}
     </h1>
 
-    <ConnectedFederal />
+    <ConnectedFederal required={inReview} />
   </div>
 )
+
+FederalWrapper.propTypes = {
+  inReview: PropTypes.bool,
+}
+
+FederalWrapper.defaultProps = {
+  inReview: false,
+}
 
 export default FederalWrapper

--- a/src/components/Section/Package/Print/__snapshots__/index.test.jsx.snap
+++ b/src/components/Section/Package/Print/__snapshots__/index.test.jsx.snap
@@ -362,7 +362,7 @@ Striving to provide the most enjoyable experience through the application proces
         Settings={Object {}}
         formSections={Array []}
       />,
-      "_debugID": 1510,
+      "_debugID": 1516,
       "_hostContainerInfo": null,
       "_hostParent": null,
       "_instance": PackagePrint {
@@ -572,7 +572,7 @@ Striving to provide the most enjoyable experience through the application proces
             </RadioGroup>
           </div>
         </div>,
-        "_debugID": 1511,
+        "_debugID": 1517,
         "_renderedOutput": <div
           className="pre-print-view"
         >

--- a/src/components/Section/__snapshots__/Section.test.jsx.snap
+++ b/src/components/Section/__snapshots__/Section.test.jsx.snap
@@ -11309,7 +11309,11 @@ exports[`The section component renders HISTORY_EDUCATION 1`] = `
     <div
       className="view view-education"
     >
-      <div>
+      <div
+        className="section-content education"
+        data-section="HISTORY"
+        data-subsection="HISTORY_EDUCATION"
+      >
         <h1
           className="section-header"
         >
@@ -13665,7 +13669,11 @@ exports[`The section component renders HISTORY_REVIEW 1`] = `
         >
           Where you went to school
         </h1>
-        <div>
+        <div
+          className="section-content education"
+          data-section="HISTORY"
+          data-subsection="HISTORY_EDUCATION"
+        >
           <div
             aria-label="List the places you went to school"
             className="field no-margin-bottom"
@@ -13778,7 +13786,29 @@ exports[`The section component renders HISTORY_REVIEW 1`] = `
                 aria-live="polite"
                 className="messages error-messages"
                 role="alert"
-              />
+              >
+                <div
+                  aria-live="polite"
+                  className="message error usa-alert usa-alert-error"
+                  role="alert"
+                >
+                  <div
+                    className="usa-alert-body"
+                  >
+                    <div
+                      data-i18n="error.required"
+                    >
+                      <h5
+                        className="usa-alert-heading"
+                      >
+                        Your response is required
+                      </h5>
+                      
+                      
+                    </div>
+                  </div>
+                </div>
+              </span>
             </div>
             <div
               className="table"
@@ -13793,7 +13823,7 @@ exports[`The section component renders HISTORY_REVIEW 1`] = `
                     className="content"
                   />
                   <div
-                    className="blocks option-list branch"
+                    className="blocks option-list branch usa-input-error"
                   >
                     <div
                       className="yes block"
@@ -13927,7 +13957,29 @@ exports[`The section component renders HISTORY_REVIEW 1`] = `
                   aria-live="polite"
                   className="messages error-messages"
                   role="alert"
-                />
+                >
+                  <div
+                    aria-live="polite"
+                    className="message error usa-alert usa-alert-error"
+                    role="alert"
+                  >
+                    <div
+                      className="usa-alert-body"
+                    >
+                      <div
+                        data-i18n="error.required"
+                      >
+                        <h5
+                          className="usa-alert-heading"
+                        >
+                          Your response is required
+                        </h5>
+                        
+                        
+                      </div>
+                    </div>
+                  </div>
+                </span>
               </div>
               <div
                 className="table"
@@ -13942,7 +13994,7 @@ exports[`The section component renders HISTORY_REVIEW 1`] = `
                       className="content"
                     />
                     <div
-                      className="blocks option-list branch"
+                      className="blocks option-list branch usa-input-error"
                     >
                       <div
                         className="yes block"


### PR DESCRIPTION
## Description

- Pass `required` prop into Education fields when on the Review screen
- Pass `required` prop into Federal component when on the Review screen
- Move `section-content` class and data attributes up to a div that contains the whole Education section

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
