### PR TITLE
[EN-3834] Validation Refactor - nested model validations

### DIFF
--- a/src/constants/dateLimits.js
+++ b/src/constants/dateLimits.js
@@ -6,8 +6,8 @@ import { DateTime } from 'luxon'
 
 const TODAY = DateTime.local()
 
-const DEFAULT_LATEST = TODAY
-const DEFAULT_EARLIEST = TODAY.minus({ years: 200, days: 1 })
+export const DEFAULT_LATEST = TODAY
+export const DEFAULT_EARLIEST = TODAY.minus({ years: 200, days: 1 })
 
 /**
  * Applicant birthdate must be:

--- a/src/models/__tests__/civilUnion.test.js
+++ b/src/models/__tests__/civilUnion.test.js
@@ -1,5 +1,88 @@
 import { validateModel } from 'models/validate'
-import civilUnion from '../civilUnion'
+import civilUnion, { otherName } from '../civilUnion'
+
+describe('The otherName model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'Name.required',
+      'MaidenName.required',
+      'DatesUsed.required',
+    ]
+
+    expect(validateModel(testData, otherName))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('Name must be a valid name', () => {
+    const testData = {
+      Name: { first: 'P' },
+    }
+    const expectedErrors = ['Name.model']
+
+    expect(validateModel(testData, otherName))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('MaidenName must have a value', () => {
+    const testData = {
+      MaidenName: 'true',
+    }
+    const expectedErrors = ['MaidenName.hasValue']
+
+    expect(validateModel(testData, otherName))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('DatesUsed must be a valid date range', () => {
+    const testData = {
+      DatesUsed: {
+        from: { year: 2010, month: 2, day: 2 },
+        present: false,
+      },
+    }
+    const expectedErrors = ['DatesUsed.daterange']
+
+    expect(validateModel(testData, otherName))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('DatesUsed must be within the given limits', () => {
+    const testData = {
+      DatesUsed: {
+        from: { year: 2001, month: 2, day: 2 },
+        to: { year: 2030, month: 1, day: 2 },
+      },
+    }
+    const dateLimits = {
+      earliest: { year: 2005, month: 1, day: 4 },
+      latest: { year: 2015, month: 2, day: 3 },
+    }
+    const expectedErrors = ['DatesUsed.daterange']
+
+    expect(validateModel(testData, otherName, dateLimits))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid otherName', () => {
+    const testData = {
+      Has: { value: 'Yes' },
+      Name: { first: 'Someone', noMiddleName: true, last: 'Else' },
+      MaidenName: { value: 'No' },
+      DatesUsed: {
+        from: { day: 1, month: 1, year: 2006 },
+        to: { day: 5, month: 10, year: 2010 },
+      },
+    }
+
+    const dateLimits = {
+      earliest: { year: 2005, month: 1, day: 4 },
+      latest: { year: 2015, month: 2, day: 3 },
+    }
+
+    expect(validateModel(testData, otherName, dateLimits)).toEqual(true)
+  })
+})
 
 describe('The civilUnion model', () => {
   it('the name field is required', () => {
@@ -227,6 +310,33 @@ describe('The civilUnion model', () => {
         ],
       },
     }
+    const expectedErrors = ['OtherNames.branchCollection']
+
+    expect(validateModel(testData, civilUnion))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('OtherNames items date range must be after the Birthdate', () => {
+    const testData = {
+      Birthdate: { year: 2000, month: 2, day: 15 },
+      OtherNames: {
+        items: [
+          {
+            Item: {
+              Has: { value: 'Yes' },
+              Name: { first: 'Someone', noMiddleName: true, last: 'Else' },
+              MaidenName: { value: 'No' },
+              DatesUsed: {
+                from: { day: 1, month: 1, year: 1990 },
+                to: { day: 5, month: 10, year: 1995 },
+              },
+            },
+          },
+          { Item: { Has: { value: 'No' } } },
+        ],
+      },
+    }
+
     const expectedErrors = ['OtherNames.branchCollection']
 
     expect(validateModel(testData, civilUnion))

--- a/src/models/__tests__/cohabitant.test.js
+++ b/src/models/__tests__/cohabitant.test.js
@@ -1,5 +1,88 @@
 import { validateModel } from 'models/validate'
-import cohabitant from '../cohabitant'
+import cohabitant, { otherName } from '../cohabitant'
+
+describe('The otherName model', () => {
+  it('validates required fields', () => {
+    const testData = {}
+    const expectedErrors = [
+      'OtherName.required',
+      'MaidenName.required',
+      'DatesUsed.required',
+    ]
+
+    expect(validateModel(testData, otherName))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('OtherName must be a valid name', () => {
+    const testData = {
+      OtherName: { first: 'P' },
+    }
+    const expectedErrors = ['OtherName.model']
+
+    expect(validateModel(testData, otherName))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('MaidenName must have a value', () => {
+    const testData = {
+      MaidenName: 'true',
+    }
+    const expectedErrors = ['MaidenName.hasValue']
+
+    expect(validateModel(testData, otherName))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('DatesUsed must be a valid date range', () => {
+    const testData = {
+      DatesUsed: {
+        from: { year: 2010, month: 2, day: 2 },
+        present: false,
+      },
+    }
+    const expectedErrors = ['DatesUsed.daterange']
+
+    expect(validateModel(testData, otherName))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('DatesUsed must be within the given limits', () => {
+    const testData = {
+      DatesUsed: {
+        from: { year: 2001, month: 2, day: 2 },
+        to: { year: 2030, month: 1, day: 2 },
+      },
+    }
+    const dateLimits = {
+      earliest: { year: 2005, month: 1, day: 4 },
+      latest: { year: 2015, month: 2, day: 3 },
+    }
+    const expectedErrors = ['DatesUsed.daterange']
+
+    expect(validateModel(testData, otherName, dateLimits))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('passes a valid otherName', () => {
+    const testData = {
+      Has: { value: 'Yes' },
+      OtherName: { first: 'Someone', noMiddleName: true, last: 'Else' },
+      MaidenName: { value: 'No' },
+      DatesUsed: {
+        from: { day: 1, month: 1, year: 2006 },
+        to: { day: 5, month: 10, year: 2010 },
+      },
+    }
+
+    const dateLimits = {
+      earliest: { year: 2005, month: 1, day: 4 },
+      latest: { year: 2015, month: 2, day: 3 },
+    }
+
+    expect(validateModel(testData, otherName, dateLimits)).toEqual(true)
+  })
+})
 
 describe('The cohabitant model', () => {
   it('name is required', () => {
@@ -119,6 +202,33 @@ describe('The cohabitant model', () => {
         ],
       },
     }
+    const expectedErrors = ['OtherNames.branchCollection']
+
+    expect(validateModel(testData, cohabitant))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('OtherNames items date range must be after the Birthdate', () => {
+    const testData = {
+      Birthdate: { year: 2000, month: 2, day: 15 },
+      OtherNames: {
+        items: [
+          {
+            Item: {
+              Has: { value: 'Yes' },
+              OtherName: { first: 'Someone', noMiddleName: true, last: 'Else' },
+              MaidenName: { value: 'No' },
+              DatesUsed: {
+                from: { day: 1, month: 1, year: 1990 },
+                to: { day: 5, month: 10, year: 1995 },
+              },
+            },
+          },
+          { Item: { Has: { value: 'No' } } },
+        ],
+      },
+    }
+
     const expectedErrors = ['OtherNames.branchCollection']
 
     expect(validateModel(testData, cohabitant))

--- a/src/models/__tests__/relative.test.js
+++ b/src/models/__tests__/relative.test.js
@@ -325,6 +325,35 @@ describe('The relative model', () => {
           .toEqual(expect.arrayContaining(expectedErrors))
       })
 
+      it('Aliases cannot be before birthdate', () => {
+        const testData = {
+          Relation: { value: 'Father' },
+          Birthdate: { year: 1950, month: 5, day: 3 },
+          Aliases: {
+            items: [
+              {
+                Item: {
+                  Has: { value: 'Yes' },
+                  Name: { first: 'Alias', middle: 'Name', last: 'Something' },
+                  Dates: {
+                    from: { year: 1930, month: 1, day: 30 },
+                    to: { year: 2018, month: 8, day: 10 },
+                  },
+                  MaidenName: { value: 'No' },
+                  Reason: { value: 'Because' },
+                },
+              },
+              { Item: { Has: { value: 'No' } } },
+            ],
+          },
+        }
+
+        const expectedErrors = ['Aliases.branchCollection']
+
+        expect(validateModel(testData, relative))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
       it('passes a valid alias', () => {
         const testData = {
           Relation: { value: 'Father' },

--- a/src/models/civilUnion.js
+++ b/src/models/civilUnion.js
@@ -7,8 +7,9 @@ import foreignBornDocument from 'models/foreignBornDocument'
 import { hasYesOrNo } from 'models/validate'
 
 import { countryString } from 'validators/location'
+import { DEFAULT_LATEST } from 'constants/dateLimits'
 
-const otherName = {
+export const otherName = {
   Name: {
     presence: true,
     model: { validator: name },
@@ -61,11 +62,17 @@ const civilUnion = {
     presence: true,
     hasValue: true,
   },
-  OtherNames: {
-    presence: true,
-    branchCollection: {
-      validator: otherName,
-    },
+  OtherNames: (value, attributes) => {
+    const dateLimits = { latest: DEFAULT_LATEST }
+    if (attributes.Birthdate) dateLimits.earliest = attributes.Birthdate
+
+    return {
+      presence: true,
+      branchCollection: {
+        validator: otherName,
+        ...dateLimits,
+      },
+    }
   },
   ForeignBornDocument: (value, attributes) => {
     if (attributes.BirthPlace

--- a/src/models/cohabitant.js
+++ b/src/models/cohabitant.js
@@ -3,8 +3,9 @@ import birthplaceWithoutCounty from 'models/shared/locations/birthplaceWithoutCo
 import foreignBornDocument from 'models/foreignBornDocument'
 
 import { countryString } from 'validators/location'
+import { DEFAULT_LATEST } from 'constants/dateLimits'
 
-const otherName = {
+export const otherName = {
   OtherName: {
     presence: true,
     model: { validator: name },
@@ -34,11 +35,17 @@ const cohabitant = {
     presence: true,
     hasValue: { validator: { length: { minimum: 1 } } },
   },
-  OtherNames: {
-    presence: true,
-    branchCollection: {
-      validator: otherName,
-    },
+  OtherNames: (value, attributes) => {
+    const dateLimits = { latest: DEFAULT_LATEST }
+    if (attributes.Birthdate) dateLimits.earliest = attributes.Birthdate
+
+    return {
+      presence: true,
+      branchCollection: {
+        validator: otherName,
+        ...dateLimits,
+      },
+    }
   },
   ForeignBornDocument: (value, attributes = {}) => {
     if (attributes.BirthPlace

--- a/src/models/relative.js
+++ b/src/models/relative.js
@@ -100,6 +100,7 @@ const relative = {
       branchCollection: {
         validator: alias,
         hideMaiden: attributes.Relation && attributes.Relation.value === MOTHER,
+        earliest: attributes.Birthdate,
       },
     }
   },

--- a/src/models/shared/__tests__/alias.test.js
+++ b/src/models/shared/__tests__/alias.test.js
@@ -49,13 +49,42 @@ describe('The alias model', () => {
   it('dates must be a valid date range', () => {
     const testData = {
       Dates: {
-        from: { year: 2030, month: 5, day: 1 },
-        present: true,
+        from: { year: 2010, month: 5, day: 1 },
+        to: { year: 2001, month: 5, day: 1 },
       },
     }
     const expectedErrors = ['Dates.daterange']
 
     expect(validateModel(testData, alias))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('dates must not be in the future', () => {
+    const testData = {
+      Dates: {
+        from: { year: 2030, month: 5, day: 1 },
+        to: { year: 2050, month: 2, day: 2 },
+      },
+    }
+    const expectedErrors = ['Dates.daterange']
+
+    expect(validateModel(testData, alias))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('dates must be after the "earliest" option', () => {
+    const testData = {
+      Dates: {
+        from: { year: 1990, month: 5, day: 1 },
+        present: true,
+      },
+    }
+    const expectedErrors = ['Dates.daterange']
+    const options = {
+      earliest: { year: 2010, month: 2, day: 3 },
+    }
+
+    expect(validateModel(testData, alias, options))
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 

--- a/src/models/shared/alias.js
+++ b/src/models/shared/alias.js
@@ -1,5 +1,6 @@
 import name from 'models/shared/name'
 import { hasYesOrNo } from 'models/validate'
+import { DEFAULT_LATEST } from 'constants/dateLimits'
 
 const alias = {
   Name: {
@@ -14,9 +15,14 @@ const alias = {
         hasValue: { validator: hasYesOrNo },
       }
   ),
-  Dates: {
-    presence: true,
-    daterange: true,
+  Dates: (value, attributes, attributeName, options) => {
+    const dateLimits = { latest: DEFAULT_LATEST }
+    if (options.earliest) dateLimits.earliest = options.earliest
+
+    return {
+      presence: true,
+      daterange: dateLimits,
+    }
   },
   Reason: {
     presence: true,

--- a/src/models/validators/__tests__/accordion.test.js
+++ b/src/models/validators/__tests__/accordion.test.js
@@ -15,7 +15,7 @@ describe('The accordion validator', () => {
 
   it('fails if there is no validator', () => {
     const testData = { items: [{ Item: 'Thing' }] }
-    expect(accordion(testData)).toEqual('Invalid validator')
+    expect(accordion(testData, {})).toEqual('Invalid validator')
   })
 
   it('fails if there is no branch value', () => {

--- a/src/models/validators/__tests__/array.test.js
+++ b/src/models/validators/__tests__/array.test.js
@@ -8,7 +8,7 @@ describe('The array validator', () => {
 
   it('fails if there is no validator', () => {
     const testData = { values: [] }
-    expect(array(testData)).toBeTruthy()
+    expect(array(testData, {})).toBeTruthy()
   })
 
   it('fails if any item in the array fails the validation', () => {

--- a/src/models/validators/__tests__/branchCollection.test.js
+++ b/src/models/validators/__tests__/branchCollection.test.js
@@ -8,17 +8,17 @@ describe('The branch collection validator', () => {
 
   it('fails if there are no items', () => {
     const testData = {}
-    expect(branchCollection(testData)).toBe('Collection is empty')
+    expect(branchCollection(testData, {})).toBe('Collection is empty')
   })
 
   it('fails if the items array is empty', () => {
     const testData = { items: [] }
-    expect(branchCollection(testData)).toBe('Collection is empty')
+    expect(branchCollection(testData, {})).toBe('Collection is empty')
   })
 
   it('fails if no validator is passed', () => {
     const testData = { items: ['one', 'two', 'three'] }
-    expect(branchCollection(testData)).toBeTruthy()
+    expect(branchCollection(testData, {})).toBeTruthy()
   })
 
   it('fails if none of the items have a "No" value', () => {

--- a/src/models/validators/__tests__/customModel.test.js
+++ b/src/models/validators/__tests__/customModel.test.js
@@ -4,7 +4,7 @@ import customModel from '../customModel'
 describe('The model validator', () => {
   it('fails if no validator is passed', () => {
     const testData = { test: '123' }
-    expect(customModel(testData)).toBeTruthy()
+    expect(customModel(testData, {})).toBeTruthy()
   })
 
   it('fails if the data is not valid for the given model', () => {

--- a/src/models/validators/__tests__/durationCoverage.test.js
+++ b/src/models/validators/__tests__/durationCoverage.test.js
@@ -43,7 +43,7 @@ describe('The duration coverage validator', () => {
       },
     ]
 
-    expect(durationCoverage({ items: testRanges }))
+    expect(durationCoverage({ items: testRanges }, {}))
       .toEqual('Invalid options')
   })
 

--- a/src/models/validators/__tests__/location.test.js
+++ b/src/models/validators/__tests__/location.test.js
@@ -4,7 +4,7 @@ import location from '../location'
 describe('The location validator', () => {
   it('fails if no validator is passed', () => {
     const testData = { test: '123' }
-    expect(location(testData)).toBeTruthy()
+    expect(location(testData, {})).toBeTruthy()
   })
 
   it('fails if the data is not valid for the given location model', () => {

--- a/src/models/validators/accordion.js
+++ b/src/models/validators/accordion.js
@@ -1,7 +1,7 @@
 import { validate } from 'validate.js'
 import { validateModel } from 'models/validate'
 
-const accordionValidator = (value, options = {}) => {
+const accordionValidator = (value, options, key, attributes, globalOptions) => {
   if (validate.isEmpty(value)) return null // Don't validate if there is no value
 
   const { validator, length, ignoreBranch } = options
@@ -17,7 +17,7 @@ const accordionValidator = (value, options = {}) => {
 
   // Validate item length
   if (length) {
-    const lengthErrors = validateModel({ items }, { items: { length } })
+    const lengthErrors = validateModel({ items }, { items: { length } }, { ...globalOptions })
     if (lengthErrors !== true) return lengthErrors
   }
 
@@ -26,7 +26,7 @@ const accordionValidator = (value, options = {}) => {
     const { Item } = items[i]
     if (!Item) return 'No item'
 
-    itemErrors = validateModel(Item, validator, options)
+    itemErrors = validateModel(Item, validator, { ...globalOptions, ...options })
     if (itemErrors !== true) return itemErrors
   }
 

--- a/src/models/validators/array.js
+++ b/src/models/validators/array.js
@@ -1,7 +1,7 @@
 import { validate } from 'validate.js'
 import { validateModel } from 'models/validate'
 
-const arrayValidator = (value, options = {}) => {
+const arrayValidator = (value, options, key, attributes, globalOptions) => {
   if (validate.isEmpty(value)) return null // Don't validate if there is no value
 
   const { values } = value
@@ -11,12 +11,20 @@ const arrayValidator = (value, options = {}) => {
   if (!validator) return 'Invalid validator'
 
   if (length) {
-    const arrayErrors = validateModel({ array: values }, { array: { length } })
+    const arrayErrors = validateModel(
+      { array: values },
+      { array: { length } },
+      { ...globalOptions }
+    )
     if (arrayErrors !== true) return arrayErrors
   }
 
   for (let i = 0; i < values.length; i += 1) {
-    const itemErrors = validateModel({ value: values[i] }, { value: validator })
+    const itemErrors = validateModel(
+      { value: values[i] },
+      { value: validator },
+      { ...globalOptions, ...options }
+    )
     if (itemErrors !== true) return itemErrors
   }
 

--- a/src/models/validators/branchCollection.js
+++ b/src/models/validators/branchCollection.js
@@ -1,6 +1,6 @@
 import { validateModel } from 'models/validate'
 
-const branchCollectionValidator = (value, options = {}) => {
+const branchCollectionValidator = (value, options, key, attributes, globalOptions) => {
   if (value === undefined) return null // Only validate if there's a value
   if (value === null) return 'Invalid value'
 
@@ -20,7 +20,7 @@ const branchCollectionValidator = (value, options = {}) => {
     if (Item && Item.Has && Item.Has.value === 'No') {
       // Skip it
     } else {
-      const itemErrors = validateModel(Item, validator, options)
+      const itemErrors = validateModel(Item, validator, { ...globalOptions, ...options })
       if (itemErrors !== true) return itemErrors
     }
   }

--- a/src/models/validators/customModel.js
+++ b/src/models/validators/customModel.js
@@ -1,13 +1,14 @@
 import { validate } from 'validate.js'
 import { validateModel } from 'models/validate'
 
-const customModelValidator = (value, options = {}) => {
+const customModelValidator = (value, options, key, attributes, globalOptions) => {
+  const { validator } = options
+
   if (validate.isEmpty(value)) return null // Don't validate if there is no value
 
-  const { validator } = options
   if (!validator) return 'Invalid validator'
 
-  const errors = validateModel(value, validator, options)
+  const errors = validateModel(value, validator, { ...globalOptions, ...options })
   if (errors !== true) return errors
 
   return null

--- a/src/models/validators/date.js
+++ b/src/models/validators/date.js
@@ -2,7 +2,7 @@ import { validate } from 'validate.js'
 import { validateModel } from 'models/validate'
 import date from 'models/shared/date'
 
-const dateValidator = (value, options) => {
+const dateValidator = (value, options, key, attributes, globalOptions) => {
   if (validate.isEmpty(value)) return null // Don't validate if there is no value
 
   const data = {
@@ -10,7 +10,7 @@ const dateValidator = (value, options) => {
     date: { ...value }, // This will get validated as a complete luxon date object
   }
 
-  const errors = validateModel(data, date, options)
+  const errors = validateModel(data, date, { ...globalOptions, ...options })
   if (errors !== true) return errors
 
   return null

--- a/src/models/validators/daterange.js
+++ b/src/models/validators/daterange.js
@@ -2,7 +2,7 @@ import { validate } from 'validate.js'
 import { validateModel } from 'models/validate'
 import { today, cleanDateObject, createDateFromObject } from 'helpers/date'
 
-const dateRangeValidator = (value = {}) => {
+const dateRangeValidator = (value = {}, options, key, attributes, globalOptions) => {
   if (validate.isEmpty(value)) return null // Don't validate if there is no value
 
   const { from, present } = value
@@ -13,7 +13,7 @@ const dateRangeValidator = (value = {}) => {
   const dateErrors = validateModel({ from, to }, {
     from: { presence: true, date: true },
     to: { presence: true, date: true },
-  })
+  }, { ...globalOptions, ...options })
 
   if (dateErrors !== true) return dateErrors
 

--- a/src/models/validators/durationCoverage.js
+++ b/src/models/validators/durationCoverage.js
@@ -2,7 +2,7 @@ import { validate } from 'validate.js'
 import { validateModel } from 'models/validate'
 import { findTimelineGaps } from 'helpers/date'
 
-const durationCoverageValidator = (value, options = {}) => {
+const durationCoverageValidator = (value, options, key, attributes, globalOptions) => {
   if (validate.isEmpty(value)) return null // Don't validate if there is no value
 
   const { requiredDuration } = options
@@ -13,7 +13,8 @@ const durationCoverageValidator = (value, options = {}) => {
   const ranges = items
     .filter(i => i.Item && i.Item.Dates && validateModel(
       { Dates: i.Item.Dates },
-      { Dates: { presence: true, daterange: true } }
+      { Dates: { presence: true, daterange: true } },
+      { ...globalOptions, ...options }
     ) === true)
     .map(i => i.Item.Dates)
 

--- a/src/models/validators/hasValue.js
+++ b/src/models/validators/hasValue.js
@@ -1,13 +1,14 @@
 /** Replacing src/validators/helpers.js validGenericTextField */
 import { validateModel } from 'models/validate'
 
