### PR TITLE
[EN-3853] Fix false positives in isInternational check

### DIFF
--- a/src/helpers/location.js
+++ b/src/helpers/location.js
@@ -10,5 +10,5 @@ export const isUS = location => (
 )
 
 export const isInternational = location => (
-  !isPO(location) && !isUS(location)
+  location && location.country && (!isPO(location) && !isUS(location))
 )

--- a/src/models/__tests__/employment.test.js
+++ b/src/models/__tests__/employment.test.js
@@ -116,6 +116,24 @@ describe('The employment model', () => {
         .toEqual(expect.arrayContaining(expectedErrors))
     })
 
+    describe('if there is no ReferenceAddress', () => {
+      it('ReferenceAlternateAddress is not required', () => {
+        const testData = {
+          ReferenceAddress: {},
+          ReferenceAlternateAddress: {
+            HasDifferentAddress: {},
+            Address: {},
+            Telephone: {},
+          },
+        }
+
+        const expectedErrors = ['ReferenceAlternateAddress.model']
+
+        expect(validateModel(testData, employment))
+          .not.toEqual(expect.arrayContaining(expectedErrors))
+      })
+    })
+
     describe('if the ReferenceAddress field is international', () => {
       it('ReferenceAlternateAddress is required', () => {
         const testData = {


### PR DESCRIPTION
## Description

Issue was the `isInternational` helper returned true for an empty location object, resulting in the employer `ReferenceAlternateAddress` thinking it was required and invalidating the employment item. Also added a test case to verify the regression itself.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
