### PR TITLE
[EN-3793] Update US Passports to use local state to control suggestions model

### DIFF
--- a/src/components/Form/Suggestions/Suggestions.jsx
+++ b/src/components/Form/Suggestions/Suggestions.jsx
@@ -1,60 +1,63 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { newGuid } from '../ValidationElement'
 import Modal from '../Modal'
 
 export default class Suggestions extends React.Component {
-  constructor(props) {
-    super(props)
-    this.dismissSuggestions = this.dismissSuggestions.bind(this)
-  }
-
   /**
    * Use a suggestion given.
    */
-  useSuggestion(suggestion) {
-    this.props.onSuggestion(suggestion)
+  useSuggestion = (suggestion) => {
+    const { onSuggestion } = this.props
+    onSuggestion(suggestion)
   }
 
   /**
    * This allows the user to bypass the suggestions and add something else
    * we have never seen before.
    */
-  dismissSuggestions(action = 'dismiss') {
-    this.props.onDismiss(action)
+  dismissSuggestions = (action = 'dismiss') => {
+    const { onDismiss } = this.props
+    onDismiss(action)
   }
 
   /**
    * Return the possible suggestions or an empty value if there is nothing to present.
    */
-  suggestions() {
-    return this.props.suggestions.map(suggestion => {
-      return (
-        <div className="suggestion" key={newGuid()}>
-          <div className="value">
-            <h5>{this.props.suggestionLabel}</h5>
-            {this.props.renderSuggestion(suggestion)}
-          </div>
-          <div className="action">
-            <button
-              className="suggestion-btn"
-              onClick={this.useSuggestion.bind(this, suggestion)}>
-              <span>{this.props.suggestionUseLabel}</span>
-              <i className="fa fa-arrow-circle-right" />
-            </button>
-          </div>
+  suggestions = () => {
+    const {
+      suggestions, suggestionLabel, renderSuggestion, suggestionUseLabel,
+    } = this.props
+    return suggestions.map(suggestion => (
+      <div className="suggestion" key={newGuid()}>
+        <div className="value">
+          <h5>{suggestionLabel}</h5>
+          {renderSuggestion(suggestion)}
         </div>
-      )
-    })
+        <div className="action">
+          <button
+            type="button"
+            className="suggestion-btn"
+            onClick={this.useSuggestion}
+          >
+            <span>{suggestionUseLabel}</span>
+            <i className="fa fa-arrow-circle-right" />
+          </button>
+        </div>
+      </div>
+    ))
   }
 
-  alternate() {
-    if (this.props.suggestionDismissAlternate) {
+  alternate = () => {
+    const { suggestionDismissAlternate } = this.props
+    if (suggestionDismissAlternate) {
       return (
         <a
-          href="javascript:;;"
+          href="javascript:;;;"
           className="right"
-          onClick={this.dismissSuggestions.bind(this, 'alternate')}>
-          <span>{this.props.suggestionDismissAlternate}</span>
+          onClick={() => this.dismissSuggestions('alternate')}
+        >
+          <span>{suggestionDismissAlternate}</span>
           <i className="fa fa-arrow-circle-right" />
         </a>
       )
@@ -64,27 +67,29 @@ export default class Suggestions extends React.Component {
   }
 
   render() {
-    // Append on any classes passed down
-    const klass = `${this.props.className}`.trim()
+    const {
+      className, show, suggestionTitle, suggestionParagraph, suggestionDismissContent, suggestionDismissLabel,
+    } = this.props
 
-    // When there is nothing special do the status quo
     return (
       <Modal
-        show={this.props.show}
+        show={show}
         closeable={true}
-        onDismiss={this.dismissSuggestions.bind(this, 'modal')}
-        className="suggestions">
-        <h3>{this.props.suggestionTitle}</h3>
-        {this.props.suggestionParagraph}
+        onDismiss={() => this.dismissSuggestions('modal')}
+        className="suggestions"
+      >
+        <h3>{suggestionTitle}</h3>
+        {suggestionParagraph}
 
-        <div className={klass}>
+        <div className={className}>
           {this.suggestions()}
           <div className="dismiss">
-            {this.props.suggestionDismissContent}
+            {suggestionDismissContent}
             <a
-              href="javascript:;;"
-              onClick={this.dismissSuggestions.bind(this, 'dismiss')}>
-              <span>{this.props.suggestionDismissLabel}</span>
+              href="javascript:;;;"
+              onClick={() => this.dismissSuggestions('dismiss')}
+            >
+              <span>{suggestionDismissLabel}</span>
               <i className="fa fa-arrow-circle-right" />
             </a>
             {this.alternate()}
@@ -95,17 +100,34 @@ export default class Suggestions extends React.Component {
   }
 }
 
+Suggestions.propTypes = {
+  suggestions: PropTypes.array,
+  suggestionTitle: PropTypes.string,
+  suggestionParagraph: PropTypes.string,
+  suggestionLabel: PropTypes.string,
+  suggestionDismissLabel: PropTypes.string,
+  suggestionDismissContent: PropTypes.string,
+  suggestionDismissAlternate: PropTypes.string,
+  suggestionUseLabel: PropTypes.string,
+  className: PropTypes.string,
+  show: PropTypes.bool,
+  renderSuggestion: PropTypes.func,
+  onSuggestion: PropTypes.func,
+  onDismiss: PropTypes.func,
+}
+
 Suggestions.defaultProps = {
+  suggestions: [],
   suggestionTitle: '',
-  suggestionParagrah: '',
+  suggestionParagraph: '',
   suggestionLabel: '',
   suggestionDismissLabel: '',
+  suggestionDismissContent: '',
   suggestionDismissAlternate: '',
   suggestionUseLabel: '',
-  suggestions: [],
   className: '',
   show: false,
-  renderSuggestion: suggestion => {},
-  onSuggestion: suggestion => {},
-  onDismiss: () => {}
+  renderSuggestion: () => {},
+  onSuggestion: () => {},
+  onDismiss: () => {},
 }

--- a/src/components/Form/Suggestions/Suggestions.jsx
+++ b/src/components/Form/Suggestions/Suggestions.jsx
@@ -28,8 +28,10 @@ export default class Suggestions extends React.Component {
     const {
       suggestions, suggestionLabel, renderSuggestion, suggestionUseLabel,
     } = this.props
-    return suggestions.map(suggestion => (
-      <div className="suggestion" key={newGuid()}>
+    return suggestions.map((suggestion, i) => (
+      <div
+        className="suggestion" key={`suggestion-${i}`}
+      >
         <div className="value">
           <h5>{suggestionLabel}</h5>
           {renderSuggestion(suggestion)}
@@ -38,7 +40,7 @@ export default class Suggestions extends React.Component {
           <button
             type="button"
             className="suggestion-btn"
-            onClick={this.useSuggestion}
+            onClick={() => this.useSuggestion(suggestion)}
           >
             <span>{suggestionUseLabel}</span>
             <i className="fa fa-arrow-circle-right" />
@@ -80,7 +82,6 @@ export default class Suggestions extends React.Component {
       >
         <h3>{suggestionTitle}</h3>
         {suggestionParagraph}
-
         <div className={className}>
           {this.suggestions()}
           <div className="dismiss">

--- a/src/components/Section/Citizenship/UsPassport/index.jsx
+++ b/src/components/Section/Citizenship/UsPassport/index.jsx
@@ -41,6 +41,9 @@ export class UsPassport extends Subsection {
     this.storeKey = storeKey
 
     this.number = null
+    this.state = {
+      showSuggestionsModal: this.showSuggestions(),
+    }
   }
 
   update = (queue, fn) => {
@@ -123,14 +126,11 @@ export class UsPassport extends Subsection {
   onSuggestion = (suggestion) => {
     this.update({
       Name: suggestion,
-      suggestedNames: [],
     })
   }
 
   onDismiss = () => {
-    this.update({
-      suggestedNames: [],
-    })
+    this.setState({ showSuggestionsModal: false })
   }
 
   showSuggestions = () => {
@@ -140,7 +140,7 @@ export class UsPassport extends Subsection {
     }
 
     // If we have suggestions, show them
-    return this.props.suggestedNames.length
+    return !!this.props.suggestedNames.length
   }
 
   passportBeforeCutoff = () => {
@@ -157,6 +157,7 @@ export class UsPassport extends Subsection {
   }
 
   render() {
+    const { showSuggestionsModal } = this.state
     const numberLength = this.passportBeforeCutoff() ? '255' : '9'
     const numberRegEx = this.passportBeforeCutoff()
       ? '^[a-zA-Z0-9]*$'
@@ -190,7 +191,7 @@ export class UsPassport extends Subsection {
               className="no-margin-bottom"
             />
             <Suggestions
-              show={this.showSuggestions()}
+              show={showSuggestionsModal}
               suggestions={this.props.suggestedNames}
               renderSuggestion={this.renderSuggestion}
               withSuggestions={true}

--- a/src/components/Section/Citizenship/UsPassport/index.jsx
+++ b/src/components/Section/Citizenship/UsPassport/index.jsx
@@ -127,6 +127,8 @@ export class UsPassport extends Subsection {
     this.update({
       Name: suggestion,
     })
+
+    this.setState({ showSuggestionsModal: false })
   }
 
   onDismiss = () => {


### PR DESCRIPTION
## Description
This PR fixes the issue where applicants aren't able to exit the "Alternate names" modal by clicking `Use a different name instead`. This modal shows up if an applicant has indicated they have had another name in the Identification section.

This fix leverages local component state rather than manipulating data and sending it up and down the component tree.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
