### PR TITLE
[SF85] Remove unnecessary validators that don't belong to the SF85

### DIFF
--- a/src/models/__tests__/drugUse.test.js
+++ b/src/models/__tests__/drugUse.test.js
@@ -206,10 +206,11 @@ describe('The drugUse model', () => {
       const testData = {}
       const expectedErrors = [
         'UseInFuture.presence.REQUIRED',
+        'Explanation.presence.REQUIRED',
       ]
 
       expect(validateModel(testData, drugUse, { requireUseInFuture: false }))
-        .not.toEqual(expect.arrayContaining(expectedErrors))
+        .toEqual(expect.not.arrayContaining(expectedErrors))
     })
 
     it('passes a valid drugUse', () => {
@@ -220,7 +221,6 @@ describe('The drugUse model', () => {
         NatureOfUse: { value: 'Testing' },
         UseWithClearance: { value: 'No' },
         UseWhileEmployed: { value: 'Yes' },
-        Explanation: { value: 'testing' },
       }
 
       expect(validateModel(testData, drugUse, { requireUseInFuture: false }))

--- a/src/models/__tests__/offense.test.js
+++ b/src/models/__tests__/offense.test.js
@@ -41,26 +41,29 @@ describe('The offense model', () => {
   })
 
   it('the InvolvedViolence field must have a valid value', () => {
+    const options = { requireLegalOffenseInvolvements: true }
     const testData = { InvolvedViolence: { value: 'true' } }
     const expectedErrors = ['InvolvedViolence.hasValue.value.inclusion.INCLUSION']
 
-    expect(validateModel(testData, offense))
+    expect(validateModel(testData, offense, options))
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
   it('the InvolvedFirearms field must have a valid value', () => {
+    const options = { requireLegalOffenseInvolvements: true }
     const testData = { InvolvedFirearms: { value: 'false' } }
     const expectedErrors = ['InvolvedFirearms.hasValue.value.inclusion.INCLUSION']
 
-    expect(validateModel(testData, offense))
+    expect(validateModel(testData, offense, options))
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
   it('the InvolvedSubstances field must have a valid value', () => {
+    const options = { requireLegalOffenseInvolvements: true }
     const testData = { InvolvedSubstances: { value: 100 } }
     const expectedErrors = ['InvolvedSubstances.hasValue.value.inclusion.INCLUSION']
 
-    expect(validateModel(testData, offense))
+    expect(validateModel(testData, offense, options))
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
@@ -391,6 +394,10 @@ describe('The offense model', () => {
       })
 
       it('the Sentence field must be a valid Sentence', () => {
+        const options = {
+          requireLegalOffenseSentenced: true,
+          requireLegalOffenseIncarcerated: true,
+        }
         const testData = {
           WasCharged: { value: 'Yes' },
           WasSentenced: { value: 'Yes' },
@@ -410,7 +417,7 @@ describe('The offense model', () => {
           'Sentence.model.ProbationDates.presence.REQUIRED',
         ]
 
-        expect(validateModel(testData, offense))
+        expect(validateModel(testData, offense, options))
           .toEqual(expect.arrayContaining(expectedErrors))
       })
 

--- a/src/models/__tests__/otherOffense.test.js
+++ b/src/models/__tests__/otherOffense.test.js
@@ -204,6 +204,10 @@ describe('The offense model', () => {
     })
 
     it('the Sentence field must be a valid Sentence', () => {
+      const options = {
+        requireLegalOffenseSentenced: true,
+        requireLegalOffenseIncarcerated: true,
+      }
       const testData = {
         WasSentenced: { value: 'Yes' },
         Sentence: {
@@ -222,7 +226,7 @@ describe('The offense model', () => {
         'Sentence.model.ProbationDates.presence.REQUIRED',
       ]
 
-      expect(validateModel(testData, offense))
+      expect(validateModel(testData, offense, options))
         .toEqual(expect.arrayContaining(expectedErrors))
     })
 

--- a/src/models/drugUse.js
+++ b/src/models/drugUse.js
@@ -24,7 +24,10 @@ const drugUse = {
     return { presence: true, date: { requireDay: false, ...dateLimits } }
   },
   NatureOfUse: { presence: true, hasValue: true },
-  Explanation: { presence: true, hasValue: true },
+  Explanation: (value, attributes, attributeName, options) => {
+    if (options && options.requireUseInFuture === false) return {}
+    return { presence: true, hasValue: true }
+  },
   UseWhileEmployed: (value, attributes, attributeName, options) => {
     if (options && options.requireUseWhileEmployed === false) return {}
     return { presence: true, hasValue: { validator: hasYesOrNo } }

--- a/src/models/offense.js
+++ b/src/models/offense.js
@@ -6,17 +6,32 @@ import { offenseChargeTypes } from 'constants/enums/legalOptions'
 const offense = {
   Date: { presence: true, date: true },
   Description: { presence: true, hasValue: true },
-  InvolvedViolence: {
-    presence: true,
-    hasValue: { validator: hasYesOrNo },
+  InvolvedViolence: (value, attributes, attributeName, options) => {
+    if (options.requireLegalOffenseInvolvements) {
+      return {
+        presence: true,
+        hasValue: { validator: hasYesOrNo },
+      }
+    }
+    return {}
   },
-  InvolvedFirearms: {
-    presence: true,
-    hasValue: { validator: hasYesOrNo },
+  InvolvedFirearms: (value, attributes, attributeName, options) => {
+    if (options.requireLegalOffenseInvolvements) {
+      return {
+        presence: true,
+        hasValue: { validator: hasYesOrNo },
+      }
+    }
+    return {}
   },
-  InvolvedSubstances: {
-    presence: true,
-    hasValue: { validator: hasYesOrNo },
+  InvolvedSubstances: (value, attributes, attributeName, options) => {
+    if (options.requireLegalOffenseInvolvements) {
+      return {
+        presence: true,
+        hasValue: { validator: hasYesOrNo },
+      }
+    }
+    return {}
   },
   Address: {
     presence: true,

--- a/src/models/shared/__tests__/sentence.test.js
+++ b/src/models/shared/__tests__/sentence.test.js
@@ -19,18 +19,20 @@ describe('The sentence model', () => {
   })
 
   it('the ExceedsYear field must have a valid value', () => {
+    const options = { requireLegalOffenseSentenced: true }
     const testData = { ExceedsYear: { value: 'true' } }
     const expectedErrors = ['ExceedsYear.hasValue.value.inclusion.INCLUSION']
 
-    expect(validateModel(testData, sentence))
+    expect(validateModel(testData, sentence, options))
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
   it('the Incarcerated field must have a valid value', () => {
+    const options = { requireLegalOffenseIncarcerated: true }
     const testData = { Incarcerated: { value: 'false' } }
     const expectedErrors = ['Incarcerated.hasValue.value.inclusion.INCLUSION']
 
-    expect(validateModel(testData, sentence))
+    expect(validateModel(testData, sentence, options))
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
@@ -218,6 +220,28 @@ describe('The sentence model', () => {
       }
 
       expect(validateModel(testData, sentence)).toEqual(true)
+    })
+  })
+
+  describe('requireLegalOffenseSentenced is false', () => {
+    it('the ExceedsYear is not required', () => {
+      const options = { requireLegalOffenseSentenced: false }
+      const testData = { ExceedsYear: { value: 'true' } }
+      const expectedErrors = ['ExceedsYear.hasValue.value.inclusion.INCLUSION']
+
+      expect(validateModel(testData, sentence, options))
+        .toEqual(expect.not.arrayContaining(expectedErrors))
+    })
+  })
+
+  describe('requireLegalOffenseIncarcerated is false', () => {
+    it('the Incarcerated field is not required', () => {
+      const options = { requireLegalOffenseIncarcerated: false }
+      const testData = { Incarcerated: { value: 'false' } }
+      const expectedErrors = ['Incarcerated.hasValue.value.inclusion.INCLUSION']
+
+      expect(validateModel(testData, sentence, options))
+        .toEqual(expect.not.arrayContaining(expectedErrors))
     })
   })
 })

--- a/src/models/shared/sentence.js
+++ b/src/models/shared/sentence.js
@@ -2,13 +2,24 @@ import { hasYesOrNo } from 'models/validate'
 
 const sentence = {
   Description: { presence: true, hasValue: true },
-  ExceedsYear: {
-    presence: true,
-    hasValue: { validator: hasYesOrNo },
+  ExceedsYear: (value, attributes, attributeName, options) => {
+    console.log('ExceedsYear options', options)
+    if (options.requireLegalOffenseSentenced) {
+      return {
+        presence: true,
+        hasValue: { validator: hasYesOrNo },
+      }
+    }
+    return {}
   },
-  Incarcerated: {
-    presence: true,
-    hasValue: { validator: hasYesOrNo },
+  Incarcerated: (value, attributes, attributeName, options) => {
+    if (options.requireLegalOffenseIncarcerated) {
+      return {
+        presence: true,
+        hasValue: { validator: hasYesOrNo },
+      }
+    }
+    return {}
   },
   IncarcerationDates: (value, attributes) => {
     if (attributes.IncarcerationDatesNA

--- a/src/validators/offense.js
+++ b/src/validators/offense.js
@@ -1,130 +1,149 @@
+import store from 'services/store'
 import { validateModel } from 'models/validate'
 import offense from 'models/offense'
+import {
+  requireLegalOffenseInvolvements,
+  requireLegalOffenseSentenced,
+  requireLegalOffenseIncarcerated,
+} from 'helpers/branches'
 
-export const validateOffense = data => validateModel(data, offense) === true
+const options = formType => (
+  {
+    requireLegalOffenseInvolvements: requireLegalOffenseInvolvements(formType),
+    requireLegalOffenseSentenced: requireLegalOffenseSentenced(formType),
+    requireLegalOffenseIncarcerated: requireLegalOffenseIncarcerated(formType),
+  }
+)
+
+export const validateOffense = (data, formType) => (
+  validateModel(data, offense, options(formType)) === true
+)
 
 export default class OffenseValidator {
   constructor(data = {}) {
+    const state = store.getState()
+    const { formType } = state.application.Settings
     this.data = data
+    this.formType = formType
   }
 
   validDate() {
     return validateModel(this.data, {
       Date: offense.Date,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validDescription() {
     return validateModel(this.data, {
       Description: offense.Description,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validViolence() {
     return validateModel(this.data, {
       InvolvedViolence: offense.InvolvedViolence,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validFirearms() {
     return validateModel(this.data, {
       InvolvedFirearms: offense.InvolvedFirearms,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validSubstances() {
     return validateModel(this.data, {
       InvolvedSubstances: offense.InvolvedSubstances,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validAddress() {
     return validateModel(this.data, {
       Address: offense.Address,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validCited() {
     return validateModel(this.data, {
       WasCited: offense.WasCited,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validCitedBy() {
     return validateModel(this.data, {
       CitedBy: offense.CitedBy,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validAgencyAddress() {
     return validateModel(this.data, {
       AgencyAddress: offense.AgencyAddress,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validCharged() {
     return validateModel(this.data, {
       WasCharged: offense.WasCharged,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validExplanation() {
     return validateModel(this.data, {
       Explanation: offense.Explanation,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validCourtName() {
     return validateModel(this.data, {
       CourtName: offense.CourtName,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validCourtAddress() {
     return validateModel(this.data, {
       CourtAddress: offense.CourtAddress,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validChargeType() {
     return validateModel(this.data, {
       ChargeType: offense.ChargeType,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validCourtCharge() {
     return validateModel(this.data, {
       CourtCharge: offense.CourtCharge,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validCourtOutcome() {
     return validateModel(this.data, {
       CourtOutcome: offense.CourtOutcome,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validCourtDate() {
     return validateModel(this.data, {
       CourtDate: offense.CourtDate,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validSentenced() {
     return validateModel(this.data, {
       WasSentenced: offense.WasSentenced,
       Sentence: offense.Sentence,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validAwaitingTrial() {
     return validateModel(this.data, {
       AwaitingTrial: offense.AwaitingTrial,
       AwaitingTrialExplanation: offense.AwaitingTrialExplanation,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   isValid() {
-    return validateOffense(this.data)
+    return validateOffense(this.data, this.formType)
   }
 }

--- a/src/validators/policeoffenses.js
+++ b/src/validators/policeoffenses.js
@@ -1,7 +1,19 @@
+import store from 'services/store'
 import { validateModel, hasYesOrNo, checkValue } from 'models/validate'
 import offense from 'models/offense'
+import {
+  requireLegalOffenseInvolvements,
+  requireLegalOffenseSentenced,
+  requireLegalOffenseIncarcerated,
+} from 'helpers/branches'
 
-export const validatePoliceOffenses = (data) => {
+export const validatePoliceOffenses = (data, formType) => {
+  const options = {
+    requireLegalOffenseInvolvements: requireLegalOffenseInvolvements(formType),
+    requireLegalOffenseSentenced: requireLegalOffenseSentenced(formType),
+    requireLegalOffenseIncarcerated: requireLegalOffenseIncarcerated(formType),
+  }
+
   const policeOffensesModel = {
     HasOffenses: { presence: true, hasValue: { validator: hasYesOrNo } },
     List: (value, attributes) => (
@@ -13,15 +25,18 @@ export const validatePoliceOffenses = (data) => {
     ),
   }
 
-  return validateModel(data, policeOffensesModel) === true
+  return validateModel(data, policeOffensesModel, options) === true
 }
 
 export default class PoliceOffensesValidator {
   constructor(data = {}) {
+    const state = store.getState()
+    const { formType } = state.application.Settings
     this.data = data
+    this.formType = formType
   }
 
   isValid() {
-    return validatePoliceOffenses(this.data)
+    return validatePoliceOffenses(this.data, this.formType)
   }
 }

--- a/src/validators/sentence.js
+++ b/src/validators/sentence.js
@@ -1,33 +1,50 @@
+import store from 'services/store'
 import { validateModel } from 'models/validate'
 import sentence from 'models/shared/sentence'
+import {
+  requireLegalOffenseSentenced,
+  requireLegalOffenseIncarcerated,
+} from 'helpers/branches'
 
-export const validateSentence = data => validateModel(data, sentence) === true
+const options = formType => (
+  {
+    requireLegalOffenseSentenced: requireLegalOffenseSentenced(formType),
+    requireLegalOffenseIncarcerated: requireLegalOffenseIncarcerated(formType),
+  }
+)
+
+export const validateSentence = (data, formType) => (
+  validateModel(data, sentence, options(formType)) === true
+)
 
 export default class SentenceValidator {
   constructor(data = {}) {
+    const state = store.getState()
+    const { formType } = state.application.Settings
     this.data = data
+    this.formType = formType
   }
 
   validChecks() {
     return validateModel(this.data, {
       ExceedsYear: sentence.ExceedsYear,
       Incarcerated: sentence.Incarcerated,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validIncarcerationDates() {
     return validateModel(this.data, {
       IncarcerationDates: sentence.IncarcerationDates,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   validProbationDates() {
     return validateModel(this.data, {
       ProbationDates: sentence.ProbationDates,
-    }) === true
+    }, options(this.formType)) === true
   }
 
   isValid() {
-    return validateSentence(this.data)
+    return validateSentence(this.data, this.formType)
   }
 }


### PR DESCRIPTION
## Description
The following fields still have validations running against them even though they aren't present on the SF85.

| Section | Form Tracking Row |
| -------- | ------------------- | 
| Substance Use / Illegal Use of Drugs and Drug Activity / Usage | 680 |
| Investigative and criminal history / Police record / Offenses |  624-626 |
| Investigative and criminal history / Police record / Offenses | 639-640 |

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)