-const hasValueValidator = (value, options) => {
+const hasValueValidator = (value, options, key, attributes, globalOptions) => {
   if (!value || !value.value) {
     return 'Invalid value'
   }
 
   if (options && options.validator) {
-    const valueErrors = validateModel(value, { value: options.validator })
+    const valueErrors = validateModel(value, { value: options.validator },
+      { ...globalOptions, ...options })
     if (valueErrors !== true) return valueErrors
   }
 

--- a/src/models/validators/location.js
+++ b/src/models/validators/location.js
@@ -4,7 +4,7 @@ import { validateModel } from 'models/validate'
 // Temporary while country values are inconsistent
 import { countryString } from 'validators/location'
 
-const locationValidator = (value, options = {}) => {
+const locationValidator = (value, options, key, attributes, globalOptions) => {
   if (validate.isEmpty(value)) return null // Don't validate if there is no value
 
   const { validator } = options
@@ -13,7 +13,7 @@ const locationValidator = (value, options = {}) => {
   const locationErrors = validateModel({
     ...value,
     country: countryString(value && value.country),
-  }, validator, options)
+  }, validator, { ...globalOptions, ...options })
 
   if (locationErrors !== true) return locationErrors
 

--- a/src/models/validators/ssn.js
+++ b/src/models/validators/ssn.js
@@ -2,7 +2,7 @@ import { validate } from 'validate.js'
 import { validateModel } from 'models/validate'
 import ssn from 'models/shared/ssn'
 
-const ssnValidator = (value) => {
+const ssnValidator = (value, options, key, attributes, globalOptions) => {
   if (validate.isEmpty(value)) return null // Don't validate if there is no value
 
   const {
@@ -11,7 +11,7 @@ const ssnValidator = (value) => {
 
   if (notApplicable === true) return null
 
-  const ssnErrors = validateModel(value, ssn)
+  const ssnErrors = validateModel(value, ssn, { ...globalOptions, ...options })
   if (ssnErrors !== true) return ssnErrors
 
   const completeSSN = `${first}-${middle}-${last}`

--- a/src/validators/civilunion.test.js
+++ b/src/validators/civilunion.test.js
@@ -236,7 +236,7 @@ describe('CivilUnion validation', () => {
           Birthdate: {
             day: '1',
             month: '1',
-            year: '2016',
+            year: '2010',
           },
           BirthPlace: {
             country: { value: 'United States' },

--- a/src/validators/marital.test.js
+++ b/src/validators/marital.test.js
@@ -181,7 +181,7 @@ describe('Marital validation', () => {
             Birthdate: {
               day: '1',
               month: '1',
-              year: '2016',
+              year: '2010',
             },
             BirthPlace: {
               country: { value: 'United States' },
@@ -327,7 +327,7 @@ describe('Marital validation', () => {
             Birthdate: {
               day: '1',
               month: '1',
-              year: '2016',
+              year: '2010',
             },
             Location: {
               country: { value: 'United States' },

--- a/src/validators/relatives.test.js
+++ b/src/validators/relatives.test.js
@@ -1864,7 +1864,7 @@ describe('Relatives validation', () => {
                   Birthdate: {
                     day: '1',
                     month: '1',
-                    year: '2016',
+                    year: '2010',
                   },
                   Birthplace: {
                     city: 'Arlington',
@@ -1950,7 +1950,7 @@ describe('Relatives validation', () => {
                   Birthdate: {
                     day: '1',
                     month: '1',
-                    year: '2016',
+                    year: '2010',
                   },
                   Birthplace: {
                     city: 'Arlington',


### PR DESCRIPTION
## Description

This PR ensures that whenever `validateModel` is called from within a custom validator, it passes along both the validator-specific `options` param as well as the `globalOptions` param (which takes whatever options were passed into the originating `validateModel` call). This should allow passing validation parameters such as date limits and form-specific requirements into custom validators that call `validateModel`.

Also adds remaining date limit parameters that are based on other attributes.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
