### PR TITLE
Fix ErrorList for Foreign Section

### DIFF
--- a/src/components/ErrorList/ErrorList.jsx
+++ b/src/components/ErrorList/ErrorList.jsx
@@ -203,7 +203,7 @@ export class ErrorList extends React.Component {
               {issues}
               {' '}
               {issues > 1 ? 'questions' : 'question'}
-              with issues
+              {' with issues'}
             </h3>
             {sectionErrors}
           </div>

--- a/src/components/Section/Foreign/Review/index.jsx
+++ b/src/components/Section/Foreign/Review/index.jsx
@@ -61,7 +61,7 @@ export const Review = ({
         <span>
           <Advice {...props} />
           {sectionDivider}
-          <Family />
+          <Family {...props} />
           {sectionDivider}
           <Employment {...props} />
           {sectionDivider}
@@ -75,13 +75,13 @@ export const Review = ({
           {sectionDivider}
           <Political {...props} />
           {sectionDivider}
-          <Voting />
+          <Voting {...props} />
           {sectionDivider}
         </span>
       )}
 
       {requireForeignTravelSection && (
-        <Travel />
+        <Travel {...props} />
       )}
     </div>
   )

--- a/src/components/Section/__snapshots__/Section.test.jsx.snap
+++ b/src/components/Section/__snapshots__/Section.test.jsx.snap
@@ -9723,7 +9723,29 @@ exports[`The section component renders FOREIGN_REVIEW 1`] = `
                 aria-live="polite"
                 className="messages error-messages"
                 role="alert"
-              />
+              >
+                <div
+                  aria-live="polite"
+                  className="message error usa-alert usa-alert-error"
+                  role="alert"
+                >
+                  <div
+                    className="usa-alert-body"
+                  >
+                    <div
+                      data-i18n="error.required"
+                    >
+                      <h5
+                        className="usa-alert-heading"
+                      >
+                        Your response is required
+                      </h5>
+                      
+                      
+                    </div>
+                  </div>
+                </div>
+              </span>
             </div>
             <div
               className="table"
@@ -9753,7 +9775,7 @@ exports[`The section component renders FOREIGN_REVIEW 1`] = `
                     </div>
                   </div>
                   <div
-                    className="blocks option-list branch"
+                    className="blocks option-list branch usa-input-error"
                   >
                     <div
                       className="yes block"
@@ -10794,7 +10816,29 @@ exports[`The section component renders FOREIGN_REVIEW 1`] = `
                 aria-live="polite"
                 className="messages error-messages"
                 role="alert"
-              />
+              >
+                <div
+                  aria-live="polite"
+                  className="message error usa-alert usa-alert-error"
+                  role="alert"
+                >
+                  <div
+                    className="usa-alert-body"
+                  >
+                    <div
+                      data-i18n="error.required"
+                    >
+                      <h5
+                        className="usa-alert-heading"
+                      >
+                        Your response is required
+                      </h5>
+                      
+                      
+                    </div>
+                  </div>
+                </div>
+              </span>
             </div>
             <div
               className="table"
@@ -10809,7 +10853,7 @@ exports[`The section component renders FOREIGN_REVIEW 1`] = `
                     className="content"
                   />
                   <div
-                    className="blocks option-list branch"
+                    className="blocks option-list branch usa-input-error"
                   >
                     <div
                       className="yes block"
@@ -10919,7 +10963,29 @@ exports[`The section component renders FOREIGN_REVIEW 1`] = `
               aria-live="polite"
               className="messages error-messages"
               role="alert"
-            />
+            >
+              <div
+                aria-live="polite"
+                className="message error usa-alert usa-alert-error"
+                role="alert"
+              >
+                <div
+                  className="usa-alert-body"
+                >
+                  <div
+                    data-i18n="error.required"
+                  >
+                    <h5
+                      className="usa-alert-heading"
+                    >
+                      Your response is required
+                    </h5>
+                    
+                    
+                  </div>
+                </div>
+              </div>
+            </span>
           </div>
           <div
             className="table"
@@ -10934,7 +11000,7 @@ exports[`The section component renders FOREIGN_REVIEW 1`] = `
                   className="content"
                 />
                 <div
-                  className="blocks option-list branch"
+                  className="blocks option-list branch usa-input-error"
                 >
                   <div
                     className="yes block"


### PR DESCRIPTION
## Description
This PR isn't directly tied to an issue, but the body of work was discovered when figuring out why `Your history` didn't show up the errors for `Where you went to school` on its `Review` page.

- fixes missing space/grammar issue in the `ErrorList`
- adds correct props so that `Review` displays the correct `ErrorList` for `Family`, `Voting`, `Travel
## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)