### PR TITLE
[EN-3833] Validation Reconciliation - Alternate Addresses

### DIFF
--- a/src/helpers/location.js
+++ b/src/helpers/location.js
@@ -1,9 +1,12 @@
+// Temporary while country values are inconsistent
+import { countryString } from 'validators/location'
+
 export const isPO = location => (
-  location.country === 'POSTOFFICE'
+  countryString(location.country) === 'POSTOFFICE'
 )
 
 export const isUS = location => (
-  location.country === 'United States'
+  countryString(location.country) === 'United States'
 )
 
 export const isInternational = location => (

--- a/src/models/__tests__/civilUnion.test.js
+++ b/src/models/__tests__/civilUnion.test.js
@@ -339,6 +339,7 @@ describe('The civilUnion model', () => {
           BirthPlace: {
             city: 'Boston', state: 'MA', country: 'United States', county: 'County',
           },
+          Email: { value: 'test@email.com' },
           Telephone: { number: '1234567890', type: 'Domestic', timeOfDay: 'Both' },
           SSN: { first: '234', middle: '12', last: '3490' },
           Separated: { value: 'No' },
@@ -361,6 +362,7 @@ describe('The civilUnion model', () => {
             city: 'Boston', state: 'MA', country: 'United States', county: 'County',
           },
           Citizenship: { value: ['United States'] },
+          EnteredCivilUnion: { day: 10, month: 10, year: 2001 },
           Divorced: { value: 'No' },
           OtherNames: {
             items: [
@@ -392,6 +394,7 @@ describe('The civilUnion model', () => {
           BirthPlace: {
             city: 'Boston', state: 'MA', country: 'United States', county: 'County',
           },
+          Email: { value: 'test@email.com' },
           Telephone: { number: '1234567890', type: 'Domestic', timeOfDay: 'Both' },
           SSN: { first: '234', middle: '12', last: '3490' },
           Separated: { value: 'No' },
@@ -407,6 +410,7 @@ describe('The civilUnion model', () => {
             city: 'Boston', state: 'MA', country: 'United States', county: 'County',
           },
           Citizenship: { value: ['United States'] },
+          EnteredCivilUnion: { day: 10, month: 10, year: 2001 },
           Divorced: { value: 'No' },
           OtherNames: {
             items: [
@@ -483,6 +487,7 @@ describe('The civilUnion model', () => {
         BirthPlace: {
           city: 'Boston', state: 'MA', country: 'United States', county: 'County',
         },
+        Email: { value: 'test@email.com' },
         Telephone: { number: '1234567890', type: 'Domestic', timeOfDay: 'Both' },
         SSN: { first: '234', middle: '12', last: '3490' },
         Separated: { value: 'No' },
@@ -506,6 +511,7 @@ describe('The civilUnion model', () => {
           city: 'Boston', state: 'MA', country: 'United States', county: 'County',
         },
         Citizenship: { value: ['United States'] },
+        EnteredCivilUnion: { day: 10, month: 10, year: 2001 },
         Divorced: { value: 'No' },
         OtherNames: {
           items: [

--- a/src/models/__tests__/civilUnion.test.js
+++ b/src/models/__tests__/civilUnion.test.js
@@ -290,6 +290,245 @@ describe('The civilUnion model', () => {
     })
   })
 
+  describe('if the Address field is international', () => {
+    it('AlternateAddress is required', () => {
+      const testData = {
+        Address: {
+          street: '123 Test St',
+          city: 'London',
+          country: { value: 'United Kingdom' },
+        },
+      }
+
+      const expectedErrors = ['AlternateAddress.required']
+
+      expect(validateModel(testData, civilUnion))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    describe('if HasDifferentAddress is "Yes"', () => {
+      it('AlternateAddress must be a PO address', () => {
+        const testData = {
+          Address: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+          AlternateAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: '123 Main St',
+              city: 'New York',
+              state: 'NY',
+              zipcode: '10002',
+              country: 'United States',
+            },
+          },
+        }
+
+        const expectedErrors = ['AlternateAddress.model']
+
+        expect(validateModel(testData, civilUnion))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('passes a valid civilUnion with an alternate address', () => {
+        const testData = {
+          Name: { first: 'Person', noMiddleName: true, last: 'Name' },
+          Birthdate: { day: 5, month: 2, year: 1980 },
+          BirthPlace: {
+            city: 'Boston', state: 'MA', country: 'United States', county: 'County',
+          },
+          Telephone: { number: '1234567890', type: 'Domestic', timeOfDay: 'Both' },
+          SSN: { first: '234', middle: '12', last: '3490' },
+          Separated: { value: 'No' },
+          Address: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+          AlternateAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: '123 Main ST',
+              city: 'FPO',
+              state: 'AA',
+              zipcode: '34035',
+              country: 'POSTOFFICE',
+            },
+          },
+          Location: {
+            city: 'Boston', state: 'MA', country: 'United States', county: 'County',
+          },
+          Citizenship: { value: ['United States'] },
+          Divorced: { value: 'No' },
+          OtherNames: {
+            items: [
+              {
+                Item: {
+                  Has: { value: 'Yes' },
+                  Name: { first: 'Someone', noMiddleName: true, last: 'Else' },
+                  MaidenName: { value: 'No' },
+                  DatesUsed: {
+                    from: { day: 1, month: 1, year: 1990 },
+                    to: { day: 5, month: 10, year: 1995 },
+                  },
+                },
+              },
+              { Item: { Has: { value: 'No' } } },
+            ],
+          },
+        }
+
+        expect(validateModel(testData, civilUnion)).toEqual(true)
+      })
+    })
+
+    describe('if HasDifferentAddress is "No"', () => {
+      it('passes a valid civilUnion with an alternate address', () => {
+        const testData = {
+          Name: { first: 'Person', noMiddleName: true, last: 'Name' },
+          Birthdate: { day: 5, month: 2, year: 1980 },
+          BirthPlace: {
+            city: 'Boston', state: 'MA', country: 'United States', county: 'County',
+          },
+          Telephone: { number: '1234567890', type: 'Domestic', timeOfDay: 'Both' },
+          SSN: { first: '234', middle: '12', last: '3490' },
+          Separated: { value: 'No' },
+          Address: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+          AlternateAddress: {
+            HasDifferentAddress: { value: 'No' },
+          },
+          Location: {
+            city: 'Boston', state: 'MA', country: 'United States', county: 'County',
+          },
+          Citizenship: { value: ['United States'] },
+          Divorced: { value: 'No' },
+          OtherNames: {
+            items: [
+              {
+                Item: {
+                  Has: { value: 'Yes' },
+                  Name: { first: 'Someone', noMiddleName: true, last: 'Else' },
+                  MaidenName: { value: 'No' },
+                  DatesUsed: {
+                    from: { day: 1, month: 1, year: 1990 },
+                    to: { day: 5, month: 10, year: 1995 },
+                  },
+                },
+              },
+              { Item: { Has: { value: 'No' } } },
+            ],
+          },
+        }
+
+        expect(validateModel(testData, civilUnion)).toEqual(true)
+      })
+    })
+  })
+
+  describe('if the Address field is a military address', () => {
+    it('AlternateAddress is required', () => {
+      const testData = {
+        Address: {
+          street: '123 Main ST',
+          city: 'FPO',
+          state: 'AA',
+          zipcode: '34035',
+          country: 'POSTOFFICE',
+        },
+      }
+
+      const expectedErrors = ['AlternateAddress.required']
+
+      expect(validateModel(testData, civilUnion))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('AlternateAddress must not be a PO address', () => {
+      const testData = {
+        Address: {
+          street: '123 Main ST',
+          city: 'FPO',
+          state: 'AA',
+          zipcode: '34035',
+          country: 'POSTOFFICE',
+        },
+        AlternateAddress: {
+          HasDifferentAddress: { value: 'Yes' },
+          Address: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+        },
+      }
+
+      const expectedErrors = ['AlternateAddress.model']
+
+      expect(validateModel(testData, civilUnion))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid civilUnion with an alternate address', () => {
+      const testData = {
+        Name: { first: 'Person', noMiddleName: true, last: 'Name' },
+        Birthdate: { day: 5, month: 2, year: 1980 },
+        BirthPlace: {
+          city: 'Boston', state: 'MA', country: 'United States', county: 'County',
+        },
+        Telephone: { number: '1234567890', type: 'Domestic', timeOfDay: 'Both' },
+        SSN: { first: '234', middle: '12', last: '3490' },
+        Separated: { value: 'No' },
+        Address: {
+          street: '123 Main ST',
+          city: 'FPO',
+          state: 'AA',
+          zipcode: '34035',
+          country: 'POSTOFFICE',
+        },
+        AlternateAddress: {
+          Address: {
+            street: '123 Main ST',
+            city: 'New York',
+            state: 'NY',
+            zipcode: '10003',
+            country: 'United States',
+          },
+        },
+        Location: {
+          city: 'Boston', state: 'MA', country: 'United States', county: 'County',
+        },
+        Citizenship: { value: ['United States'] },
+        Divorced: { value: 'No' },
+        OtherNames: {
+          items: [
+            {
+              Item: {
+                Has: { value: 'Yes' },
+                Name: { first: 'Someone', noMiddleName: true, last: 'Else' },
+                MaidenName: { value: 'No' },
+                DatesUsed: {
+                  from: { day: 1, month: 1, year: 1990 },
+                  to: { day: 5, month: 10, year: 1995 },
+                },
+              },
+            },
+            { Item: { Has: { value: 'No' } } },
+          ],
+        },
+      }
+
+      expect(validateModel(testData, civilUnion)).toEqual(true)
+    })
+  })
+
   it('the Location field is required', () => {
     const testData = {}
     const expectedErrors = ['Location.required']

--- a/src/models/__tests__/employment.test.js
+++ b/src/models/__tests__/employment.test.js
@@ -116,6 +116,206 @@ describe('The employment model', () => {
         .toEqual(expect.arrayContaining(expectedErrors))
     })
 
+    describe('if the ReferenceAddress field is international', () => {
+      it('ReferenceAlternateAddress is required', () => {
+        const testData = {
+          ReferenceAddress: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+        }
+
+        const expectedErrors = ['ReferenceAlternateAddress.required']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      describe('if HasDifferentAddress is "Yes"', () => {
+        it('ReferenceAlternateAddress must be a PO address', () => {
+          const testData = {
+            ReferenceAddress: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            ReferenceAlternateAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Main St',
+                city: 'New York',
+                state: 'NY',
+                zipcode: '10002',
+                country: 'United States',
+              },
+            },
+          }
+
+          const expectedErrors = ['ReferenceAlternateAddress.model']
+
+          expect(validateModel(testData, employment))
+            .toEqual(expect.arrayContaining(expectedErrors))
+        })
+
+        it('passes a valid employment with a reference alternate address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'Unemployment' },
+            Dates: {
+              from: { year: 1990, month: 5, day: 12 },
+              to: { year: 2000, month: 12, day: 1 },
+              present: false,
+            },
+            ReferenceName: {
+              first: 'Person',
+              noMiddleName: true,
+              last: 'Name',
+            },
+            ReferencePhone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Both',
+            },
+            ReferenceAddress: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            ReferenceAlternateAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Main ST',
+                city: 'FPO',
+                state: 'AA',
+                zipcode: '34035',
+                country: 'POSTOFFICE',
+              },
+            },
+          }
+
+          expect(validateModel(testData, employment)).toEqual(true)
+        })
+      })
+
+      describe('if HasDifferentAddress is "No"', () => {
+        it('passes a valid employment with a reference alternate address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'Unemployment' },
+            Dates: {
+              from: { year: 1990, month: 5, day: 12 },
+              to: { year: 2000, month: 12, day: 1 },
+              present: false,
+            },
+            ReferenceName: {
+              first: 'Person',
+              noMiddleName: true,
+              last: 'Name',
+            },
+            ReferencePhone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Both',
+            },
+            ReferenceAddress: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            ReferenceAlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+          }
+
+          expect(validateModel(testData, employment)).toEqual(true)
+        })
+      })
+    })
+
+    describe('if the ReferenceAddress field is a military address', () => {
+      it('ReferenceAlternateAddress is required', () => {
+        const testData = {
+          ReferenceAddress: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+        }
+
+        const expectedErrors = ['ReferenceAlternateAddress.required']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('ReferenceAlternateAddress must not be a PO address', () => {
+        const testData = {
+          ReferenceAddress: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+          ReferenceAlternateAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: '123 Main ST',
+              city: 'FPO',
+              state: 'AA',
+              zipcode: '34035',
+              country: 'POSTOFFICE',
+            },
+          },
+        }
+
+        const expectedErrors = ['ReferenceAlternateAddress.model']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('passes a valid employment with a reference alternate address', () => {
+        const testData = {
+          EmploymentActivity: { value: 'Unemployment' },
+          Dates: {
+            from: { year: 1990, month: 5, day: 12 },
+            to: { year: 2000, month: 12, day: 1 },
+            present: false,
+          },
+          ReferenceName: {
+            first: 'Person',
+            noMiddleName: true,
+            last: 'Name',
+          },
+          ReferencePhone: {
+            number: '1234567890',
+            type: 'Domestic',
+            timeOfDay: 'Both',
+          },
+          ReferenceAddress: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+          ReferenceAlternateAddress: {
+            Address: {
+              street: '123 Main ST',
+              city: 'New York',
+              state: 'NY',
+              zipcode: '10003',
+              country: 'United States',
+            },
+          },
+        }
+
+        expect(validateModel(testData, employment)).toEqual(true)
+      })
+    })
+
     it('passes a valid Employment item', () => {
       const testData = {
         EmploymentActivity: { value: 'Unemployment' },
@@ -475,6 +675,167 @@ describe('The employment model', () => {
         .toEqual(expect.arrayContaining(expectedErrors))
     })
 
+    describe('if the Address field is international', () => {
+      it('AlternateAddress is required', () => {
+        const testData = {
+          EmploymentActivity: { value: 'SelfEmployment' },
+          Address: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+        }
+
+        const expectedErrors = ['AlternateAddress.required']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      describe('if HasDifferentAddress is "Yes"', () => {
+        it('AlternateAddress must be a PO address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'SelfEmployment' },
+            Address: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Test St',
+                city: 'London',
+                country: { value: 'United Kingdom' },
+              },
+            },
+          }
+
+          const expectedErrors = ['AlternateAddress.model']
+
+          expect(validateModel(testData, employment))
+            .toEqual(expect.arrayContaining(expectedErrors))
+        })
+
+        it('passes a valid employment item with an alternate address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'SelfEmployment' },
+            Dates: {
+              from: { year: 1990, month: 5, day: 12 },
+              present: true,
+            },
+            Title: 'Manager',
+            Status: 'Full-time',
+            Address: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Main ST',
+                city: 'FPO',
+                state: 'AA',
+                zipcode: '34035',
+                country: 'POSTOFFICE',
+              },
+            },
+            PhysicalAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            Telephone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Day',
+            },
+            Employment: 'Company',
+            ReferenceName: {
+              first: 'Person',
+              noMiddleName: true,
+              last: 'Name',
+            },
+            ReferencePhone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Both',
+            },
+            ReferenceAddress: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            ReferenceAlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            Reprimand: {
+              items: [
+                { Item: { Has: { value: 'No' } } },
+              ],
+            },
+          }
+
+          expect(validateModel(testData, employment)).toEqual(true)
+        })
+      })
+
+      describe('if HasDifferentAddress is "No"', () => {
+        it('passes a valid employment item with an alternate address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'SelfEmployment' },
+            Dates: {
+              from: { year: 1990, month: 5, day: 12 },
+              present: true,
+            },
+            Title: 'Manager',
+            Status: 'Full-time',
+            Address: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            PhysicalAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            Telephone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Day',
+            },
+            Employment: 'Company',
+            ReferenceName: {
+              first: 'Person',
+              noMiddleName: true,
+              last: 'Name',
+            },
+            ReferencePhone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Both',
+            },
+            ReferenceAddress: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            ReferenceAlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            Reprimand: {
+              items: [
+                { Item: { Has: { value: 'No' } } },
+              ],
+            },
+          }
+
+          expect(validateModel(testData, employment)).toEqual(true)
+        })
+      })
+    })
+
     it('the PhysicalAddress field is required', () => {
       const testData = {
         EmploymentActivity: { value: 'SelfEmployment' },
@@ -502,6 +863,311 @@ describe('The employment model', () => {
 
       expect(validateModel(testData, employment))
         .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    describe('if the PhysicalAddress field is international', () => {
+      it('PhysicalAlternateAddress is required', () => {
+        const testData = {
+          EmploymentActivity: { value: 'SelfEmployment' },
+          PhysicalAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+          },
+        }
+
+        const expectedErrors = ['PhysicalAlternateAddress.required']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      describe('if HasDifferentAddress is "Yes"', () => {
+        it('PhysicalAlternateAddress must be a PO address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'SelfEmployment' },
+            PhysicalAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Test St',
+                city: 'London',
+                country: { value: 'United Kingdom' },
+              },
+            },
+            PhysicalAlternateAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Test St',
+                city: 'London',
+                country: { value: 'United Kingdom' },
+              },
+            },
+          }
+
+          const expectedErrors = ['PhysicalAlternateAddress.model']
+
+          expect(validateModel(testData, employment))
+            .toEqual(expect.arrayContaining(expectedErrors))
+        })
+
+        it('passes a valid employment item with an alternate physical address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'SelfEmployment' },
+            Dates: {
+              from: { year: 1990, month: 5, day: 12 },
+              present: true,
+            },
+            Title: 'Manager',
+            Status: 'Full-time',
+            Address: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            PhysicalAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Test St',
+                city: 'London',
+                country: { value: 'United Kingdom' },
+              },
+            },
+            PhysicalAlternateAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Main ST',
+                city: 'FPO',
+                state: 'AA',
+                zipcode: '34035',
+                country: 'POSTOFFICE',
+              },
+            },
+            Telephone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Day',
+            },
+            Employment: 'Company',
+            ReferenceName: {
+              first: 'Person',
+              noMiddleName: true,
+              last: 'Name',
+            },
+            ReferencePhone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Both',
+            },
+            ReferenceAddress: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            ReferenceAlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            Reprimand: {
+              items: [
+                { Item: { Has: { value: 'No' } } },
+              ],
+            },
+          }
+
+          expect(validateModel(testData, employment)).toEqual(true)
+        })
+      })
+
+      describe('if HasDifferentAddress is "No"', () => {
+        it('passes a valid employment item with an alternate physical address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'SelfEmployment' },
+            Dates: {
+              from: { year: 1990, month: 5, day: 12 },
+              present: true,
+            },
+            Title: 'Manager',
+            Status: 'Full-time',
+            Address: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            PhysicalAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Test St',
+                city: 'London',
+                country: { value: 'United Kingdom' },
+              },
+            },
+            PhysicalAlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            Telephone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Day',
+            },
+            Employment: 'Company',
+            ReferenceName: {
+              first: 'Person',
+              noMiddleName: true,
+              last: 'Name',
+            },
+            ReferencePhone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Both',
+            },
+            ReferenceAddress: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            ReferenceAlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            Reprimand: {
+              items: [
+                { Item: { Has: { value: 'No' } } },
+              ],
+            },
+          }
+
+          expect(validateModel(testData, employment)).toEqual(true)
+        })
+      })
+    })
+
+    describe('if the PhysicalAddress field is a military address', () => {
+      it('PhysicalAlternateAddress is required', () => {
+        const testData = {
+          EmploymentActivity: { value: 'SelfEmployment' },
+          PhysicalAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: '123 Main ST',
+              city: 'FPO',
+              state: 'AA',
+              zipcode: '34035',
+              country: 'POSTOFFICE',
+            },
+          },
+        }
+
+        const expectedErrors = ['PhysicalAlternateAddress.required']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('PhysicalAlternateAddress must not be a PO address', () => {
+        const testData = {
+          EmploymentActivity: { value: 'SelfEmployment' },
+          PhysicalAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: '123 Main ST',
+              city: 'FPO',
+              state: 'AA',
+              zipcode: '34035',
+              country: 'POSTOFFICE',
+            },
+          },
+          PhysicalAlternateAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: '123 Main ST',
+              city: 'FPO',
+              state: 'AA',
+              zipcode: '34035',
+              country: 'POSTOFFICE',
+            },
+          },
+        }
+
+        const expectedErrors = ['PhysicalAlternateAddress.model']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('passes a valid employment item with an alternate physical address', () => {
+        const testData = {
+          EmploymentActivity: { value: 'SelfEmployment' },
+          Dates: {
+            from: { year: 1990, month: 5, day: 12 },
+            present: true,
+          },
+          Title: 'Manager',
+          Status: 'Full-time',
+          Address: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+          AlternateAddress: {
+            HasDifferentAddress: { value: 'No' },
+          },
+          PhysicalAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: '123 Main ST',
+              city: 'FPO',
+              state: 'AA',
+              zipcode: '34035',
+              country: 'POSTOFFICE',
+            },
+          },
+          PhysicalAlternateAddress: {
+            Address: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+          },
+          Telephone: {
+            number: '1234567890',
+            type: 'Domestic',
+            timeOfDay: 'Day',
+          },
+          Employment: 'Company',
+          ReferenceName: {
+            first: 'Person',
+            noMiddleName: true,
+            last: 'Name',
+          },
+          ReferencePhone: {
+            number: '1234567890',
+            type: 'Domestic',
+            timeOfDay: 'Both',
+          },
+          ReferenceAddress: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+          ReferenceAlternateAddress: {
+            HasDifferentAddress: { value: 'No' },
+          },
+          Reprimand: {
+            items: [
+              { Item: { Has: { value: 'No' } } },
+            ],
+          },
+        }
+
+        expect(validateModel(testData, employment)).toEqual(true)
+      })
     })
 
     it('the Telephone field is required', () => {
@@ -605,6 +1271,276 @@ describe('The employment model', () => {
 
       expect(validateModel(testData, employment))
         .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    describe('if the ReferenceAddress field is international', () => {
+      it('ReferenceAlternateAddress is required', () => {
+        const testData = {
+          EmploymentActivity: { value: 'SelfEmployment' },
+          ReferenceAddress: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+        }
+
+        const expectedErrors = ['ReferenceAlternateAddress.required']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      describe('if HasDifferentAddress is "Yes"', () => {
+        it('ReferenceAlternateAddress must be a PO address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'SelfEmployment' },
+            ReferenceAddress: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            ReferenceAlternateAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Main St',
+                city: 'New York',
+                state: 'NY',
+                zipcode: '10002',
+                country: 'United States',
+              },
+            },
+          }
+
+          const expectedErrors = ['ReferenceAlternateAddress.model']
+
+          expect(validateModel(testData, employment))
+            .toEqual(expect.arrayContaining(expectedErrors))
+        })
+
+        it('passes a valid employment with a reference alternate address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'SelfEmployment' },
+            Dates: {
+              from: { year: 1990, month: 5, day: 12 },
+              present: true,
+            },
+            Title: 'Manager',
+            Status: 'Full-time',
+            Address: {
+              street: '40 Office St',
+              city: 'New York',
+              state: 'NY',
+              zipcode: '10001',
+              country: 'United States',
+            },
+            PhysicalAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            Telephone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Day',
+            },
+            Employment: 'Company',
+            ReferenceName: {
+              first: 'Person',
+              noMiddleName: true,
+              last: 'Name',
+            },
+            ReferencePhone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Both',
+            },
+            ReferenceAddress: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            ReferenceAlternateAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Main ST',
+                city: 'FPO',
+                state: 'AA',
+                zipcode: '34035',
+                country: 'POSTOFFICE',
+              },
+            },
+            Reprimand: {
+              items: [
+                { Item: { Has: { value: 'No' } } },
+              ],
+            },
+          }
+
+          expect(validateModel(testData, employment)).toEqual(true)
+        })
+      })
+
+      describe('if HasDifferentAddress is "No"', () => {
+        it('passes a valid employment with a reference alternate address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'SelfEmployment' },
+            Dates: {
+              from: { year: 1990, month: 5, day: 12 },
+              present: true,
+            },
+            Title: 'Manager',
+            Status: 'Full-time',
+            Address: {
+              street: '40 Office St',
+              city: 'New York',
+              state: 'NY',
+              zipcode: '10001',
+              country: 'United States',
+            },
+            PhysicalAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            Telephone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Day',
+            },
+            Employment: 'Company',
+            ReferenceName: {
+              first: 'Person',
+              noMiddleName: true,
+              last: 'Name',
+            },
+            ReferencePhone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Both',
+            },
+            ReferenceAddress: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            ReferenceAlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            Reprimand: {
+              items: [
+                { Item: { Has: { value: 'No' } } },
+              ],
+            },
+          }
+
+          expect(validateModel(testData, employment)).toEqual(true)
+        })
+      })
+    })
+
+    describe('if the ReferenceAddress field is a military address', () => {
+      it('ReferenceAlternateAddress is required', () => {
+        const testData = {
+          EmploymentActivity: { value: 'SelfEmployment' },
+          ReferenceAddress: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+        }
+
+        const expectedErrors = ['ReferenceAlternateAddress.required']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('ReferenceAlternateAddress must not be a PO address', () => {
+        const testData = {
+          EmploymentActivity: { value: 'SelfEmployment' },
+          ReferenceAddress: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+          ReferenceAlternateAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: '123 Main ST',
+              city: 'FPO',
+              state: 'AA',
+              zipcode: '34035',
+              country: 'POSTOFFICE',
+            },
+          },
+        }
+
+        const expectedErrors = ['ReferenceAlternateAddress.model']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('passes a valid employment with a reference alternate address', () => {
+        const testData = {
+          EmploymentActivity: { value: 'SelfEmployment' },
+          Dates: {
+            from: { year: 1990, month: 5, day: 12 },
+            present: true,
+          },
+          Title: 'Manager',
+          Status: 'Full-time',
+          Address: {
+            street: '40 Office St',
+            city: 'New York',
+            state: 'NY',
+            zipcode: '10001',
+            country: 'United States',
+          },
+          PhysicalAddress: {
+            HasDifferentAddress: { value: 'No' },
+          },
+          Telephone: {
+            number: '1234567890',
+            type: 'Domestic',
+            timeOfDay: 'Day',
+          },
+          Employment: 'Company',
+          ReferenceName: {
+            first: 'Person',
+            noMiddleName: true,
+            last: 'Name',
+          },
+          ReferencePhone: {
+            number: '1234567890',
+            type: 'Domestic',
+            timeOfDay: 'Both',
+          },
+          Reprimand: {
+            items: [
+              { Item: { Has: { value: 'No' } } },
+            ],
+          },
+          ReferenceAddress: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+          ReferenceAlternateAddress: {
+            Address: {
+              street: '123 Main ST',
+              city: 'New York',
+              state: 'NY',
+              zipcode: '10003',
+              country: 'United States',
+            },
+          },
+        }
+
+        expect(validateModel(testData, employment)).toEqual(true)
+      })
     })
 
     it('passes a valid Employment item', () => {
@@ -791,6 +1727,261 @@ describe('The employment model', () => {
         .toEqual(expect.arrayContaining(expectedErrors))
     })
 
+    describe('if the Address field is international', () => {
+      it('AlternateAddress is required', () => {
+        const testData = {
+          EmploymentActivity: { value: 'ActiveMilitary' },
+          Address: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+        }
+
+        const expectedErrors = ['AlternateAddress.required']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      describe('if HasDifferentAddress is "Yes"', () => {
+        it('AlternateAddress must be a PO address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'ActiveMilitary' },
+            Address: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Test St',
+                city: 'London',
+                country: { value: 'United Kingdom' },
+              },
+            },
+          }
+
+          const expectedErrors = ['AlternateAddress.model']
+
+          expect(validateModel(testData, employment))
+            .toEqual(expect.arrayContaining(expectedErrors))
+        })
+
+        it('passes a valid employment item with an alternate address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'ActiveMilitary' },
+            Dates: {
+              from: { year: 1990, month: 5, day: 12 },
+              present: true,
+            },
+            Title: 'Manager',
+            DutyStation: 'Something',
+            Status: 'Full-time',
+            Address: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Main ST',
+                city: 'FPO',
+                state: 'AA',
+                zipcode: '34035',
+                country: 'POSTOFFICE',
+              },
+            },
+            Telephone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Day',
+            },
+            Supervisor: {
+              SupervisorName: { value: 'Person Supervisor' },
+              Title: { value: 'VP' },
+              EmailNotApplicable: { applicable: false },
+              Address: {
+                street: '40 Office St',
+                city: 'New York',
+                state: 'NY',
+                zipcode: '10001',
+                country: 'United States',
+              },
+              Telephone: {
+                number: '1234567890',
+                type: 'Domestic',
+                timeOfDay: 'Day',
+              },
+            },
+            Reprimand: {
+              items: [
+                { Item: { Has: { value: 'No' } } },
+              ],
+            },
+          }
+
+          expect(validateModel(testData, employment)).toEqual(true)
+        })
+      })
+
+      describe('if HasDifferentAddress is "No"', () => {
+        it('passes a valid employment item with an alternate address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'ActiveMilitary' },
+            Dates: {
+              from: { year: 1990, month: 5, day: 12 },
+              present: true,
+            },
+            Title: 'Manager',
+            DutyStation: 'Something',
+            Status: 'Full-time',
+            Address: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            Telephone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Day',
+            },
+            Supervisor: {
+              SupervisorName: { value: 'Person Supervisor' },
+              Title: { value: 'VP' },
+              EmailNotApplicable: { applicable: false },
+              Address: {
+                street: '40 Office St',
+                city: 'New York',
+                state: 'NY',
+                zipcode: '10001',
+                country: 'United States',
+              },
+              Telephone: {
+                number: '1234567890',
+                type: 'Domestic',
+                timeOfDay: 'Day',
+              },
+            },
+            Reprimand: {
+              items: [
+                { Item: { Has: { value: 'No' } } },
+              ],
+            },
+          }
+
+          expect(validateModel(testData, employment)).toEqual(true)
+        })
+      })
+    })
+
+    describe('if the Address field is a military address', () => {
+      it('AlternateAddress is required', () => {
+        const testData = {
+          Address: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+        }
+
+        const expectedErrors = ['AlternateAddress.required']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('AlternateAddress must not be a PO address', () => {
+        const testData = {
+          Address: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+          AlternateAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: '123 Main ST',
+              city: 'FPO',
+              state: 'AA',
+              zipcode: '34035',
+              country: 'POSTOFFICE',
+            },
+          },
+        }
+
+        const expectedErrors = ['AlternateAddress.model']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('passes a valid employment item with an alternate address', () => {
+        const testData = {
+          EmploymentActivity: { value: 'ActiveMilitary' },
+          Dates: {
+            from: { year: 1990, month: 5, day: 12 },
+            present: true,
+          },
+          Title: 'Manager',
+          DutyStation: 'Something',
+          Status: 'Full-time',
+          Address: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+          AlternateAddress: {
+            Address: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+          },
+          Telephone: {
+            number: '1234567890',
+            type: 'Domestic',
+            timeOfDay: 'Day',
+          },
+          Supervisor: {
+            SupervisorName: { value: 'Person Supervisor' },
+            Title: { value: 'VP' },
+            EmailNotApplicable: { applicable: false },
+            Address: {
+              street: '40 Office St',
+              city: 'New York',
+              state: 'NY',
+              zipcode: '10001',
+              country: 'United States',
+            },
+            Telephone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Day',
+            },
+          },
+          Reprimand: {
+            items: [
+              { Item: { Has: { value: 'No' } } },
+            ],
+          },
+        }
+
+        expect(validateModel(testData, employment)).toEqual(true)
+      })
+    })
+
     it('the Telephone field is required', () => {
       const testData = {
         EmploymentActivity: { value: 'NationalGuard' },
@@ -964,6 +2155,274 @@ describe('The employment model', () => {
 
       expect(validateModel(testData, employment))
         .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    describe('if the Address field is international', () => {
+      it('AlternateAddress is required', () => {
+        const testData = {
+          EmploymentActivity: { value: 'NonGovernment' },
+          Address: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+        }
+
+        const expectedErrors = ['AlternateAddress.required']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      describe('if HasDifferentAddress is "Yes"', () => {
+        it('AlternateAddress must be a PO address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'NonGovernment' },
+            Address: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Test St',
+                city: 'London',
+                country: { value: 'United Kingdom' },
+              },
+            },
+          }
+
+          const expectedErrors = ['AlternateAddress.model']
+
+          expect(validateModel(testData, employment))
+            .toEqual(expect.arrayContaining(expectedErrors))
+        })
+
+        it('passes a valid employment item with an alternate address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'NonGovernment' },
+            Dates: {
+              from: { year: 1990, month: 5, day: 12 },
+              present: true,
+            },
+            Title: 'Manager',
+            Employment: 'My Company',
+            Status: 'Full-time',
+            Address: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Main ST',
+                city: 'FPO',
+                state: 'AA',
+                zipcode: '34035',
+                country: 'POSTOFFICE',
+              },
+            },
+            PhysicalAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            Telephone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Day',
+            },
+            Supervisor: {
+              SupervisorName: { value: 'Person Supervisor' },
+              Title: { value: 'VP' },
+              EmailNotApplicable: { applicable: false },
+              Address: {
+                street: '40 Office St',
+                city: 'New York',
+                state: 'NY',
+                zipcode: '10001',
+                country: 'United States',
+              },
+              Telephone: {
+                number: '1234567890',
+                type: 'Domestic',
+                timeOfDay: 'Day',
+              },
+            },
+            Reprimand: {
+              items: [
+                { Item: { Has: { value: 'No' } } },
+              ],
+            },
+          }
+
+          expect(validateModel(testData, employment)).toEqual(true)
+        })
+      })
+
+      describe('if HasDifferentAddress is "No"', () => {
+        it('passes a valid employment item with an alternate address', () => {
+          const testData = {
+            EmploymentActivity: { value: 'NonGovernment' },
+            Dates: {
+              from: { year: 1990, month: 5, day: 12 },
+              present: true,
+            },
+            Title: 'Manager',
+            Employment: 'My Company',
+            Status: 'Full-time',
+            Address: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            PhysicalAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
+            Telephone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Day',
+            },
+            Supervisor: {
+              SupervisorName: { value: 'Person Supervisor' },
+              Title: { value: 'VP' },
+              EmailNotApplicable: { applicable: false },
+              Address: {
+                street: '40 Office St',
+                city: 'New York',
+                state: 'NY',
+                zipcode: '10001',
+                country: 'United States',
+              },
+              Telephone: {
+                number: '1234567890',
+                type: 'Domestic',
+                timeOfDay: 'Day',
+              },
+            },
+            Reprimand: {
+              items: [
+                { Item: { Has: { value: 'No' } } },
+              ],
+            },
+          }
+
+          expect(validateModel(testData, employment)).toEqual(true)
+        })
+      })
+    })
+
+    describe('if the Address field is a military address', () => {
+      it('AlternateAddress is required', () => {
+        const testData = {
+          EmploymentActivity: { value: 'NonGovernment' },
+          Address: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+        }
+
+        const expectedErrors = ['AlternateAddress.required']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('AlternateAddress must not be a PO address', () => {
+        const testData = {
+          EmploymentActivity: { value: 'NonGovernment' },
+          Address: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+          AlternateAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: '123 Main ST',
+              city: 'FPO',
+              state: 'AA',
+              zipcode: '34035',
+              country: 'POSTOFFICE',
+            },
+          },
+        }
+
+        const expectedErrors = ['AlternateAddress.model']
+
+        expect(validateModel(testData, employment))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('passes a valid employment item with an alternate address', () => {
+        const testData = {
+          EmploymentActivity: { value: 'NonGovernment' },
+          Dates: {
+            from: { year: 1990, month: 5, day: 12 },
+            present: true,
+          },
+          Title: 'Manager',
+          Employment: 'My Company',
+          Status: 'Full-time',
+          Address: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+          AlternateAddress: {
+            Address: {
+              street: '40 Office St',
+              city: 'New York',
+              state: 'NY',
+              zipcode: '10001',
+              country: 'United States',
+            },
+          },
+          PhysicalAddress: {
+            HasDifferentAddress: { value: 'No' },
+          },
+          Telephone: {
+            number: '1234567890',
+            type: 'Domestic',
+            timeOfDay: 'Day',
+          },
+          Supervisor: {
+            SupervisorName: { value: 'Person Supervisor' },
+            Title: { value: 'VP' },
+            EmailNotApplicable: { applicable: false },
+            Address: {
+              street: '40 Office St',
+              city: 'New York',
+              state: 'NY',
+              zipcode: '10001',
+              country: 'United States',
+            },
+            Telephone: {
+              number: '1234567890',
+              type: 'Domestic',
+              timeOfDay: 'Day',
+            },
+          },
+          Reprimand: {
+            items: [
+              { Item: { Has: { value: 'No' } } },
+            ],
+          },
+        }
+
+        expect(validateModel(testData, employment)).toEqual(true)
+      })
     })
 
     it('the Telephone field is required', () => {

--- a/src/models/__tests__/foreignContact.test.js
+++ b/src/models/__tests__/foreignContact.test.js
@@ -367,6 +367,45 @@ describe('The foreignContact model', () => {
     })
   })
 
+  it('AlternateAddress is required', () => {
+    const testData = {}
+    const expectedErrors = ['AlternateAddress.required']
+
+    expect(validateModel(testData, foreignContact))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('AlternateAddress must be a valid physical address', () => {
+    const testData = {
+      AlternateAddress: {
+        HasDifferentAddress: false,
+      },
+    }
+    const expectedErrors = ['AlternateAddress.model']
+
+    expect(validateModel(testData, foreignContact))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
+  it('AlternateAddress must be a military address', () => {
+    const testData = {
+      AlternateAddress: {
+        HasDifferentAddress: { value: 'Yes' },
+        Address: {
+          street: '123 Main ST',
+          city: 'New York',
+          state: 'NY',
+          zipcode: '10003',
+          country: 'United States',
+        },
+      },
+    }
+    const expectedErrors = ['AlternateAddress.model']
+
+    expect(validateModel(testData, foreignContact))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
   it('Employer is required', () => {
     const testData = {}
     const expectedErrors = ['Employer.required']
@@ -471,6 +510,16 @@ describe('The foreignContact model', () => {
       Birthdate: { year: 1980, month: 10, day: 12 },
       Birthplace: { city: 'London', country: 'United Kingdom' },
       AddressNotApplicable: { applicable: false },
+      AlternateAddress: {
+        HasDifferentAddress: { value: 'Yes' },
+        Address: {
+          street: '123 Main ST',
+          city: 'FPO',
+          state: 'AA',
+          zipcode: '34035',
+          country: 'POSTOFFICE',
+        },
+      },
       Employer: { value: 'Something' },
       EmployerAddressNotApplicable: { applicable: false },
       HasAffiliations: { value: 'No' },

--- a/src/models/__tests__/relative.test.js
+++ b/src/models/__tests__/relative.test.js
@@ -480,6 +480,9 @@ describe('The relative model', () => {
           zipcode: '10001',
           country: 'United States',
         },
+        AlternateAddress: {
+          HasDifferentAddress: { value: 'No' },
+        },
         IsDeceased: { value: 'No' },
       }
 
@@ -539,6 +542,49 @@ describe('The relative model', () => {
         .toEqual(expect.arrayContaining(expectedErrors))
     })
 
+    it('AlternateAddress is required', () => {
+      const testData = {
+        IsDeceased: { value: 'No' },
+      }
+      const expectedErrors = ['AlternateAddress.required']
+
+      expect(validateModel(testData, relative))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('AlternateAddress must be a valid physical address', () => {
+      const testData = {
+        IsDeceased: { value: 'No' },
+        AlternateAddress: {
+          HasDifferentAddress: false,
+        },
+      }
+      const expectedErrors = ['AlternateAddress.model']
+
+      expect(validateModel(testData, relative))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('AlternateAddress must be a military address', () => {
+      const testData = {
+        IsDeceased: { value: 'No' },
+        AlternateAddress: {
+          HasDifferentAddress: { value: 'Yes' },
+          Address: {
+            street: '123 Main ST',
+            city: 'New York',
+            state: 'NY',
+            zipcode: '10003',
+            country: 'United States',
+          },
+        },
+      }
+      const expectedErrors = ['AlternateAddress.model']
+
+      expect(validateModel(testData, relative))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
     it('passes a valid relative', () => {
       const testData = {
         Name: { first: 'Relative', noMiddleName: true, last: 'Person' },
@@ -559,6 +605,16 @@ describe('The relative model', () => {
         },
         Aliases: { items: [{ Item: { Has: { value: 'No' } } }] },
         IsDeceased: { value: 'No' },
+        AlternateAddress: {
+          HasDifferentAddress: { value: 'Yes' },
+          Address: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+        },
       }
 
       expect(validateModel(testData, relative)).toEqual(true)
@@ -628,6 +684,9 @@ describe('The relative model', () => {
             state: 'NY',
             zipcode: '10001',
             country: 'United States',
+          },
+          AlternateAddress: {
+            HasDifferentAddress: { value: 'No' },
           },
           Aliases: { items: [{ Item: { Has: { value: 'No' } } }] },
           IsDeceased: { value: 'No' },
@@ -700,6 +759,9 @@ describe('The relative model', () => {
               state: 'NY',
               zipcode: '10001',
               country: 'United States',
+            },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
             },
             Aliases: { items: [{ Item: { Has: { value: 'No' } } }] },
             IsDeceased: { value: 'No' },
@@ -806,6 +868,9 @@ describe('The relative model', () => {
             state: 'NY',
             zipcode: '10001',
             country: 'United States',
+          },
+          AlternateAddress: {
+            HasDifferentAddress: { value: 'No' },
           },
           Aliases: { items: [{ Item: { Has: { value: 'No' } } }] },
           IsDeceased: { value: 'No' },
@@ -1054,6 +1119,9 @@ describe('The relative model', () => {
               zipcode: '10001',
               country: 'United States',
             },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
+            },
             Aliases: { items: [{ Item: { Has: { value: 'No' } } }] },
             IsDeceased: { value: 'No' },
             Document: { value: 'Permanent' },
@@ -1109,6 +1177,9 @@ describe('The relative model', () => {
             state: 'NY',
             zipcode: '10001',
             country: 'United States',
+          },
+          AlternateAddress: {
+            HasDifferentAddress: { value: 'No' },
           },
           Aliases: { items: [{ Item: { Has: { value: 'No' } } }] },
           IsDeceased: { value: 'No' },
@@ -1166,6 +1237,9 @@ describe('The relative model', () => {
               state: 'NY',
               zipcode: '10001',
               country: 'United States',
+            },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
             },
             Aliases: { items: [{ Item: { Has: { value: 'No' } } }] },
             IsDeceased: { value: 'No' },
@@ -1303,6 +1377,9 @@ describe('The relative model', () => {
                 city: 'Toronto',
                 country: 'Canada',
               },
+              AlternateAddress: {
+                HasDifferentAddress: { value: 'No' },
+              },
               Aliases: { items: [{ Item: { Has: { value: 'No' } } }] },
               IsDeceased: { value: 'No' },
               EmployerNotApplicable: { applicable: false },
@@ -1368,6 +1445,9 @@ describe('The relative model', () => {
                 street: '123 Street',
                 city: 'Toronto',
                 country: 'Canada',
+              },
+              AlternateAddress: {
+                HasDifferentAddress: { value: 'No' },
               },
               Aliases: { items: [{ Item: { Has: { value: 'No' } } }] },
               IsDeceased: { value: 'No' },
@@ -1435,6 +1515,9 @@ describe('The relative model', () => {
                 city: 'Toronto',
                 country: 'Canada',
               },
+              AlternateAddress: {
+                HasDifferentAddress: { value: 'No' },
+              },
               Aliases: { items: [{ Item: { Has: { value: 'No' } } }] },
               IsDeceased: { value: 'No' },
               Employer: { value: 'Boss' },
@@ -1490,6 +1573,9 @@ describe('The relative model', () => {
                 city: 'Toronto',
                 country: 'Canada',
               },
+              AlternateAddress: {
+                HasDifferentAddress: { value: 'No' },
+              },
               Aliases: { items: [{ Item: { Has: { value: 'No' } } }] },
               IsDeceased: { value: 'No' },
               Employer: { value: 'Boss' },
@@ -1531,6 +1617,9 @@ describe('The relative model', () => {
                 street: '123 Street',
                 city: 'Toronto',
                 country: 'Canada',
+              },
+              AlternateAddress: {
+                HasDifferentAddress: { value: 'No' },
               },
               Aliases: { items: [{ Item: { Has: { value: 'No' } } }] },
               IsDeceased: { value: 'No' },
@@ -1709,6 +1798,9 @@ describe('The relative model', () => {
               state: 'NY',
               zipcode: '10002',
               country: 'United States',
+            },
+            AlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
             },
             Aliases: { items: [{ Item: { Has: { value: 'No' } } }] },
             IsDeceased: { value: 'No' },

--- a/src/models/__tests__/residence.test.js
+++ b/src/models/__tests__/residence.test.js
@@ -103,6 +103,36 @@ describe('The residence model', () => {
           .toEqual(expect.arrayContaining(expectedErrors))
       })
 
+      it('AlternateAddress may not be a PO box', () => {
+        const testData = {
+          Address: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+          AlternateAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: 'P.O. Box 234',
+              city: 'FPO',
+              state: 'AA',
+              zipcode: '34035',
+              country: 'POSTOFFICE',
+            },
+          },
+          Dates: {
+            from: { year: 2000, month: 1, day: 1 },
+            to: { year: 2001, month: 1, day: 1 },
+          },
+          Role: { value: 'Own' },
+        }
+
+        const expectedErrors = ['AlternateAddress.model']
+
+        expect(validateModel(testData, residence))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
       it('passes a valid residence with an alternate address', () => {
         const testData = {
           Address: {
@@ -191,6 +221,37 @@ describe('The residence model', () => {
             country: 'POSTOFFICE',
           },
         },
+      }
+
+      const expectedErrors = ['AlternateAddress.model']
+
+      expect(validateModel(testData, residence))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('AlternateAddress may not be a PO box', () => {
+      const testData = {
+        Address: {
+          street: '123 Main ST',
+          city: 'FPO',
+          state: 'AA',
+          zipcode: '34035',
+          country: 'POSTOFFICE',
+        },
+        AlternateAddress: {
+          Address: {
+            street: 'PO Box 123',
+            city: 'New York',
+            state: 'NY',
+            zipcode: '10003',
+            country: 'United States',
+          },
+        },
+        Dates: {
+          from: { year: 2000, month: 1, day: 1 },
+          to: { year: 2001, month: 1, day: 1 },
+        },
+        Role: { value: 'Own' },
       }
 
       const expectedErrors = ['AlternateAddress.model']

--- a/src/models/__tests__/residence.test.js
+++ b/src/models/__tests__/residence.test.js
@@ -61,6 +61,173 @@ describe('The residence model', () => {
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
+  describe('if the Address field is international', () => {
+    it('AlternateAddress is required', () => {
+      const testData = {
+        Address: {
+          street: '123 Test St',
+          city: 'London',
+          country: { value: 'United Kingdom' },
+        },
+      }
+
+      const expectedErrors = ['AlternateAddress.required']
+
+      expect(validateModel(testData, residence))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    describe('if HasDifferentAddress is "Yes"', () => {
+      it('AlternateAddress must be a PO address', () => {
+        const testData = {
+          Address: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+          AlternateAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: '123 Main St',
+              city: 'New York',
+              state: 'NY',
+              zipcode: '10002',
+              country: 'United States',
+            },
+          },
+        }
+
+        const expectedErrors = ['AlternateAddress.model']
+
+        expect(validateModel(testData, residence))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('passes a valid residence with an alternate address', () => {
+        const testData = {
+          Address: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+          AlternateAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: '123 Main ST',
+              city: 'FPO',
+              state: 'AA',
+              zipcode: '34035',
+              country: 'POSTOFFICE',
+            },
+          },
+          Dates: {
+            from: { year: 2000, month: 1, day: 1 },
+            to: { year: 2001, month: 1, day: 1 },
+          },
+          Role: { value: 'Own' },
+        }
+
+        expect(validateModel(testData, residence)).toEqual(true)
+      })
+    })
+
+    describe('if HasDifferentAddress is "No"', () => {
+      it('passes a valid residence with an alternate address', () => {
+        const testData = {
+          Address: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+          AlternateAddress: {
+            HasDifferentAddress: { value: 'No' },
+          },
+          Dates: {
+            from: { year: 2000, month: 1, day: 1 },
+            to: { year: 2001, month: 1, day: 1 },
+          },
+          Role: { value: 'Own' },
+        }
+
+        expect(validateModel(testData, residence)).toEqual(true)
+      })
+    })
+  })
+
+  describe('if the Address field is a military address', () => {
+    it('AlternateAddress is required', () => {
+      const testData = {
+        Address: {
+          street: '123 Main ST',
+          city: 'FPO',
+          state: 'AA',
+          zipcode: '34035',
+          country: 'POSTOFFICE',
+        },
+      }
+
+      const expectedErrors = ['AlternateAddress.required']
+
+      expect(validateModel(testData, residence))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('AlternateAddress must not be a PO address', () => {
+      const testData = {
+        Address: {
+          street: '123 Main ST',
+          city: 'FPO',
+          state: 'AA',
+          zipcode: '34035',
+          country: 'POSTOFFICE',
+        },
+        AlternateAddress: {
+          HasDifferentAddress: { value: 'Yes' },
+          Address: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+        },
+      }
+
+      const expectedErrors = ['AlternateAddress.model']
+
+      expect(validateModel(testData, residence))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid residence with an alternate address', () => {
+      const testData = {
+        Address: {
+          street: '123 Main ST',
+          city: 'FPO',
+          state: 'AA',
+          zipcode: '34035',
+          country: 'POSTOFFICE',
+        },
+        AlternateAddress: {
+          Address: {
+            street: '123 Main ST',
+            city: 'New York',
+            state: 'NY',
+            zipcode: '10003',
+            country: 'United States',
+          },
+        },
+        Dates: {
+          from: { year: 2000, month: 1, day: 1 },
+          to: { year: 2001, month: 1, day: 1 },
+        },
+        Role: { value: 'Own' },
+      }
+
+      expect(validateModel(testData, residence)).toEqual(true)
+    })
+  })
+
   it('the Role field is required', () => {
     const testData = { Role: '' }
     const expectedErrors = ['Role.required']
@@ -416,6 +583,234 @@ describe('The residence model', () => {
       }
 
       expect(validateModel(testData, residence)).toEqual(true)
+    })
+
+    describe('if the ReferenceAddress field is international', () => {
+      it('ReferenceAlternateAddress is required', () => {
+        const testData = {
+          ReferenceAddress: {
+            street: '123 Test St',
+            city: 'London',
+            country: { value: 'United Kingdom' },
+          },
+        }
+
+        const expectedErrors = ['ReferenceAlternateAddress.required']
+
+        expect(validateModel(testData, residence))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      describe('if HasDifferentAddress is "Yes"', () => {
+        it('ReferenceAlternateAddress must be a PO address', () => {
+          const testData = {
+            ReferenceAddress: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            ReferenceAlternateAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Main St',
+                city: 'New York',
+                state: 'NY',
+                zipcode: '10002',
+                country: 'United States',
+              },
+            },
+          }
+
+          const expectedErrors = ['ReferenceAlternateAddress.model']
+
+          expect(validateModel(testData, residence))
+            .toEqual(expect.arrayContaining(expectedErrors))
+        })
+
+        it('passes a valid residence with an alternate address', () => {
+          const testData = {
+            Dates: {
+              from: { year: 2015, month: 1, day: 1 },
+              present: true,
+            },
+            Address: {
+              street: '123 Main St',
+              city: 'New York',
+              state: 'NY',
+              zipcode: '10002',
+              country: 'United States',
+            },
+            Role: { value: 'Own' },
+            ReferenceName: {
+              first: 'Person',
+              noMiddleName: true,
+              last: 'Name',
+            },
+            ReferenceLastContact: { year: '2019', month: '01', day: '01' },
+            ReferencePhoneEvening: { number: '1234567890', type: 'Domestic', timeOfDay: 'NA' },
+            ReferencePhoneDay: { noNumber: true },
+            ReferencePhoneMobile: { number: '1234567890', type: 'Domestic', timeOfDay: 'NA' },
+            ReferenceRelationship: { values: ['Friend', 'Neighbor'] },
+            ReferenceEmail: { value: 'myfriend@gmail.com' },
+            ReferenceAddress: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            ReferenceAlternateAddress: {
+              HasDifferentAddress: { value: 'Yes' },
+              Address: {
+                street: '123 Main ST',
+                city: 'FPO',
+                state: 'AA',
+                zipcode: '34035',
+                country: 'POSTOFFICE',
+              },
+            },
+          }
+
+          expect(validateModel(testData, residence)).toEqual(true)
+        })
+      })
+
+      describe('if HasDifferentAddress is "No"', () => {
+        it('passes a valid residence with an alternate address', () => {
+          const testData = {
+            Dates: {
+              from: { year: 2015, month: 1, day: 1 },
+              present: true,
+            },
+            Address: {
+              street: '123 Main St',
+              city: 'New York',
+              state: 'NY',
+              zipcode: '10002',
+              country: 'United States',
+            },
+            Role: { value: 'Own' },
+            ReferenceName: {
+              first: 'Person',
+              noMiddleName: true,
+              last: 'Name',
+            },
+            ReferenceLastContact: { year: '2019', month: '01', day: '01' },
+            ReferencePhoneEvening: { number: '1234567890', type: 'Domestic', timeOfDay: 'NA' },
+            ReferencePhoneDay: { noNumber: true },
+            ReferencePhoneMobile: { number: '1234567890', type: 'Domestic', timeOfDay: 'NA' },
+            ReferenceRelationship: { values: ['Friend', 'Neighbor'] },
+            ReferenceEmail: { value: 'myfriend@gmail.com' },
+            ReferenceAddress: {
+              street: '123 Test St',
+              city: 'London',
+              country: { value: 'United Kingdom' },
+            },
+            ReferenceAlternateAddress: {
+              HasDifferentAddress: { value: 'No' },
+              Address: {
+                street: '123 Main ST',
+                city: 'FPO',
+                state: 'AA',
+                zipcode: '34035',
+                country: 'POSTOFFICE',
+              },
+            },
+          }
+
+          expect(validateModel(testData, residence)).toEqual(true)
+        })
+      })
+    })
+
+    describe('if the ReferenceAddress field is a military address', () => {
+      it('ReferenceAlternateAddress is required', () => {
+        const testData = {
+          ReferenceAddress: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+        }
+
+        const expectedErrors = ['ReferenceAlternateAddress.required']
+
+        expect(validateModel(testData, residence))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('ReferenceAlternateAddress must not be a PO address', () => {
+        const testData = {
+          ReferenceAddress: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+          ReferenceAlternateAddress: {
+            HasDifferentAddress: { value: 'Yes' },
+            Address: {
+              street: '123 Main ST',
+              city: 'FPO',
+              state: 'AA',
+              zipcode: '34035',
+              country: 'POSTOFFICE',
+            },
+          },
+        }
+
+        const expectedErrors = ['ReferenceAlternateAddress.model']
+
+        expect(validateModel(testData, residence))
+          .toEqual(expect.arrayContaining(expectedErrors))
+      })
+
+      it('passes a valid residence with an alternate address', () => {
+        const testData = {
+          Dates: {
+            from: { year: 2015, month: 1, day: 1 },
+            present: true,
+          },
+          Address: {
+            street: '123 Main St',
+            city: 'New York',
+            state: 'NY',
+            zipcode: '10002',
+            country: 'United States',
+          },
+          Role: { value: 'Own' },
+          ReferenceName: {
+            first: 'Person',
+            noMiddleName: true,
+            last: 'Name',
+          },
+          ReferenceLastContact: { year: '2019', month: '01', day: '01' },
+          ReferencePhoneEvening: { number: '1234567890', type: 'Domestic', timeOfDay: 'NA' },
+          ReferencePhoneDay: { noNumber: true },
+          ReferencePhoneMobile: { number: '1234567890', type: 'Domestic', timeOfDay: 'NA' },
+          ReferenceRelationship: { values: ['Friend', 'Neighbor'] },
+          ReferenceEmail: { value: 'myfriend@gmail.com' },
+          ReferenceAddress: {
+            street: '123 Main ST',
+            city: 'FPO',
+            state: 'AA',
+            zipcode: '34035',
+            country: 'POSTOFFICE',
+          },
+          ReferenceAlternateAddress: {
+            Address: {
+              street: '123 Main ST',
+              city: 'New York',
+              state: 'NY',
+              zipcode: '10003',
+              country: 'United States',
+            },
+          },
+        }
+
+        expect(validateModel(testData, residence)).toEqual(true)
+      })
     })
   })
 })

--- a/src/models/civilUnion.js
+++ b/src/models/civilUnion.js
@@ -3,11 +3,12 @@ import phone from 'models/shared/phone'
 import birthplace from 'models/shared/locations/birthplace'
 import address from 'models/shared/locations/address'
 import usCityStateZipInternationalCity from 'models/shared/locations/usCityStateZipInternationalCity'
+import physicalAddress from 'models/shared/physicalAddress'
 import foreignBornDocument from 'models/foreignBornDocument'
 import { hasYesOrNo } from 'models/validate'
 import { DEFAULT_LATEST, OTHER } from 'constants/dateLimits'
-
 import { countryString } from 'validators/location'
+import { isInternational, isPO } from 'helpers/location'
 
 export const otherName = {
   Name: {
@@ -59,6 +60,23 @@ const civilUnion = {
       && attributes.UseCurrentAddress.applicable === true) return {}
 
     return { presence: true, location: { validator: address } }
+  },
+  AlternateAddress: (value, attributes) => {
+    if (attributes.Address && isInternational(attributes.Address)) {
+      return {
+        presence: true,
+        model: { validator: physicalAddress, militaryAddress: true },
+      }
+    }
+
+    if (attributes.Address && isPO(attributes.Address)) {
+      return {
+        presence: true,
+        model: { validator: physicalAddress, militaryAddress: false },
+      }
+    }
+
+    return {}
   },
   Location: {
     presence: true,

--- a/src/models/employment.js
+++ b/src/models/employment.js
@@ -13,6 +13,8 @@ import address from 'models/shared/locations/address'
 import phone from 'models/shared/phone'
 
 import { today, dateWithinRange } from 'helpers/date'
+import { isInternational, isPO } from 'helpers/location'
+import { checkValue } from 'models/validate'
 
 /** Helpers */
 const withinSevenYears = (dates = {}) => {
@@ -42,6 +44,23 @@ const supervisor = {
     return { presence: true, model: { validator: email } }
   },
   Address: { presence: true, location: { validator: address } },
+  AlternateAddress: (value, attributes) => {
+    if (attributes.Address && isInternational(attributes.Address)) {
+      return {
+        presence: true,
+        model: { validator: physicalAddress, militaryAddress: true },
+      }
+    }
+
+    if (attributes.Address && isPO(attributes.Address)) {
+      return {
+        presence: true,
+        model: { validator: physicalAddress, militaryAddress: false },
+      }
+    }
+
+    return {}
+  },
   Telephone: { presence: true, model: { validator: phone } },
 }
 
@@ -118,6 +137,23 @@ const employment = {
       presence: true,
       location: { validator: address },
     }
+  },
+  AlternateAddress: (value, attributes) => {
+    if (attributes.Address && isInternational(attributes.Address)) {
+      return {
+        presence: true,
+        model: { validator: physicalAddress, militaryAddress: true },
+      }
+    }
+
+    if (attributes.Address && isPO(attributes.Address)) {
+      return {
+        presence: true,
+        model: { validator: physicalAddress, militaryAddress: false },
+      }
+    }
+
+    return {}
   },
   Telephone: (value, attributes = {}) => {
     if (matchEmploymentActivity(attributes, [UNEMPLOYMENT])) return {}
@@ -201,6 +237,28 @@ const employment = {
     return {}
   },
 
+  PhysicalAlternateAddress: (value, attributes) => {
+    const { PhysicalAddress } = attributes
+    if (PhysicalAddress && checkValue(PhysicalAddress.HasDifferentAddress, 'Yes')) {
+      const { Address } = PhysicalAddress
+      if (Address && isInternational(Address)) {
+        return {
+          presence: true,
+          model: { validator: physicalAddress, militaryAddress: true },
+        }
+      }
+
+      if (Address && isPO(Address)) {
+        return {
+          presence: true,
+          model: { validator: physicalAddress, militaryAddress: false },
+        }
+      }
+    }
+
+    return {}
+  },
+
   // Required by self-employment & unemployed
   ReferenceName: (value, attributes = {}) => {
     if (matchEmploymentActivity(attributes, [
@@ -239,6 +297,23 @@ const employment = {
       return {
         presence: true,
         location: { validator: address },
+      }
+    }
+
+    return {}
+  },
+  ReferenceAlternateAddress: (value, attributes = {}) => {
+    if (attributes.ReferenceAddress && isInternational(attributes.ReferenceAddress)) {
+      return {
+        presence: true,
+        model: { validator: physicalAddress, militaryAddress: true },
+      }
+    }
+
+    if (attributes.ReferenceAddress && isPO(attributes.ReferenceAddress)) {
+      return {
+        presence: true,
+        model: { validator: physicalAddress, militaryAddress: false },
       }
     }
 

--- a/src/models/foreignContact.js
+++ b/src/models/foreignContact.js
@@ -1,6 +1,8 @@
 import name from 'models/shared/name'
 import cityCountry from 'models/shared/locations/cityCountry'
 import address from 'models/shared/locations/address'
+import physicalAddress from 'models/shared/physicalAddress'
+
 import { OTHER, DEFAULT_LATEST } from 'constants/dateLimits'
 
 const contactMethodOptions = [
@@ -144,6 +146,10 @@ const foreignContact = {
         validator: address,
       },
     }
+  },
+  AlternateAddress: {
+    presence: true,
+    model: { validator: physicalAddress, militaryAddress: true },
   },
   Employer: (value, attributes) => {
     const { EmployerNotApplicable } = attributes

--- a/src/models/relative.js
+++ b/src/models/relative.js
@@ -3,6 +3,7 @@ import alias from 'models/shared/alias'
 import address from 'models/shared/locations/address'
 import usAddress from 'models/shared/locations/usAddress'
 import birthplaceWithoutCounty from 'models/shared/locations/birthplaceWithoutCounty'
+import physicalAddress from 'models/shared/physicalAddress'
 import { hasYesOrNo } from 'models/validate'
 
 import {
@@ -109,6 +110,15 @@ const relative = {
     return {
       presence: true,
       location: { validator: address },
+    }
+  },
+  AlternateAddress: (value, attributes) => {
+    if (attributes.IsDeceased
+      && attributes.IsDeceased.value === 'Yes') return {}
+
+    return {
+      presence: true,
+      model: { validator: physicalAddress, militaryAddress: true },
     }
   },
   CitizenshipDocumentation: (value, attributes) => {

--- a/src/models/residence.js
+++ b/src/models/residence.js
@@ -35,14 +35,14 @@ const residence = {
     if (attributes.Address && isInternational(attributes.Address)) {
       return {
         presence: true,
-        model: { validator: physicalAddress, militaryAddress: true },
+        model: { validator: physicalAddress, militaryAddress: true, allowPOBox: false },
       }
     }
 
     if (attributes.Address && isPO(attributes.Address)) {
       return {
         presence: true,
-        model: { validator: physicalAddress, militaryAddress: false },
+        model: { validator: physicalAddress, militaryAddress: false, allowPOBox: false },
       }
     }
 

--- a/src/models/residence.js
+++ b/src/models/residence.js
@@ -4,8 +4,10 @@ import address from 'models/shared/locations/address'
 import name from 'models/shared/name'
 import phone from 'models/shared/phone'
 import email from 'models/shared/email'
+import physicalAddress from 'models/shared/physicalAddress'
 
 import { today, dateWithinRange } from 'helpers/date'
+import { isInternational, isPO } from 'helpers/location'
 
 const residenceRequiresReference = (dates = {}) => {
   const { from, present } = dates
@@ -29,12 +31,22 @@ const residence = {
     },
   },
 
-  AlternateAddress: {
-    // TODO required if Address is APO/FPO/DPO or if Address is outside of US and APO/FPO is yes
-    // TODO no PO box allowed
-    // TODO must be valid physical address
-    // US: Street/Unit/Duty/Location, City/Post name, State, Zip, Country
-    // Foreign: APO/FPO: address, APO/FPO/DPo, state, zipcode
+  AlternateAddress: (value, attributes) => {
+    if (attributes.Address && isInternational(attributes.Address)) {
+      return {
+        presence: true,
+        model: { validator: physicalAddress, militaryAddress: true },
+      }
+    }
+
+    if (attributes.Address && isPO(attributes.Address)) {
+      return {
+        presence: true,
+        model: { validator: physicalAddress, militaryAddress: false },
+      }
+    }
+
+    return {}
   },
 
   Role: {
@@ -135,8 +147,22 @@ const residence = {
         location: { validator: address },
       } : {}
   ),
-  ReferenceAlternateAddress: {
-    // TODO same validations as AlternateAddress
+  ReferenceAlternateAddress: (value, attributes) => {
+    if (attributes.ReferenceAddress && isInternational(attributes.ReferenceAddress)) {
+      return {
+        presence: true,
+        model: { validator: physicalAddress, militaryAddress: true },
+      }
+    }
+
+    if (attributes.ReferenceAddress && isPO(attributes.ReferenceAddress)) {
+      return {
+        presence: true,
+        model: { validator: physicalAddress, militaryAddress: false },
+      }
+    }
+
+    return {}
   },
 }
 

--- a/src/models/shared/__tests__/physicalAddress.test.js
+++ b/src/models/shared/__tests__/physicalAddress.test.js
@@ -124,4 +124,81 @@ describe('The PhysicalAddress model', () => {
       expect(validateModel(testData, physicalAddress)).toBe(true)
     })
   })
+
+  describe('with the "militaryAddress" option set to true', () => {
+    it('Address must be a military address', () => {
+      const testData = {
+        HasDifferentAddress: { value: 'Yes' },
+        Address: {
+          street: '123 Main ST',
+          city: 'New York',
+          state: 'NY',
+          zipcode: '10003',
+          country: 'United States',
+        },
+      }
+
+      const expectedErrors = ['Address.location']
+
+      expect(validateModel(testData, physicalAddress, { militaryAddress: true }))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid address', () => {
+      const testData = {
+        HasDifferentAddress: { value: 'Yes' },
+        Address: {
+          street: '123 Main ST',
+          city: 'FPO',
+          state: 'AA',
+          zipcode: '34035',
+          country: 'POSTOFFICE',
+        },
+      }
+
+      expect(validateModel(testData, physicalAddress, { militaryAddress: true }))
+        .toEqual(true)
+    })
+  })
+
+  describe('with the "militaryAddress" option set to false', () => {
+    it('HasDifferentAddress is not required', () => {
+      const testData = {}
+      const expectedErrors = ['HasDifferentAddress.required']
+      expect(validateModel(testData, physicalAddress, { militaryAddress: false }))
+        .not.toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('Address must not be a military address', () => {
+      const testData = {
+        Address: {
+          street: '123 Main ST',
+          city: 'FPO',
+          state: 'AA',
+          zipcode: '34035',
+          country: 'POSTOFFICE',
+        },
+      }
+
+      const expectedErrors = ['Address.location']
+
+      expect(validateModel(testData, physicalAddress, { militaryAddress: false }))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid address', () => {
+      const testData = {
+        Address: {
+          street: '123 Main ST',
+          city: 'New York',
+          state: 'NY',
+          zipcode: '10003',
+          country: 'United States',
+        },
+      }
+
+      expect(validateModel(testData, physicalAddress, { militaryAddress: false }))
+        .toEqual(true)
+    })
+  })
 })

--- a/src/models/shared/location.js
+++ b/src/models/shared/location.js
@@ -61,7 +61,23 @@ const location = {
 
     return { requireEmpty: true }
   },
-  country: { presence: true },
+  country: (value, attributes, attributeName, options) => {
+    if (options.militaryAddress === true) {
+      return {
+        presence: true,
+        inclusion: ['POSTOFFICE'],
+      }
+    }
+
+    if (options.militaryAddress === false) {
+      return {
+        presence: true,
+        exclusion: ['POSTOFFICE'],
+      }
+    }
+
+    return { presence: true }
+  },
   county: (value, attributes = {}) => {
     if (!isInternational(attributes)) {
       return { presence: true }

--- a/src/models/shared/locations/__tests__/address.test.js
+++ b/src/models/shared/locations/__tests__/address.test.js
@@ -92,4 +92,64 @@ describe('The location/address model', () => {
       expect(validateModel(testData, address)).toEqual(true)
     })
   })
+
+  describe('with the "militaryAddress" option set to true', () => {
+    it('must be a military address', () => {
+      const testData = {
+        street: '123 Main ST',
+        city: 'New York',
+        state: 'NY',
+        zipcode: '10003',
+        country: 'United States',
+      }
+
+      const expectedErrors = ['country.inclusion']
+
+      expect(validateModel(testData, address, { militaryAddress: true }))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid military address', () => {
+      const testData = {
+        street: '123 Main ST',
+        city: 'FPO',
+        state: 'AA',
+        zipcode: '34035',
+        country: 'POSTOFFICE',
+      }
+
+      expect(validateModel(testData, address, { militaryAddress: true }))
+        .toEqual(true)
+    })
+  })
+
+  describe('with the "militaryAddress" option set to false', () => {
+    it('must not be a military address', () => {
+      const testData = {
+        street: '123 Main ST',
+        city: 'FPO',
+        state: 'AA',
+        zipcode: '34035',
+        country: 'POSTOFFICE',
+      }
+
+      const expectedErrors = ['country.exclusion']
+
+      expect(validateModel(testData, address, { militaryAddress: false }))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('passes a valid non-military address', () => {
+      const testData = {
+        street: '123 Main ST',
+        city: 'New York',
+        state: 'NY',
+        zipcode: '10003',
+        country: 'United States',
+      }
+
+      expect(validateModel(testData, address, { militaryAddress: false }))
+        .toEqual(true)
+    })
+  })
 })

--- a/src/models/shared/physicalAddress.js
+++ b/src/models/shared/physicalAddress.js
@@ -3,20 +3,20 @@ import phone from 'models/shared/phone'
 import { hasYesOrNo } from 'models/validate'
 
 const physicalAddress = {
-  HasDifferentAddress: {
-    presence: true,
-    hasValue: {
-      validator: hasYesOrNo,
-    },
-  },
-  Address: (value, attributes = {}) => {
+  HasDifferentAddress: (value, attributes, attributeName, options) => (
+    options.militaryAddress === false ? {} : {
+      presence: true,
+      hasValue: { validator: hasYesOrNo },
+    }
+  ),
+  Address: (value, attributes = {}, attributeName, options) => {
     const { HasDifferentAddress } = attributes
-    if (HasDifferentAddress
+    if (options.militaryAddress === false || (HasDifferentAddress
       && HasDifferentAddress.value
-      && HasDifferentAddress.value === 'Yes') {
+      && HasDifferentAddress.value === 'Yes')) {
       return {
         presence: true,
-        location: { validator: address },
+        location: { ...options, validator: address },
       }
     }
 

--- a/src/validators/foreigncontacts.test.js
+++ b/src/validators/foreigncontacts.test.js
@@ -1,48 +1,48 @@
 import ForeignContactsValidator, {
-  ForeignNationalValidator
+  ForeignNationalValidator,
 } from './foreigncontacts'
 import { battery } from './helpers'
 import Location from '../components/Form/Location'
 
-describe('Foreign contacts component validation', function() {
-  it('validate foreign national name', function() {
+describe('Foreign contacts component validation', () => {
+  it('validate foreign national name', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
           NameNotApplicable: {
-            applicable: false
-          }
+            applicable: false,
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
           NameNotApplicable: {
-            applicable: false
+            applicable: false,
           },
           NameExplanation: {
-            value: 'explanation'
-          }
-        },
-        expected: true
-      },
-      {
-        data: {
-          NameNotApplicable: {
-            applicable: true
+            value: 'explanation',
           },
-          Name: {}
         },
-        expected: false
+        expected: true,
       },
       {
         data: {
           NameNotApplicable: {
-            applicable: true
+            applicable: true,
+          },
+          Name: {},
+        },
+        expected: false,
+      },
+      {
+        data: {
+          NameNotApplicable: {
+            applicable: true,
           },
           Name: {
             first: 'Foo',
@@ -51,222 +51,222 @@ describe('Foreign contacts component validation', function() {
             middleInitialOnly: true,
             noMiddleName: false,
             last: 'Bar',
-            suffix: 'Jr'
-          }
+            suffix: 'Jr',
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignNationalValidator, 'validName')
   })
 
-  it('validate foreign nation date of first contact', function() {
+  it('validate foreign nation date of first contact', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
           FirstContact: {
             day: '1',
             month: '1',
-            year: '2016'
-          }
+            year: '2016',
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignNationalValidator, 'validFirstContact')
   })
 
-  it('validate foreign nation date of last contact', function() {
+  it('validate foreign nation date of last contact', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
           LastContact: {
             day: '1',
             month: '1',
-            year: '2016'
-          }
+            year: '2016',
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignNationalValidator, 'validLastContact')
   })
 
-  it('validate foreign national methods of contact', function() {
+  it('validate foreign national methods of contact', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
-          Methods: { values: [] }
+          Methods: { values: [] },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
-          Methods: { values: ['In person'] }
+          Methods: { values: ['In person'] },
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
-          Methods: { values: ['In person', 'Written'] }
+          Methods: { values: ['In person', 'Written'] },
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
-          Methods: { values: ['In person', 'Other'] }
+          Methods: { values: ['In person', 'Other'] },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
           Methods: { values: ['In person', 'Other'] },
           MethodsExplanation: {
-            value: 'explanation'
-          }
+            value: 'explanation',
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignNationalValidator, 'validMethods')
   })
 
-  it('validate foreign national frequency of contact', function() {
+  it('validate foreign national frequency of contact', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
-          Frequency: { value: '' }
+          Frequency: { value: '' },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
-          Frequency: { value: 'Weekly' }
+          Frequency: { value: 'Weekly' },
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
-          Frequency: { value: 'Other' }
+          Frequency: { value: 'Other' },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
           Frequency: { value: 'Other' },
           FrequencyExplanation: {
-            value: 'explanation'
-          }
+            value: 'explanation',
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignNationalValidator, 'validFrequency')
   })
 
-  it('validate foreign national nature of the relationship', function() {
+  it('validate foreign national nature of the relationship', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
-          Relationship: { values: [] }
+          Relationship: { values: [] },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
-          Relationship: { values: ['Personal'] }
+          Relationship: { values: ['Personal'] },
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
-          Relationship: { values: ['Personal', 'Professional'] }
+          Relationship: { values: ['Personal', 'Professional'] },
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
-          Relationship: { values: ['Personal', 'Other'] }
+          Relationship: { values: ['Personal', 'Other'] },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
           Relationship: { values: ['Personal', 'Other'] },
           RelationshipExplanation: {
-            value: 'explanation'
-          }
+            value: 'explanation',
+          },
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
           Relationship: { values: ['Personal', 'Obligation'] },
           RelationshipExplanation: {
-            value: 'explanation'
-          }
+            value: 'explanation',
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignNationalValidator, 'validRelationship')
   })
 
-  it('validate foreign national aliases', function() {
+  it('validate foreign national aliases', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
           Aliases: {
-            items: []
-          }
+            items: [],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
           Aliases: {
-            items: [{ Item: { Has: { value: 'No' } } }]
-          }
+            items: [{ Item: { Has: { value: 'No' } } }],
+          },
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
           Aliases: {
-            items: [{ Item: { Has: { value: 'Yes' } } }]
-          }
+            items: [{ Item: { Has: { value: 'Yes' } } }],
+          },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
@@ -282,169 +282,169 @@ describe('Foreign contacts component validation', function() {
                     middleInitialOnly: true,
                     noMiddleName: false,
                     last: 'Bar',
-                    suffix: 'Jr'
-                  }
-                }
+                    suffix: 'Jr',
+                  },
+                },
               },
               {
                 Item: {
-                  Has: { value: 'No' }
-                }
-              }
-            ]
-          }
+                  Has: { value: 'No' },
+                },
+              },
+            ],
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignNationalValidator, 'validAliases')
   })
 
-  it('validate foreign national citizenship', function() {
+  it('validate foreign national citizenship', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
-          Citizenship: {}
+          Citizenship: {},
         },
-        expected: false
-      },
-      {
-        data: {
-          Citizenship: {
-            value: ['United States']
-          }
-        },
-        expected: true
+        expected: false,
       },
       {
         data: {
           Citizenship: {
-            value: ['United States', 'Germany']
-          }
+            value: ['United States'],
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
+      {
+        data: {
+          Citizenship: {
+            value: ['United States', 'Germany'],
+          },
+        },
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignNationalValidator, 'validCitizenship')
   })
 
-  it('validate foreign national date of birth', function() {
+  it('validate foreign national date of birth', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
           BirthdateNotApplicable: {
-            applicable: false
-          }
-        },
-        expected: true
-      },
-      {
-        data: {
-          BirthdateNotApplicable: {
-            applicable: true
+            applicable: false,
           },
-          Birthdate: {}
         },
-        expected: false
+        expected: true,
       },
       {
         data: {
           BirthdateNotApplicable: {
-            applicable: true
+            applicable: true,
+          },
+          Birthdate: {},
+        },
+        expected: false,
+      },
+      {
+        data: {
+          BirthdateNotApplicable: {
+            applicable: true,
           },
           Birthdate: {
             day: '1',
             month: '1',
-            year: '2016'
-          }
+            year: '2016',
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignNationalValidator, 'validBirthdate')
   })
 
-  it('validate foreign national place of birth', function() {
+  it('validate foreign national place of birth', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
           BirthplaceNotApplicable: {
-            applicable: false
-          }
-        },
-        expected: true
-      },
-      {
-        data: {
-          BirthplaceNotApplicable: {
-            applicable: true
+            applicable: false,
           },
-          Birthplace: {}
         },
-        expected: false
+        expected: true,
       },
       {
         data: {
           BirthplaceNotApplicable: {
-            applicable: true
+            applicable: true,
+          },
+          Birthplace: {},
+        },
+        expected: false,
+      },
+      {
+        data: {
+          BirthplaceNotApplicable: {
+            applicable: true,
           },
           Birthplace: {
             domestic: 'Yes',
             country: { value: 'United States' },
             city: 'Arlington',
             county: 'Arlington',
-            state: 'VA'
-          }
+            state: 'VA',
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignNationalValidator, 'validBirthplace')
   })
 
-  it('validate foreign national current address', function() {
+  it('validate foreign national current address', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
           AddressNotApplicable: {
-            applicable: false
-          }
-        },
-        expected: true
-      },
-      {
-        data: {
-          AddressNotApplicable: {
-            applicable: true
+            applicable: false,
           },
-          Address: {}
         },
-        expected: false
+        expected: true,
       },
       {
         data: {
           AddressNotApplicable: {
-            applicable: true
+            applicable: true,
+          },
+          Address: {},
+        },
+        expected: false,
+      },
+      {
+        data: {
+          AddressNotApplicable: {
+            applicable: true,
           },
           Address: {
             country: { value: 'United States' },
@@ -452,82 +452,82 @@ describe('Foreign contacts component validation', function() {
             city: 'Arlington',
             state: 'VA',
             zipcode: '22202',
-            layout: Location.ADDRESS
-          }
+            layout: Location.ADDRESS,
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignNationalValidator, 'validAddress')
   })
 
-  it('validate foreign national employer', function() {
+  it('validate foreign national employer', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
           EmployerNotApplicable: {
-            applicable: false
-          }
-        },
-        expected: true
-      },
-      {
-        data: {
-          EmployerNotApplicable: {
-            applicable: true
+            applicable: false,
           },
-          Employer: {}
         },
-        expected: false
+        expected: true,
       },
       {
         data: {
           EmployerNotApplicable: {
-            applicable: true
+            applicable: true,
+          },
+          Employer: {},
+        },
+        expected: false,
+      },
+      {
+        data: {
+          EmployerNotApplicable: {
+            applicable: true,
           },
           Employer: {
-            value: 'employer name'
-          }
+            value: 'employer name',
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignNationalValidator, 'validEmployer')
   })
 
-  it('validate foreign national employer address', function() {
+  it('validate foreign national employer address', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
           EmployerAddressNotApplicable: {
-            applicable: false
-          }
-        },
-        expected: true
-      },
-      {
-        data: {
-          EmployerAddressNotApplicable: {
-            applicable: true
+            applicable: false,
           },
-          EmployerAddress: {}
         },
-        expected: false
+        expected: true,
       },
       {
         data: {
           EmployerAddressNotApplicable: {
-            applicable: true
+            applicable: true,
+          },
+          EmployerAddress: {},
+        },
+        expected: false,
+      },
+      {
+        data: {
+          EmployerAddressNotApplicable: {
+            applicable: true,
           },
           EmployerAddress: {
             country: { value: 'United States' },
@@ -535,72 +535,72 @@ describe('Foreign contacts component validation', function() {
             city: 'Arlington',
             state: 'VA',
             zipcode: '22202',
-            layout: Location.ADDRESS
-          }
+            layout: Location.ADDRESS,
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignNationalValidator, 'validEmployerAddress')
   })
 
-  it('validate foreign national affiliations', function() {
+  it('validate foreign national affiliations', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
-          HasAffiliations: { value: 'No' }
+          HasAffiliations: { value: 'No' },
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
-          HasAffiliations: { value: "I don't know" }
+          HasAffiliations: { value: "I don't know" },
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
           HasAffiliations: { value: 'Yes' },
-          Affiliations: {}
+          Affiliations: {},
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
           HasAffiliations: { value: 'Yes' },
           Affiliations: {
-            value: 'list of my affiliations'
-          }
+            value: 'list of my affiliations',
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignNationalValidator, 'validAffiliations')
   })
 
-  it('validate foreign contacts', function() {
+  it('validate foreign contacts', () => {
     const tests = [
       {
         data: {},
-        expected: false
+        expected: false,
       },
       {
         data: {
-          HasForeignContacts: { value: 'No' }
+          HasForeignContacts: { value: 'No' },
         },
-        expected: true
+        expected: true,
       },
       {
         data: {
-          HasForeignContacts: { value: 'Yes' }
+          HasForeignContacts: { value: 'Yes' },
         },
-        expected: false
+        expected: false,
       },
       {
         data: {
@@ -611,53 +611,56 @@ describe('Foreign contacts component validation', function() {
               {
                 Item: {
                   NameNotApplicable: {
-                    applicable: false
+                    applicable: false,
                   },
                   NameExplanation: {
-                    value: 'explanation'
+                    value: 'explanation',
                   },
                   FirstContact: {
                     day: '1',
                     month: '1',
-                    year: '2016'
+                    year: '2016',
                   },
                   LastContact: {
                     day: '1',
                     month: '1',
-                    year: '2016'
+                    year: '2016',
                   },
                   Methods: { values: ['In person'] },
                   Frequency: { value: 'Weekly' },
                   Relationship: { values: ['Personal'] },
                   Aliases: {
-                    items: [{ Item: { Has: { value: 'No' } } }]
+                    items: [{ Item: { Has: { value: 'No' } } }],
                   },
                   Citizenship: {
-                    value: ['United States']
+                    value: ['United States'],
                   },
                   BirthdateNotApplicable: {
-                    applicable: false
+                    applicable: false,
                   },
                   BirthplaceNotApplicable: {
-                    applicable: false
+                    applicable: false,
                   },
                   AddressNotApplicable: {
-                    applicable: false
+                    applicable: false,
                   },
                   EmployerNotApplicable: {
-                    applicable: false
+                    applicable: false,
                   },
                   EmployerAddressNotApplicable: {
-                    applicable: false
+                    applicable: false,
                   },
-                  HasAffiliations: { value: 'No' }
-                }
-              }
-            ]
-          }
+                  HasAffiliations: { value: 'No' },
+                  AlternateAddress: {
+                    HasDifferentAddress: { value: 'No' },
+                  },
+                },
+              },
+            ],
+          },
         },
-        expected: true
-      }
+        expected: true,
+      },
     ]
 
     battery(tests, ForeignContactsValidator, 'isValid')

--- a/src/validators/relatives.test.js
+++ b/src/validators/relatives.test.js
@@ -1931,6 +1931,9 @@ describe('Relatives validation', () => {
                     zipcode: '22202',
                     layout: Location.ADDRESS,
                   },
+                  AlternateAddress: {
+                    HasDifferentAddress: { value: 'No' },
+                  },
                 },
               },
               {
@@ -2016,6 +2019,9 @@ describe('Relatives validation', () => {
                     state: 'VA',
                     zipcode: '22202',
                     layout: Location.ADDRESS,
+                  },
+                  AlternateAddress: {
+                    HasDifferentAddress: { value: 'No' },
                   },
                 },
               },


### PR DESCRIPTION
## Description

- Adds `militaryAddress` option to address & physicalAddress models to enforce or disallow military addresses
- Adds AlternateAddress validations to residence, employment, and civilUnion models if Address (`Address, ReferenceAddress, PhysicalAddress`) is international (optional PO address) or military (required physical address)
- Adds AlternateAddress validations to relative & foreignContact models (optional PO address fields)

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Try loading tests cases and make sure they validate
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
