### PR TITLE
[EN-3850] Finish connecting validation state

### DIFF
--- a/src/components/Form/Accordion/Accordion.jsx
+++ b/src/components/Form/Accordion/Accordion.jsx
@@ -536,14 +536,8 @@ export default class Accordion extends ValidationElement {
    * */
   isValid(item, uuid) {
     if (this.props.required) {
-      try {
-        return this.props.validator(item) === true && this.hasNoErrors(uuid)
-      } catch (e) {
-        // eslint-disable-next-line new-cap
-        return new this.props.validator(item).isValid() === true && this.hasNoErrors(uuid)
-      }
+      return new this.props.validator(item).isValid() === true && this.hasNoErrors(uuid)
     }
-
     return true
   }
 

--- a/src/components/Form/Accordion/Accordion.jsx
+++ b/src/components/Form/Accordion/Accordion.jsx
@@ -536,8 +536,14 @@ export default class Accordion extends ValidationElement {
    * */
   isValid(item, uuid) {
     if (this.props.required) {
-      return new this.props.validator(item).isValid() && this.hasNoErrors(uuid)
+      try {
+        return this.props.validator(item) === true && this.hasNoErrors(uuid)
+      } catch (e) {
+        // eslint-disable-next-line new-cap
+        return new this.props.validator(item).isValid() === true && this.hasNoErrors(uuid)
+      }
     }
+
     return true
   }
 

--- a/src/components/Section/History/Education/Education.jsx
+++ b/src/components/Section/History/Education/Education.jsx
@@ -67,7 +67,7 @@ export class Education extends Subsection {
       overrideInitial,
       'history.education.collection.school.summary.incomplete',
       this.props.required,
-      i => new EducationItemValidator(i).isValid(),
+      i => new EducationItemValidator(i).isValid() === true,
     )
   }
 

--- a/src/components/Section/History/Education/EducationSummaryProgress.jsx
+++ b/src/components/Section/History/Education/EducationSummaryProgress.jsx
@@ -30,7 +30,7 @@ const diplomasRangesList = (items) => {
   items.forEach((i) => {
     if (!i.Item) { return }
 
-    if (!new EducationItemValidator(i.Item).isValid() === true) {
+    if (new EducationItemValidator(i.Item).isValid() !== true) {
       return
     }
 

--- a/src/components/Section/History/Education/EducationSummaryProgress.jsx
+++ b/src/components/Section/History/Education/EducationSummaryProgress.jsx
@@ -16,7 +16,7 @@ const schoolRangesList = (items) => {
       return
     }
 
-    if (new EducationItemValidator(i.Item).isValid()) {
+    if (new EducationItemValidator(i.Item).isValid() === true) {
       dates.push(i.Item.Dates)
     }
   })
@@ -30,7 +30,7 @@ const diplomasRangesList = (items) => {
   items.forEach((i) => {
     if (!i.Item) { return }
 
-    if (!new EducationItemValidator(i.Item).isValid()) {
+    if (!new EducationItemValidator(i.Item).isValid() === true) {
       return
     }
 

--- a/src/components/Section/History/Education/EducationWrapper.jsx
+++ b/src/components/Section/History/Education/EducationWrapper.jsx
@@ -35,7 +35,7 @@ class EducationWrapper extends React.Component {
       reportCompletion(
         'history',
         'education',
-        new HistoryEducationValidator(education, education).isValid(),
+        new HistoryEducationValidator(education, education).isValid() === true,
       ),
     )
   }
@@ -51,7 +51,7 @@ class EducationWrapper extends React.Component {
       reportCompletion(
         'history',
         'education',
-        new HistoryEducationValidator(education, education).isValid(),
+        new HistoryEducationValidator(education, education).isValid() === true,
       ),
     )
   }

--- a/src/components/Section/History/Education/EducationWrapper.jsx
+++ b/src/components/Section/History/Education/EducationWrapper.jsx
@@ -17,6 +17,7 @@ import ConnectedEducation from './Education'
 import EducationSummaryProgress from './EducationSummaryProgress'
 
 const sectionConfig = {
+  key: HISTORY_EDUCATION.key,
   section: HISTORY.name,
   store: HISTORY.store,
   subsection: HISTORY_EDUCATION.name,

--- a/src/components/Section/History/Employment/Employment.jsx
+++ b/src/components/Section/History/Employment/Employment.jsx
@@ -73,7 +73,7 @@ export class Employment extends Subsection {
       overrideInitial,
       'history.employment.default.collection.summary.incomplete',
       this.props.required,
-      i => new EmploymentValidator(i).isValid(),
+      i => new EmploymentValidator(i).isValid() === true,
     )
   }
 

--- a/src/components/Section/History/Employment/EmploymentSummaryProgress.jsx
+++ b/src/components/Section/History/Employment/EmploymentSummaryProgress.jsx
@@ -15,7 +15,7 @@ const dateRangeList = (items) => {
   items.forEach((i) => {
     if (!i.Item) { return }
 
-    if (new EmploymentValidator(i.Item).isValid()) {
+    if (new EmploymentValidator(i.Item).isValid() === true) {
       dates.push(i.Item.Dates)
     }
   })

--- a/src/components/Section/History/Residence/Residence.jsx
+++ b/src/components/Section/History/Residence/Residence.jsx
@@ -75,7 +75,7 @@ export class Residence extends Subsection {
       overrideInitial,
       'history.residence.collection.summary.incomplete',
       this.props.required,
-      i => new ResidenceValidator(i, null).isValid(),
+      i => new ResidenceValidator(i, null).isValid() === true,
     )
   }
 
@@ -179,7 +179,7 @@ Residence.defaultProps = {
   onError: (value, arr) => arr,
   addressBooks: {},
   dispatch: () => {},
-  validator: data => new HistoryResidenceValidator(data).isValid(),
+  validator: data => new HistoryResidenceValidator(data).isValid() === true,
 }
 
 export default connectSubsection(Residence, sectionConfig)

--- a/src/components/Section/History/Residence/ResidenceSummaryProgress.jsx
+++ b/src/components/Section/History/Residence/ResidenceSummaryProgress.jsx
@@ -15,7 +15,7 @@ const dateRangeList = (items) => {
   items.forEach((i) => {
     if (!i.Item) { return }
 
-    if (new ResidenceValidator(i.Item).isValid()) {
+    if (new ResidenceValidator(i.Item).isValid() === true) {
       dates.push(i.Item.Dates)
     }
   })

--- a/src/components/Section/History/summaries.jsx
+++ b/src/components/Section/History/summaries.jsx
@@ -121,7 +121,7 @@ export const ResidenceCustomSummary = (
 ) => {
   return CustomSummary(
     x => {
-      return new ResidenceValidator(x, null).isValid()
+      return new ResidenceValidator(x, null).isValid() === true
     },
     (x, e) => {
       return ResidenceSummary(x, index, e, item.open)
@@ -235,7 +235,7 @@ export const EmploymentCustomSummary = (
 ) => {
   return CustomSummary(
     x => {
-      return new EmploymentValidator(x).isValid()
+      return new EmploymentValidator(x).isValid() === true
     },
     (x, e) => {
       return EmploymentSummary(x, index, e, item.open)
@@ -321,7 +321,7 @@ export const EducationCustomSummary = (
 ) => {
   return CustomSummary(
     x => {
-      return new EducationItemValidator(x).isValid()
+      return new EducationItemValidator(x).isValid() === true
     },
     (x, e) => {
       return EducationSummary(x, index, e, item.open)

--- a/src/components/Section/Identification/ApplicantName/ApplicantName.jsx
+++ b/src/components/Section/Identification/ApplicantName/ApplicantName.jsx
@@ -91,7 +91,7 @@ ApplicantName.defaultProps = {
   onError: (value, arr) => arr,
   dispatch: () => {},
   required: false,
-  validator: data => validate(schema('identification.name', data)),
+  validator: data => validate(schema('identification.name', data)) === true,
 }
 
 ApplicantName.errors = []

--- a/src/components/Section/Identification/ContactInformation/ContactInformation.jsx
+++ b/src/components/Section/Identification/ContactInformation/ContactInformation.jsx
@@ -235,7 +235,7 @@ ContactInformation.defaultProps = {
   onError: (value, arr) => arr,
   dispatch: () => {},
   validator: data => (
-    new IdentificationContactInformationValidator(data).isValid()
+    new IdentificationContactInformationValidator(data).isValid() === true
   ),
   defaultState: true,
   isReview: false,

--- a/src/components/Section/Relationships/People/People.jsx
+++ b/src/components/Section/Relationships/People/People.jsx
@@ -121,7 +121,7 @@ export class People extends Subsection {
 
   peopleSummaryList = () => (
     this.excludeGaps(this.props.List.items).reduce((dates, item) => {
-      if (!item || !new PersonValidator(item.Item).isValid() === true) {
+      if (!item || new PersonValidator(item.Item).isValid() !== true) {
         return dates
       }
 

--- a/src/components/Section/Relationships/People/People.jsx
+++ b/src/components/Section/Relationships/People/People.jsx
@@ -121,7 +121,7 @@ export class People extends Subsection {
 
   peopleSummaryList = () => (
     this.excludeGaps(this.props.List.items).reduce((dates, item) => {
-      if (!item || !new PersonValidator(item.Item).isValid()) {
+      if (!item || !new PersonValidator(item.Item).isValid() === true) {
         return dates
       }
 

--- a/src/config/formTypes.js
+++ b/src/config/formTypes.js
@@ -477,21 +477,26 @@ export const reviewSections = {
   ],
 }
 
-export const reduceSubsections = (sections, parentPath, breadcrumbs = []) => (
+export const reduceSubsections = (sections, parentPath, breadcrumbs = [], parentStore) => (
   sections.reduce((accumulator, section) => {
     if (section.subsections && section.subsections.length) {
       const builtPath = parentPath
         ? `${parentPath}/${section.path}`
         : section.path
 
+      const store = parentStore || section.store
+
       /* eslint no-param-reassign: 0 */
       accumulator = accumulator
-        .concat(reduceSubsections(section.subsections, builtPath, [...breadcrumbs, section.label]))
+        .concat(
+          reduceSubsections(section.subsections, builtPath, [...breadcrumbs, section.label], store)
+        )
     } else {
       accumulator.push({
         ...section,
         fullPath: `/form/${parentPath}/${section.path}`,
         breadcrumbs: [...breadcrumbs, section.label],
+        parentStore,
       })
     }
 

--- a/src/helpers/sectionKeys.js
+++ b/src/helpers/sectionKeys.js
@@ -11,4 +11,7 @@ FLAT_SF86.filter(s => s.storeKey && s.parentStore)
     sectionKeyMap[`${s.parentStore}.${s.storeKey}`] = s.key
   })
 
+// special case
+sectionKeyMap['Foreign.Passport'] = 'CITIZENSHIP_US_PASSPORT'
+
 export default sectionKeyMap

--- a/src/helpers/sectionKeys.js
+++ b/src/helpers/sectionKeys.js
@@ -1,0 +1,14 @@
+// Helper for mapping legacy section "store keys" to new section keys
+// Currently needed because /form data does not include section keys
+
+// Only using SF86 because it's a superset of all form sections
+import { FLAT_SF86 } from 'config/formTypes'
+
+const sectionKeyMap = {}
+
+FLAT_SF86.filter(s => s.storeKey && s.parentStore)
+  .forEach((s) => {
+    sectionKeyMap[`${s.parentStore}.${s.storeKey}`] = s.key
+  })
+
+export default sectionKeyMap

--- a/src/sagas/form.js
+++ b/src/sagas/form.js
@@ -25,10 +25,13 @@ export function* updateSectionDataLegacy(name, data) {
       const sectionKey = sectionKeys[`${name}.${subsection}`]
       const sectionData = unschema(data[subsection])
 
-      return all([
-        put(updateApplication(name, subsection, sectionData)),
-        put(handleSubsectionUpdateAction(sectionKey, undefined, sectionData)),
-      ])
+      const updateActions = [put(updateApplication(name, subsection, sectionData))]
+
+      if (sectionKey) {
+        updateActions.push(put(handleSubsectionUpdateAction(sectionKey, undefined, sectionData)))
+      }
+
+      return all(updateActions)
     }))
   } catch (e) {
     console.warn('failed to update section', name, e)

--- a/src/sagas/form.js
+++ b/src/sagas/form.js
@@ -1,7 +1,7 @@
 /* eslint import/no-cycle: 0 */
 
 import {
-  take, select, call, put, all,
+  select, call, put, all, takeEvery,
 } from 'redux-saga/effects'
 
 import { HANDLE_SUBSECTION_UPDATE } from 'constants/actionTypes'
@@ -79,8 +79,5 @@ export function* handleSubsectionUpdate({ key, data }) {
 }
 
 export function* updateSubsectionWatcher() {
-  while (true) {
-    const action = yield take(HANDLE_SUBSECTION_UPDATE)
-    yield call(handleSubsectionUpdate, action)
-  }
+  yield takeEvery(HANDLE_SUBSECTION_UPDATE, handleSubsectionUpdate)
 }

--- a/src/sagas/form.test.js
+++ b/src/sagas/form.test.js
@@ -1,5 +1,5 @@
 import {
-  take, select, call, put, all,
+  select, call, put, all, takeEvery,
 } from 'redux-saga/effects'
 
 import { HANDLE_SUBSECTION_UPDATE } from 'constants/actionTypes'
@@ -118,23 +118,11 @@ describe('The updateSubsection watcher', () => {
 
   it('takes all HANDLE_SUBSECTION_UPDATE actions', () => {
     expect(generator.next().value)
-      .toEqual(take(HANDLE_SUBSECTION_UPDATE))
+      .toEqual(takeEvery(HANDLE_SUBSECTION_UPDATE, handleSubsectionUpdate))
   })
 
-  it('calls the handleSubsectionUpdate handler', () => {
-    const action = {
-      type: HANDLE_SUBSECTION_UPDATE,
-      key: 'IDENTIFICATION_NAME',
-      field: 'Name',
-      data: { first: 'test data' },
-    }
-
-    expect(generator.next(action).value)
-      .toEqual(call(handleSubsectionUpdate, action))
-  })
-
-  it('is never done', () => {
-    expect(generator.next().done).toBe(false)
+  it('is done', () => {
+    expect(generator.next().done).toBe(true)
   })
 })
 

--- a/src/sagas/form.test.js
+++ b/src/sagas/form.test.js
@@ -3,12 +3,16 @@ import {
 } from 'redux-saga/effects'
 
 import { HANDLE_SUBSECTION_UPDATE } from 'constants/actionTypes'
-import { updateSubsection } from 'actions/FormActions'
+import {
+  updateSubsection, handleSubsectionUpdate as handleSubsectionUpdateAction,
+} from 'actions/FormActions'
 import { updateApplication, validateFormData } from 'actions/ApplicationActions'
 
 import { env } from 'config'
 
 import { validateSection } from 'helpers/validation'
+import sectionKeys from 'helpers/sectionKeys'
+
 import { selectSubsection, formTypeSelector } from './selectors'
 
 import {
@@ -86,13 +90,15 @@ describe('updateSectionDataLegacy saga', () => {
 
     it('puts the updateApplication action for each subsection', () => {
       expect(generator.next().value).toEqual(
-        all(['Multiple', 'Passports', 'Status'].map(s => put(
-          updateApplication(
-            'Citizenship',
-            s,
-            testSectionData[s],
-          )
-        )))
+        all(['Multiple', 'Passports', 'Status'].map((s) => {
+          const sectionKey = sectionKeys[`Citizenship.${s}`]
+          const sectionData = testSectionData[s]
+
+          return all([
+            put(updateApplication('Citizenship', s, sectionData)),
+            put(handleSubsectionUpdateAction(sectionKey, undefined, sectionData)),
+          ])
+        }))
       )
     })
 

--- a/src/validators/alcoholnegativeimpact.js
+++ b/src/validators/alcoholnegativeimpact.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import alcoholNegativeImpact from 'models/alcoholNegativeImpact'
 
 export const validateNegativeImpact = data => (
-  validateModel(data, alcoholNegativeImpact) === true
+  validateModel(data, alcoholNegativeImpact)
 )
 
 export const validateNegativeImpacts = (data) => {
@@ -16,7 +16,7 @@ export const validateNegativeImpacts = (data) => {
     },
   }
 
-  return validateModel(data, negativeImpactsModel) === true
+  return validateModel(data, negativeImpactsModel)
 }
 
 export default class NegativeImpactsValidator {
@@ -25,7 +25,7 @@ export default class NegativeImpactsValidator {
   }
 
   isValid() {
-    return validateNegativeImpacts(this.data)
+    return validateNegativeImpacts(this.data) === true
   }
 }
 
@@ -35,6 +35,6 @@ export class NegativeImpactValidator {
   }
 
   isValid() {
-    return validateNegativeImpact(this.data)
+    return validateNegativeImpact(this.data) === true
   }
 }

--- a/src/validators/alcoholorderedcounseling.js
+++ b/src/validators/alcoholorderedcounseling.js
@@ -8,7 +8,7 @@ export const validateOrderedCounseling = (data, formType = formTypes.SF86) => {
   const options = {
     requireAlcoholOrderedCounselingParty: requireAlcoholOrderedCounselingParty(formType),
   }
-  return validateModel(data, alcoholOrderedCounseling, options) === true
+  return validateModel(data, alcoholOrderedCounseling, options)
 }
 
 export const validateOrderedCounselings = (data, formType = formTypes.SF86) => {
@@ -26,7 +26,7 @@ export const validateOrderedCounselings = (data, formType = formTypes.SF86) => {
     },
   }
 
-  return validateModel(data, orderedCounselingsModel, options) === true
+  return validateModel(data, orderedCounselingsModel, options)
 }
 
 export default class OrderedCounselingsValidator {
@@ -38,7 +38,7 @@ export default class OrderedCounselingsValidator {
   }
 
   isValid() {
-    return validateOrderedCounselings(this.data, this.formType)
+    return validateOrderedCounselings(this.data, this.formType) === true
   }
 }
 
@@ -58,6 +58,6 @@ export class OrderedCounselingValidator {
   }
 
   isValid() {
-    return validateOrderedCounseling(this.data, this.formType)
+    return validateOrderedCounseling(this.data, this.formType) === true
   }
 }

--- a/src/validators/alcoholreceivedcounseling.js
+++ b/src/validators/alcoholreceivedcounseling.js
@@ -10,7 +10,7 @@ export const validateReceivedCounseling = (data) => {
     },
   }
 
-  return validateModel(modelData, alcoholReceivedCounseling) === true
+  return validateModel(modelData, alcoholReceivedCounseling)
 }
 
 export const validateReceivedCounselings = (data) => {
@@ -42,7 +42,7 @@ export const validateReceivedCounselings = (data) => {
     modelData.List.items = newItems
   }
 
-  return validateModel(modelData, receivedCounselingsModel) === true
+  return validateModel(modelData, receivedCounselingsModel)
 }
 
 export default class ReceivedCounselingsValidator {
@@ -51,7 +51,7 @@ export default class ReceivedCounselingsValidator {
   }
 
   isValid() {
-    return validateReceivedCounselings(this.data)
+    return validateReceivedCounselings(this.data) === true
   }
 }
 
@@ -76,6 +76,6 @@ export class ReceivedCounselingValidator {
   }
 
   isValid() {
-    return validateReceivedCounseling(this.data)
+    return validateReceivedCounseling(this.data) === true
   }
 }

--- a/src/validators/alcoholvoluntarycounseling.js
+++ b/src/validators/alcoholvoluntarycounseling.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import alcoholVoluntaryCounseling from 'models/alcoholVoluntaryCounseling'
 
 export const validateVoluntaryCounseling = data => (
-  validateModel(data, alcoholVoluntaryCounseling) === true
+  validateModel(data, alcoholVoluntaryCounseling)
 )
 
 export const validateVoluntaryCounselings = (data) => {
@@ -17,7 +17,7 @@ export const validateVoluntaryCounselings = (data) => {
     },
   }
 
-  return validateModel(data, voluntaryCounselingsModel) === true
+  return validateModel(data, voluntaryCounselingsModel)
 }
 
 export default class VoluntaryCounselingsValidator {
@@ -26,7 +26,7 @@ export default class VoluntaryCounselingsValidator {
   }
 
   isValid() {
-    return validateVoluntaryCounselings(this.data)
+    return validateVoluntaryCounselings(this.data) === true
   }
 }
 
@@ -43,6 +43,6 @@ export class VoluntaryCounselingValidator {
   }
 
   isValid() {
-    return validateVoluntaryCounseling(this.data)
+    return validateVoluntaryCounseling(this.data) === true
   }
 }

--- a/src/validators/bankruptcy.js
+++ b/src/validators/bankruptcy.js
@@ -16,7 +16,7 @@ const financialBankruptcyModel = {
 }
 
 export const validateFinancialBankruptcy = data => (
-  validateModel(data, financialBankruptcyModel) === true
+  validateModel(data, financialBankruptcyModel)
 )
 
 /**
@@ -44,7 +44,7 @@ export default class BankruptcyValidator {
    * Validates all bankruptcy items
    */
   isValid() {
-    return validateFinancialBankruptcy(this.data)
+    return validateFinancialBankruptcy(this.data) === true
   }
 }
 

--- a/src/validators/cardabuse.js
+++ b/src/validators/cardabuse.js
@@ -26,7 +26,7 @@ export const validateFinancialCardAbuse = (data, formType) => (
     data,
     cardAbuseModel,
     { requireFinancialCardDisciplinaryDate: requireFinancialCardDisciplinaryDate(formType) },
-  ) === true
+  )
 )
 
 export default class CardAbuseValidator {
@@ -46,7 +46,7 @@ export default class CardAbuseValidator {
   }
 
   isValid() {
-    return validateFinancialCardAbuse(this.data, this.formType)
+    return validateFinancialCardAbuse(this.data, this.formType) === true
   }
 }
 
@@ -55,7 +55,7 @@ const validateCardAbuseItem = (data, formType) => (
     data,
     financialCardAbuse,
     { requireFinancialCardDisciplinaryDate: requireFinancialCardDisciplinaryDate(formType) },
-  ) === true
+  )
 )
 
 export class CardAbuseItemValidator {
@@ -95,6 +95,6 @@ export class CardAbuseItemValidator {
   }
 
   isValid() {
-    return validateCardAbuseItem(this.data, this.formType)
+    return validateCardAbuseItem(this.data, this.formType) === true
   }
 }

--- a/src/validators/citizenship-multiple.js
+++ b/src/validators/citizenship-multiple.js
@@ -27,7 +27,7 @@ const citizenshipMultipleModel = {
 
 export const validateCitizenshipMultiple = (data = {}, formType = formTypes.SF86) => {
   const requireCitizenshipRenounced = requireMultipleCitizenshipRenounced(formType)
-  return validateModel(data, citizenshipMultipleModel, { requireCitizenshipRenounced }) === true
+  return validateModel(data, citizenshipMultipleModel, { requireCitizenshipRenounced })
 }
 
 /** Object Validators (as classes) - legacy */
@@ -69,7 +69,7 @@ export default class CitizenshipMultipleValidator {
   }
 
   isValid() {
-    return validateCitizenshipMultiple(this.data, this.formType)
+    return validateCitizenshipMultiple(this.data, this.formType) === true
   }
 }
 
@@ -114,6 +114,6 @@ export class CitizenshipItemValidator {
   }
 
   isValid() {
-    return validateCitizenship(this.data, this.formType)
+    return validateCitizenship(this.data, this.formType) === true
   }
 }

--- a/src/validators/citizenship-multiple.test.js
+++ b/src/validators/citizenship-multiple.test.js
@@ -67,7 +67,11 @@ describe('validateCitizenshipMultiple function', () => {
         },
       }
 
-      expect(validateCitizenshipMultiple(testData, 'SF86')).toEqual(false)
+      expect(validateCitizenshipMultiple(testData, 'SF86'))
+        .toEqual(expect.arrayContaining([
+          'List.accordion.1.Renounced.presence.REQUIRED',
+          'List.accordion.1.RenouncedExplanation.presence.REQUIRED',
+        ]))
     })
 
     it('passes valid citizenships', () => {

--- a/src/validators/citizenship-passports.js
+++ b/src/validators/citizenship-passports.js
@@ -3,10 +3,12 @@ import foreignPassport from 'models/foreignPassport'
 import foreignPassportTravel from 'models/foreignPassportTravel'
 
 export const validateForeignPassportTravel = data => (
-  validateModel(data, foreignPassportTravel) === true)
+  validateModel(data, foreignPassportTravel)
+)
 
 export const validateForeignPassport = data => (
-  validateModel(data, foreignPassport) === true)
+  validateModel(data, foreignPassport)
+)
 
 export const validateCitizenshipPassports = (data) => {
   const citizenshipPassportsModel = {
@@ -18,7 +20,7 @@ export const validateCitizenshipPassports = (data) => {
     },
   }
 
-  return validateModel(data, citizenshipPassportsModel) === true
+  return validateModel(data, citizenshipPassportsModel)
 }
 
 export default class CitizenshipPassportsValidator {
@@ -27,7 +29,7 @@ export default class CitizenshipPassportsValidator {
   }
 
   isValid() {
-    return validateCitizenshipPassports(this.data)
+    return validateCitizenshipPassports(this.data) === true
   }
 }
 
@@ -86,7 +88,7 @@ export class PassportItemValidator {
   }
 
   isValid() {
-    return validateForeignPassport(this.data)
+    return validateForeignPassport(this.data) === true
   }
 }
 
@@ -108,6 +110,6 @@ export class TravelItemValidator {
   }
 
   isValid() {
-    return validateForeignPassportTravel(this.data)
+    return validateForeignPassportTravel(this.data) === true
   }
 }

--- a/src/validators/citizenship.js
+++ b/src/validators/citizenship.js
@@ -12,7 +12,7 @@ export const validateCitizenshipStatus = (data) => {
 
   return validateModel(data, citizenshipStatus, {
     requireForeignBornDocumentation: !hasValidUSPassport,
-  }) === true
+  })
 }
 
 export const isCertificateRequired = (data, requireForeignBornDocumentation) => (
@@ -70,6 +70,6 @@ export default class CitizenshipValidator {
   }
 
   isValid() {
-    return validateCitizenshipStatus(this.data)
+    return validateCitizenshipStatus(this.data) === true
   }
 }

--- a/src/validators/civilunion.js
+++ b/src/validators/civilunion.js
@@ -11,7 +11,7 @@ export const validateCivilUnion = (data, formType = formTypes.SF86) => {
     data,
     civilUnion,
     { requireForeignBornDocExpiration: isForeignBornDocExpirationRequired },
-  ) === true
+  )
 }
 
 export default class CivilUnionValidator {
@@ -56,6 +56,6 @@ export default class CivilUnionValidator {
   }
 
   isValid() {
-    return validateCivilUnion(this.data, this.formType)
+    return validateCivilUnion(this.data, this.formType) === true
   }
 }

--- a/src/validators/cohabitant.js
+++ b/src/validators/cohabitant.js
@@ -1,7 +1,7 @@
 import { validateModel, hasYesOrNo } from 'models/validate'
 import cohabitant from 'models/cohabitant'
 
-export const validateCohabitant = data => validateModel(data, cohabitant) === true
+export const validateCohabitant = data => validateModel(data, cohabitant)
 
 export const validateCohabitants = (data) => {
   const cohabitantsModel = {
@@ -21,7 +21,7 @@ export const validateCohabitants = (data) => {
     },
   }
 
-  return validateModel(data, cohabitantsModel) === true
+  return validateModel(data, cohabitantsModel)
 }
 
 export default class CohabitantsValidator {
@@ -75,6 +75,6 @@ export class CohabitantValidator {
   }
 
   isValid() {
-    return validateCohabitant(this.data)
+    return validateCohabitant(this.data) === true
   }
 }

--- a/src/validators/competence.js
+++ b/src/validators/competence.js
@@ -2,7 +2,7 @@ import { validateModel } from 'models/validate'
 import competence from 'models/competence'
 
 export const validateCompetence = data => (
-  validateModel(data, competence) === true
+  validateModel(data, competence)
 )
 
 export default class CompetenceValidator {
@@ -11,6 +11,6 @@ export default class CompetenceValidator {
   }
 
   isValid() {
-    return validateCompetence(this.data)
+    return validateCompetence(this.data) === true
   }
 }

--- a/src/validators/consultation.js
+++ b/src/validators/consultation.js
@@ -2,7 +2,7 @@ import { validateModel } from 'models/validate'
 import consultation from 'models/consultation'
 
 export const validateConsultations = data => (
-  validateModel(data, consultation) === true
+  validateModel(data, consultation)
 )
 
 export default class ConsultationValidator {
@@ -11,6 +11,6 @@ export default class ConsultationValidator {
   }
 
   isValid() {
-    return validateConsultations(this.data)
+    return validateConsultations(this.data) === true
   }
 }

--- a/src/validators/credit.js
+++ b/src/validators/credit.js
@@ -19,7 +19,7 @@ const creditCounselingModel = {
 }
 
 export const validateFinancialCredit = data => (
-  validateModel(data, creditCounselingModel) === true
+  validateModel(data, creditCounselingModel)
 )
 
 export default class CreditValidator {
@@ -38,12 +38,12 @@ export default class CreditValidator {
   }
 
   isValid() {
-    return validateFinancialCredit(this.data)
+    return validateFinancialCredit(this.data) === true
   }
 }
 
 const validateCreditCounselingItem = data => (
-  validateModel(data, financialCreditCounseling) === true
+  validateModel(data, financialCreditCounseling)
 )
 
 export class CreditItemValidator {
@@ -72,6 +72,6 @@ export class CreditItemValidator {
   }
 
   isValid() {
-    return validateCreditCounselingItem(this.data)
+    return validateCreditCounselingItem(this.data) === true
   }
 }

--- a/src/validators/delinquent.js
+++ b/src/validators/delinquent.js
@@ -32,7 +32,7 @@ export const validateFinancialDelinquent = (data, formType = formTypes.SF86) => 
   return validateModel(data, delinquentItemsModel, {
     requiredFinancialDelinquentName,
     requiredFinancialDelinquentInfraction,
-  }) === true
+  })
 }
 
 /** Object Validators (as classes) - legacy */
@@ -63,7 +63,7 @@ export default class DelinquentValidator {
   }
 
   isValid() {
-    return validateFinancialDelinquent(this.data, this.formType)
+    return validateFinancialDelinquent(this.data, this.formType) === true
   }
 }
 
@@ -75,7 +75,7 @@ const validateDelinquentItem = (data, formType = formTypes.SF86) => {
     data,
     financialDelinquentPayments,
     { requiredFinancialDelinquentName, requiredFinancialDelinquentInfraction },
-  ) === true
+  )
 }
 
 export class DelinquentItemValidator {
@@ -179,6 +179,6 @@ export class DelinquentItemValidator {
   }
 
   isValid() {
-    return validateDelinquentItem(this.data, this.formType)
+    return validateDelinquentItem(this.data, this.formType) === true
   }
 }

--- a/src/validators/diagnoses.js
+++ b/src/validators/diagnoses.js
@@ -1,7 +1,7 @@
 import { validateModel } from 'models/validate'
 import diagnoses from 'models/diagnoses'
 
-export const validateDiagnoses = data => validateModel(data, diagnoses) === true
+export const validateDiagnoses = data => validateModel(data, diagnoses)
 
 export default class DiagnosesValidator {
   constructor(data = {}) {
@@ -21,6 +21,6 @@ export default class DiagnosesValidator {
   }
 
   isValid() {
-    return validateDiagnoses(this.data)
+    return validateDiagnoses(this.data) === true
   }
 }

--- a/src/validators/diagnosis.js
+++ b/src/validators/diagnosis.js
@@ -25,7 +25,7 @@ export default class DiagnosisValidator {
   }
 
   isValid() {
-    return validateDiagnosis(this.data, this.prefix === 'existingConditions.diagnosis')
+    return validateDiagnosis(this.data, this.prefix === 'existingConditions.diagnosis') === true
   }
 }
 

--- a/src/validators/divorce.js
+++ b/src/validators/divorce.js
@@ -1,7 +1,7 @@
 import { validateModel } from 'models/validate'
 import divorce from 'models/divorce'
 
-export const validateDivorce = data => validateModel(data, divorce) === true
+export const validateDivorce = data => validateModel(data, divorce)
 
 export default class DivorceValidator {
   constructor(data = {}) {
@@ -28,6 +28,6 @@ export default class DivorceValidator {
   }
 
   isValid() {
-    return validateDivorce(this.data)
+    return validateDivorce(this.data) === true
   }
 }

--- a/src/validators/domesticviolence.js
+++ b/src/validators/domesticviolence.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import domesticViolence from 'models/domesticViolence'
 
 export const validateDomesticViolenceItem = data => (
-  validateModel(data, domesticViolence) === true
+  validateModel(data, domesticViolence)
 )
 
 export const validateDomesticViolence = (data) => {
@@ -20,7 +20,7 @@ export const validateDomesticViolence = (data) => {
     },
   }
 
-  return validateModel(data, domesticViolenceModel) === true
+  return validateModel(data, domesticViolenceModel)
 }
 
 export default class DomesticViolence {
@@ -29,7 +29,7 @@ export default class DomesticViolence {
   }
 
   isValid() {
-    return validateDomesticViolence(this.data)
+    return validateDomesticViolence(this.data) === true
   }
 }
 
@@ -39,6 +39,6 @@ export class DomesticViolenceItem {
   }
 
   isValid() {
-    return validateDomesticViolenceItem(this.data)
+    return validateDomesticViolenceItem(this.data) === true
   }
 }

--- a/src/validators/drugclearanceuses.js
+++ b/src/validators/drugclearanceuses.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import drugClearanceUse from 'models/drugClearanceUse'
 
 export const validateDrugClearanceUse = data => (
-  validateModel(data, drugClearanceUse) === true
+  validateModel(data, drugClearanceUse)
 )
 
 export const validateDrugClearanceUses = (data) => {
@@ -19,7 +19,7 @@ export const validateDrugClearanceUses = (data) => {
     },
   }
 
-  return validateModel(data, drugClearanceUsesModel) === true
+  return validateModel(data, drugClearanceUsesModel)
 }
 
 export default class DrugClearanceUsesValidator {
@@ -28,7 +28,7 @@ export default class DrugClearanceUsesValidator {
   }
 
   isValid() {
-    return validateDrugClearanceUses(this.data)
+    return validateDrugClearanceUses(this.data) === true
   }
 }
 
@@ -38,6 +38,6 @@ export class DrugClearanceUseValidator {
   }
 
   isValid() {
-    return validateDrugClearanceUse(this.data)
+    return validateDrugClearanceUse(this.data) === true
   }
 }

--- a/src/validators/druginvolvements.js
+++ b/src/validators/druginvolvements.js
@@ -14,7 +14,7 @@ export const validateDrugInvolvement = (data = {}, formType = formTypes.SF86) =>
     requireInvolvementWhileEmployed: requireDrugWhileSafety(formType),
     requireInvolvementWithClearance: requireDrugWithClearance(formType),
     requireInvolvementInFuture: requireDrugInFuture(formType),
-  }) === true
+  })
 )
 
 export const validateDrugInvolvements = (data = {}, formType = formTypes.SF86) => {
@@ -36,7 +36,7 @@ export const validateDrugInvolvements = (data = {}, formType = formTypes.SF86) =
     },
   }
 
-  return validateModel(data, drugInvolvementsModel) === true
+  return validateModel(data, drugInvolvementsModel)
 }
 
 /** Object Validators (as classes) - legacy */
@@ -56,7 +56,7 @@ export class DrugInvolvementValidator {
   }
 
   isValid() {
-    return validateDrugInvolvement(this.data, this.formType)
+    return validateDrugInvolvement(this.data, this.formType) === true
   }
 }
 
@@ -69,6 +69,6 @@ export default class DrugInvolvementsValidator {
   }
 
   isValid() {
-    return validateDrugInvolvements(this.data, this.formType)
+    return validateDrugInvolvements(this.data, this.formType) === true
   }
 }

--- a/src/validators/druginvolvements.test.js
+++ b/src/validators/druginvolvements.test.js
@@ -38,7 +38,12 @@ describe('validateDrugInvolvements function', () => {
         },
       }
 
-      expect(validateDrugInvolvements(testData, 'SF86')).toEqual(false)
+      expect(validateDrugInvolvements(testData, 'SF86'))
+        .toEqual(expect.arrayContaining([
+          'List.accordion.0.InvolvementWhileEmployed.presence.REQUIRED',
+          'List.accordion.0.InvolvementWithClearance.presence.REQUIRED',
+          'List.accordion.0.InvolvementInFuture.presence.REQUIRED',
+        ]))
     })
 
     it('passes valid data', () => {
@@ -114,7 +119,10 @@ describe('validateDrugInvolvements function', () => {
         },
       }
 
-      expect(validateDrugInvolvements(testData, 'SF85')).toEqual(false)
+      expect(validateDrugInvolvements(testData, 'SF85'))
+        .toEqual(expect.arrayContaining([
+          'List.accordion.INVALID_BRANCH',
+        ]))
     })
 
     it('passes valid data', () => {

--- a/src/validators/drugorderedtreatments.js
+++ b/src/validators/drugorderedtreatments.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import drugOrderedTreatment from 'models/drugOrderedTreatment'
 
 export const validateDrugOrderedTreatment = data => (
-  validateModel(data, drugOrderedTreatment) === true
+  validateModel(data, drugOrderedTreatment)
 )
 
 export const validateDrugOrderedTreatments = (data) => {
@@ -17,7 +17,7 @@ export const validateDrugOrderedTreatments = (data) => {
     },
   }
 
-  return validateModel(data, drugOrderedTreatmentsModel) === true
+  return validateModel(data, drugOrderedTreatmentsModel)
 }
 
 export default class DrugOrderedTreatmentsValidator {
@@ -26,7 +26,7 @@ export default class DrugOrderedTreatmentsValidator {
   }
 
   isValid() {
-    return validateDrugOrderedTreatments(this.data)
+    return validateDrugOrderedTreatments(this.data) === true
   }
 }
 
@@ -43,6 +43,6 @@ export class DrugOrderedTreatmentValidator {
   }
 
   isValid() {
-    return validateDrugOrderedTreatment(this.data)
+    return validateDrugOrderedTreatment(this.data) === true
   }
 }

--- a/src/validators/drugprescriptionuses.js
+++ b/src/validators/drugprescriptionuses.js
@@ -13,7 +13,7 @@ export const validateDrugPrescriptionUse = (data = {}, formType = formTypes.SF86
   validateModel(data, drugPrescriptionUse, {
     requireUseWhileEmployed: requireDrugWhileSafety(formType),
     requireUseWithClearance: requireDrugWithClearance(formType),
-  }) === true
+  })
 )
 
 export const validateDrugPrescriptionUses = (data = {}, formType = formTypes.SF86) => {
@@ -34,7 +34,7 @@ export const validateDrugPrescriptionUses = (data = {}, formType = formTypes.SF8
     },
   }
 
-  return validateModel(data, drugUsesModel) === true
+  return validateModel(data, drugUsesModel)
 }
 
 /** Object Validators (as classes) - legacy */
@@ -47,7 +47,7 @@ export default class DrugPrescriptionUsesValidator {
   }
 
   isValid() {
-    return validateDrugPrescriptionUses(this.data, this.formType)
+    return validateDrugPrescriptionUses(this.data, this.formType) === true
   }
 }
 
@@ -60,6 +60,6 @@ export class DrugPrescriptionUseValidator {
   }
 
   isValid() {
-    return validateDrugPrescriptionUse(this.data, this.formType)
+    return validateDrugPrescriptionUse(this.data, this.formType) === true
   }
 }

--- a/src/validators/drugprescriptionuses.test.js
+++ b/src/validators/drugprescriptionuses.test.js
@@ -37,7 +37,11 @@ describe('validateDrugPrescriptionUses function', () => {
         },
       }
 
-      expect(validateDrugPrescriptionUses(testData, 'SF86')).toEqual(false)
+      expect(validateDrugPrescriptionUses(testData, 'SF86'))
+        .toEqual(expect.arrayContaining([
+          'List.accordion.0.UseWhileEmployed.presence.REQUIRED',
+          'List.accordion.0.UseWithClearance.presence.REQUIRED',
+        ]))
     })
 
     it('passes valid data', () => {
@@ -110,7 +114,10 @@ describe('validateDrugPrescriptionUses function', () => {
         },
       }
 
-      expect(validateDrugPrescriptionUses(testData, 'SF85')).toEqual(false)
+      expect(validateDrugPrescriptionUses(testData, 'SF85'))
+        .toEqual(expect.arrayContaining([
+          'List.accordion.0.Reason.presence.REQUIRED',
+        ]))
     })
 
     it('passes valid data', () => {

--- a/src/validators/drugpublicsafetyuses.js
+++ b/src/validators/drugpublicsafetyuses.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import drugSafetyUse from 'models/drugSafetyUse'
 
 export const validateDrugSafetyUse = data => (
-  validateModel(data, drugSafetyUse) === true
+  validateModel(data, drugSafetyUse)
 )
 
 export const validateDrugSafetyUses = (data) => {
@@ -19,7 +19,7 @@ export const validateDrugSafetyUses = (data) => {
     },
   }
 
-  return validateModel(data, drugSafetyUsesModel) === true
+  return validateModel(data, drugSafetyUsesModel)
 }
 
 export default class DrugPublicSafetyUsesValidator {
@@ -28,7 +28,7 @@ export default class DrugPublicSafetyUsesValidator {
   }
 
   isValid() {
-    return validateDrugSafetyUses(this.data)
+    return validateDrugSafetyUses(this.data) === true
   }
 }
 
@@ -38,6 +38,6 @@ export class DrugPublicSafetyUseValidator {
   }
 
   isValid() {
-    return validateDrugSafetyUse(this.data)
+    return validateDrugSafetyUse(this.data) === true
   }
 }

--- a/src/validators/druguses.js
+++ b/src/validators/druguses.js
@@ -14,7 +14,7 @@ export const validateDrugUse = (data = {}, formType = formTypes.SF86) => (
     requireUseWhileEmployed: requireDrugWhileSafety(formType),
     requireUseWithClearance: requireDrugWithClearance(formType),
     requireUseInFuture: requireDrugInFuture(formType),
-  }) === true
+  })
 )
 
 export const validateDrugUses = (data = {}, formType = formTypes.SF86) => {
@@ -36,7 +36,7 @@ export const validateDrugUses = (data = {}, formType = formTypes.SF86) => {
     },
   }
 
-  return validateModel(data, drugUsesModel) === true
+  return validateModel(data, drugUsesModel)
 }
 
 /** Object Validators (as classes) - legacy */
@@ -49,7 +49,7 @@ export default class DrugUsesValidator {
   }
 
   isValid() {
-    return validateDrugUses(this.data, this.formType)
+    return validateDrugUses(this.data, this.formType) === true
   }
 }
 
@@ -62,6 +62,6 @@ export class DrugUseValidator {
   }
 
   isValid() {
-    return validateDrugUse(this.data, this.formType)
+    return validateDrugUse(this.data, this.formType) === true
   }
 }

--- a/src/validators/druguses.test.js
+++ b/src/validators/druguses.test.js
@@ -37,7 +37,12 @@ describe('validateDrugUses function', () => {
         },
       }
 
-      expect(validateDrugUses(testData, 'SF86')).toEqual(false)
+      expect(validateDrugUses(testData, 'SF86'))
+        .toEqual(expect.arrayContaining([
+          'List.accordion.0.UseWhileEmployed.presence.REQUIRED',
+          'List.accordion.0.UseWithClearance.presence.REQUIRED',
+          'List.accordion.0.UseInFuture.presence.REQUIRED',
+        ]))
     })
 
     it('passes valid data', () => {
@@ -106,7 +111,11 @@ describe('validateDrugUses function', () => {
         },
       }
 
-      expect(validateDrugUses(testData, 'SF85')).toEqual(false)
+      expect(validateDrugUses(testData, 'SF85'))
+        .toEqual(expect.arrayContaining([
+          'List.accordion.0.DrugType.presence.REQUIRED',
+          'List.accordion.0.FirstUse.presence.REQUIRED',
+        ]))
     })
 
     it('passes valid data', () => {

--- a/src/validators/drugvoluntarytreatments.js
+++ b/src/validators/drugvoluntarytreatments.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import drugVoluntaryTreatment from 'models/drugVoluntaryTreatment'
 
 export const validateDrugVoluntaryTreatment = data => (
-  validateModel(data, drugVoluntaryTreatment) === true
+  validateModel(data, drugVoluntaryTreatment)
 )
 
 export const validateDrugVoluntaryTreatments = (data) => {
@@ -17,7 +17,7 @@ export const validateDrugVoluntaryTreatments = (data) => {
     },
   }
 
-  return validateModel(data, drugVoluntaryTreatmentsModel) === true
+  return validateModel(data, drugVoluntaryTreatmentsModel)
 }
 
 export default class DrugVoluntaryTreatmentsValidator {
@@ -26,7 +26,7 @@ export default class DrugVoluntaryTreatmentsValidator {
   }
 
   isValid() {
-    return validateDrugVoluntaryTreatments(this.data)
+    return validateDrugVoluntaryTreatments(this.data) === true
   }
 }
 
@@ -43,6 +43,6 @@ export class DrugVoluntaryTreatmentValidator {
   }
 
   isValid() {
-    return validateDrugVoluntaryTreatment(this.data)
+    return validateDrugVoluntaryTreatment(this.data) === true
   }
 }

--- a/src/validators/education.js
+++ b/src/validators/education.js
@@ -32,11 +32,11 @@ const historyEducationModel = {
 }
 
 export const validateEducation = data => (
-  validateModel(data, education) === true
+  validateModel(data, education)
 )
 
 export const validateHistoryEducation = data => (
-  validateModel(data, historyEducationModel) === true
+  validateModel(data, historyEducationModel)
 )
 
 export default class HistoryEducationValidator {
@@ -58,7 +58,7 @@ export default class HistoryEducationValidator {
   }
 
   isValid() {
-    return validateHistoryEducation(this.data)
+    return validateHistoryEducation(this.data) === true
   }
 }
 
@@ -97,6 +97,6 @@ export class EducationItemValidator {
   }
 
   isValid() {
-    return validateEducation(this.data)
+    return validateEducation(this.data) === true
   }
 }

--- a/src/validators/employment.js
+++ b/src/validators/employment.js
@@ -2,7 +2,7 @@ import { validateModel } from 'models/validate'
 import employment from 'models/employment'
 
 export const validateEmployment = data => (
-  validateModel(data, employment) === true
+  validateModel(data, employment)
 )
 
 export const validateHistoryEmployment = (data) => {
@@ -19,7 +19,7 @@ export const validateHistoryEmployment = (data) => {
     },
   }
 
-  return validateModel(data, historyEmploymentModel) === true
+  return validateModel(data, historyEmploymentModel)
 }
 
 export default class HistoryEmploymentValidator {
@@ -28,7 +28,7 @@ export default class HistoryEmploymentValidator {
   }
 
   isValid() {
-    return validateHistoryEmployment(this.data)
+    return validateHistoryEmployment(this.data) === true
   }
 }
 
@@ -74,6 +74,6 @@ export class EmploymentValidator {
   }
 
   isValid() {
-    return validateEmployment(this.data)
+    return validateEmployment(this.data) === true
   }
 }

--- a/src/validators/existingconditions.js
+++ b/src/validators/existingconditions.js
@@ -2,7 +2,7 @@ import { validateModel } from 'models/validate'
 import existingConditions from 'models/existingConditions'
 
 export const validateExistingConditions = data => (
-  validateModel(data, existingConditions) === true
+  validateModel(data, existingConditions)
 )
 
 export default class ExistingConditionsValidator {
@@ -26,6 +26,6 @@ export default class ExistingConditionsValidator {
   }
 
   isValid() {
-    return validateModel(this.data, existingConditions)
+    return validateModel(this.data, existingConditions) === true
   }
 }

--- a/src/validators/federalservice.js
+++ b/src/validators/federalservice.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import federal from 'models/federal'
 
 export const validateFederalServiceItem = data => (
-  validateModel(data, federal) === true
+  validateModel(data, federal)
 )
 
 export const validateHistoryFederal = (data) => {
@@ -24,7 +24,7 @@ export const validateHistoryFederal = (data) => {
     },
   }
 
-  return validateModel(data, historyFederalModel) === true
+  return validateModel(data, historyFederalModel)
 }
 
 export default class FederalServiceValidator {
@@ -33,7 +33,7 @@ export default class FederalServiceValidator {
   }
 
   isValid() {
-    return validateHistoryFederal(this.data)
+    return validateHistoryFederal(this.data) === true
   }
 }
 
@@ -43,6 +43,6 @@ export class FederalServiceItemValidator {
   }
 
   isValid() {
-    return validateFederalServiceItem(this.data)
+    return validateFederalServiceItem(this.data) === true
   }
 }

--- a/src/validators/foreignbenefit.js
+++ b/src/validators/foreignbenefit.js
@@ -3,11 +3,11 @@ import foreignBenefit from 'models/foreignBenefit'
 import foreignBenefitType from 'models/foreignBenefitType'
 
 export const validateForeignBenefit = data => (
-  validateModel(data, foreignBenefit) === true
+  validateModel(data, foreignBenefit)
 )
 
 export const validateForeignBenefitType = (data, options = {}) => (
-  validateModel(data, foreignBenefitType, options) === true
+  validateModel(data, foreignBenefitType, options)
 )
 
 export default class ForeignBenefitValidator {
@@ -33,7 +33,7 @@ export default class ForeignBenefitValidator {
   }
 
   isValid() {
-    return validateForeignBenefit(this.data)
+    return validateForeignBenefit(this.data) === true
   }
 }
 
@@ -50,7 +50,7 @@ export class OneTimeBenefitValidator {
   }
 
   isValid() {
-    return validateForeignBenefitType(this.data, { benefitType: 'OneTime' })
+    return validateForeignBenefitType(this.data, { benefitType: 'OneTime' }) === true
   }
 }
 
@@ -74,7 +74,7 @@ export class FutureBenefitValidator {
   }
 
   isValid() {
-    return validateForeignBenefitType(this.data, { benefitType: 'Future' })
+    return validateForeignBenefitType(this.data, { benefitType: 'Future' }) === true
   }
 }
 
@@ -98,7 +98,7 @@ export class ContinuingBenefitValidator {
   }
 
   isValid() {
-    return validateForeignBenefitType(this.data, { benefitType: 'Continuing' })
+    return validateForeignBenefitType(this.data, { benefitType: 'Continuing' }) === true
   }
 }
 
@@ -115,6 +115,6 @@ export class OtherBenefitValidator {
   }
 
   isValid() {
-    return validateForeignBenefitType(this.data, { benefitType: 'Other' })
+    return validateForeignBenefitType(this.data, { benefitType: 'Other' }) === true
   }
 }

--- a/src/validators/foreignbenefitactivity.js
+++ b/src/validators/foreignbenefitactivity.js
@@ -19,7 +19,7 @@ export const validateForeignBenefitActivity = (data) => {
     },
   }
 
-  return validateModel(data, foreignBenefitActivityModel) === true
+  return validateModel(data, foreignBenefitActivityModel)
 }
 
 export default class ForeignBenefitActivityValidator {
@@ -28,6 +28,6 @@ export default class ForeignBenefitActivityValidator {
   }
 
   isValid() {
-    return validateForeignBenefitActivity(this.data)
+    return validateForeignBenefitActivity(this.data) === true
   }
 }

--- a/src/validators/foreignborndocument.js
+++ b/src/validators/foreignborndocument.js
@@ -10,7 +10,7 @@ export const validateForeignBornDocument = (data, formType = formTypes.SF86) => 
     data,
     foreignBornDocument,
     { requireForeignBornDocExpiration: isForeignBornDocExpirationRequired }
-  ) === true
+  )
 }
 
 export default class ForeignBornDocumentValidator {
@@ -41,6 +41,6 @@ export default class ForeignBornDocumentValidator {
   }
 
   isValid() {
-    return validateForeignBornDocument(this.data, this.formType)
+    return validateForeignBornDocument(this.data, this.formType) === true
   }
 }

--- a/src/validators/foreignbusinessadvice.js
+++ b/src/validators/foreignbusinessadvice.js
@@ -1,7 +1,7 @@
 import { validateModel, hasYesOrNo } from 'models/validate'
 import foreignBusinessAdvice from 'models/foreignBusinessAdvice'
 
-export const validateAdvice = data => validateModel(data, foreignBusinessAdvice) === true
+export const validateAdvice = data => validateModel(data, foreignBusinessAdvice)
 
 export const validateForeignBusinessAdvice = (data) => {
   const foreignBusinessAdviceModel = {
@@ -18,7 +18,7 @@ export const validateForeignBusinessAdvice = (data) => {
     },
   }
 
-  return validateModel(data, foreignBusinessAdviceModel) === true
+  return validateModel(data, foreignBusinessAdviceModel)
 }
 
 export default class ForeignBusinessAdviceValidator {
@@ -27,7 +27,7 @@ export default class ForeignBusinessAdviceValidator {
   }
 
   isValid() {
-    return validateForeignBusinessAdvice(this.data)
+    return validateForeignBusinessAdvice(this.data) === true
   }
 }
 
@@ -67,6 +67,6 @@ export class AdviceValidator {
   }
 
   isValid() {
-    return validateAdvice(this.data)
+    return validateAdvice(this.data) === true
   }
 }

--- a/src/validators/foreignbusinessconferences.js
+++ b/src/validators/foreignbusinessconferences.js
@@ -1,7 +1,7 @@
 import { validateModel, hasYesOrNo } from 'models/validate'
 import foreignBusinessConferences from 'models/foreignBusinessConferences'
 
-export const validateConferences = data => validateModel(data, foreignBusinessConferences) === true
+export const validateConferences = data => validateModel(data, foreignBusinessConferences)
 
 export const validateForeignBusinessConferences = (data) => {
   const foreignBusinessConferencesModel = {
@@ -18,7 +18,7 @@ export const validateForeignBusinessConferences = (data) => {
     },
   }
 
-  return validateModel(data, foreignBusinessConferencesModel) === true
+  return validateModel(data, foreignBusinessConferencesModel)
 }
 
 export default class ForeignBusinessConferencesValidator {
@@ -27,7 +27,7 @@ export default class ForeignBusinessConferencesValidator {
   }
 
   isValid() {
-    return validateForeignBusinessConferences(this.data)
+    return validateForeignBusinessConferences(this.data) === true
   }
 }
 
@@ -86,6 +86,6 @@ export class ConferencesValidator {
   }
 
   isValid() {
-    return validateConferences(this.data)
+    return validateConferences(this.data) === true
   }
 }

--- a/src/validators/foreignbusinesscontact.js
+++ b/src/validators/foreignbusinesscontact.js
@@ -1,7 +1,7 @@
 import { validateModel, hasYesOrNo } from 'models/validate'
 import foreignBusinessContact from 'models/foreignBusinessContact'
 
-export const validateContact = data => validateModel(data, foreignBusinessContact) === true
+export const validateContact = data => validateModel(data, foreignBusinessContact)
 
 export const validateForeignBusinessContacts = (data) => {
   const foreignBusinessContactsModel = {
@@ -18,7 +18,7 @@ export const validateForeignBusinessContacts = (data) => {
     },
   }
 
-  return validateModel(data, foreignBusinessContactsModel) === true
+  return validateModel(data, foreignBusinessContactsModel)
 }
 
 export default class ForeignBusinessContactValidator {
@@ -27,7 +27,7 @@ export default class ForeignBusinessContactValidator {
   }
 
   isValid() {
-    return validateForeignBusinessContacts(this.data)
+    return validateForeignBusinessContacts(this.data) === true
   }
 }
 
@@ -85,6 +85,6 @@ export class ContactValidator {
   }
 
   isValid() {
-    return validateContact(this.data)
+    return validateContact(this.data) === true
   }
 }

--- a/src/validators/foreignbusinessemployment.js
+++ b/src/validators/foreignbusinessemployment.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import foreignBusinessEmployment from 'models/foreignBusinessEmployment'
 
 export const validateForeignBusinessEmploymentItem = data => (
-  validateModel(data, foreignBusinessEmployment) === true
+  validateModel(data, foreignBusinessEmployment)
 )
 
 export const validateForeignBusinessEmployment = (data) => {
@@ -20,7 +20,7 @@ export const validateForeignBusinessEmployment = (data) => {
     },
   }
 
-  return validateModel(data, foreignBusinessEmploymentModel) === true
+  return validateModel(data, foreignBusinessEmploymentModel)
 }
 
 export default class ForeignBusinessEmploymentValidator {
@@ -29,7 +29,7 @@ export default class ForeignBusinessEmploymentValidator {
   }
 
   isValid() {
-    return validateForeignBusinessEmployment(this.data)
+    return validateForeignBusinessEmployment(this.data) === true
   }
 }
 
@@ -70,6 +70,6 @@ export class ForeignBusinessEmploymentItemValidator {
   }
 
   isValid() {
-    return validateForeignBusinessEmploymentItem(this.data)
+    return validateForeignBusinessEmploymentItem(this.data) === true
   }
 }

--- a/src/validators/foreignbusinessfamily.js
+++ b/src/validators/foreignbusinessfamily.js
@@ -1,7 +1,7 @@
 import { validateModel, hasYesOrNo } from 'models/validate'
 import foreignBusinessFamily from 'models/foreignBusinessFamily'
 
-export const validateFamily = data => validateModel(data, foreignBusinessFamily) === true
+export const validateFamily = data => validateModel(data, foreignBusinessFamily)
 
 export const validateForeignBusinessFamily = (data) => {
   const foreignBusinessFamilyModel = {
@@ -18,7 +18,7 @@ export const validateForeignBusinessFamily = (data) => {
     },
   }
 
-  return validateModel(data, foreignBusinessFamilyModel) === true
+  return validateModel(data, foreignBusinessFamilyModel)
 }
 
 export default class ForeignBusinessFamilyValidator {
@@ -27,7 +27,7 @@ export default class ForeignBusinessFamilyValidator {
   }
 
   isValid() {
-    return validateForeignBusinessFamily(this.data)
+    return validateForeignBusinessFamily(this.data) === true
   }
 }
 
@@ -67,6 +67,6 @@ export class FamilyValidator {
   }
 
   isValid() {
-    return validateFamily(this.data)
+    return validateFamily(this.data) === true
   }
 }

--- a/src/validators/foreignbusinesspolitical.js
+++ b/src/validators/foreignbusinesspolitical.js
@@ -1,7 +1,7 @@
 import { validateModel, hasYesOrNo } from 'models/validate'
 import foreignBusinessPolitical from 'models/foreignBusinessPolitical'
 
-export const validatePolitical = data => validateModel(data, foreignBusinessPolitical) === true
+export const validatePolitical = data => validateModel(data, foreignBusinessPolitical)
 
 export const validateForeignBusinessPolitical = (data) => {
   const foreignBusinessPoliticalModel = {
@@ -18,7 +18,7 @@ export const validateForeignBusinessPolitical = (data) => {
     },
   }
 
-  return validateModel(data, foreignBusinessPoliticalModel) === true
+  return validateModel(data, foreignBusinessPoliticalModel)
 }
 
 export default class ForeignBusinessPoliticalValidator {
@@ -27,7 +27,7 @@ export default class ForeignBusinessPoliticalValidator {
   }
 
   isValid() {
-    return validateForeignBusinessPolitical(this.data)
+    return validateForeignBusinessPolitical(this.data) === true
   }
 }
 
@@ -67,6 +67,6 @@ export class PoliticalValidator {
   }
 
   isValid() {
-    return validatePolitical(this.data)
+    return validatePolitical(this.data) === true
   }
 }

--- a/src/validators/foreignbusinesssponsorship.js
+++ b/src/validators/foreignbusinesssponsorship.js
@@ -1,7 +1,7 @@
 import { validateModel, hasYesOrNo } from 'models/validate'
 import foreignBusinessSponsorship from 'models/foreignBusinessSponsorship'
 
-export const validateSponsorship = data => validateModel(data, foreignBusinessSponsorship) === true
+export const validateSponsorship = data => validateModel(data, foreignBusinessSponsorship)
 
 export const validateForeignBusinessSponsorship = (data) => {
   const foreignBusinessSponsorshipModel = {
@@ -18,7 +18,7 @@ export const validateForeignBusinessSponsorship = (data) => {
     },
   }
 
-  return validateModel(data, foreignBusinessSponsorshipModel) === true
+  return validateModel(data, foreignBusinessSponsorshipModel)
 }
 
 export default class ForeignBusinessSponsorshipValidator {
@@ -27,7 +27,7 @@ export default class ForeignBusinessSponsorshipValidator {
   }
 
   isValid() {
-    return validateForeignBusinessSponsorship(this.data)
+    return validateForeignBusinessSponsorship(this.data) === true
   }
 }
 
@@ -103,6 +103,6 @@ export class SponsorshipValidator {
   }
 
   isValid() {
-    return validateSponsorship(this.data)
+    return validateSponsorship(this.data) === true
   }
 }

--- a/src/validators/foreignbusinessventures.js
+++ b/src/validators/foreignbusinessventures.js
@@ -1,7 +1,7 @@
 import { validateModel, hasYesOrNo } from 'models/validate'
 import foreignBusinessVentures from 'models/foreignBusinessVentures'
 
-export const validateVentures = data => validateModel(data, foreignBusinessVentures) === true
+export const validateVentures = data => validateModel(data, foreignBusinessVentures)
 
 export const validateForeignBusinessVentures = (data) => {
   const foreignBusinessVenturesModel = {
@@ -18,7 +18,7 @@ export const validateForeignBusinessVentures = (data) => {
     },
   }
 
-  return validateModel(data, foreignBusinessVenturesModel) === true
+  return validateModel(data, foreignBusinessVenturesModel)
 }
 
 export default class ForeignBusinessVenturesValidator {
@@ -27,7 +27,7 @@ export default class ForeignBusinessVenturesValidator {
   }
 
   isValid() {
-    return validateForeignBusinessVentures(this.data)
+    return validateForeignBusinessVentures(this.data) === true
   }
 }
 
@@ -103,6 +103,6 @@ export class VenturesValidator {
   }
 
   isValid() {
-    return validateVentures(this.data)
+    return validateVentures(this.data) === true
   }
 }

--- a/src/validators/foreignbusinessvoting.js
+++ b/src/validators/foreignbusinessvoting.js
@@ -1,7 +1,7 @@
 import { validateModel, hasYesOrNo } from 'models/validate'
 import foreignBusinessVoting from 'models/foreignBusinessVoting'
 
-export const validateVoting = data => validateModel(data, foreignBusinessVoting) === true
+export const validateVoting = data => validateModel(data, foreignBusinessVoting)
 
 export const validateForeignBusinessVoting = (data) => {
   const foreignBusinessVotingModel = {
@@ -18,7 +18,7 @@ export const validateForeignBusinessVoting = (data) => {
     },
   }
 
-  return validateModel(data, foreignBusinessVotingModel) === true
+  return validateModel(data, foreignBusinessVotingModel)
 }
 
 export default class ForeignBusinessVotingValidator {
@@ -27,7 +27,7 @@ export default class ForeignBusinessVotingValidator {
   }
 
   isValid() {
-    return validateForeignBusinessVoting(this.data)
+    return validateForeignBusinessVoting(this.data) === true
   }
 }
 
@@ -61,6 +61,6 @@ export class VotingValidator {
   }
 
   isValid() {
-    return validateVoting(this.data)
+    return validateVoting(this.data) === true
   }
 }

--- a/src/validators/foreigncontacts.js
+++ b/src/validators/foreigncontacts.js
@@ -1,7 +1,7 @@
 import { validateModel, hasYesOrNo } from 'models/validate'
 import foreignContact from 'models/foreignContact'
 
-export const validateForeignContact = data => validateModel(data, foreignContact) === true
+export const validateForeignContact = data => validateModel(data, foreignContact)
 
 export const validateForeignContacts = (data) => {
   const foreignContactsModel = {
@@ -18,7 +18,7 @@ export const validateForeignContacts = (data) => {
     },
   }
 
-  return validateModel(data, foreignContactsModel) === true
+  return validateModel(data, foreignContactsModel)
 }
 
 export default class ForeignContactsValidator {
@@ -27,7 +27,7 @@ export default class ForeignContactsValidator {
   }
 
   isValid() {
-    return validateForeignContacts(this.data)
+    return validateForeignContacts(this.data) === true
   }
 }
 
@@ -132,6 +132,6 @@ export class ForeignNationalValidator {
   }
 
   isValid() {
-    return validateForeignContact(this.data)
+    return validateForeignContact(this.data) === true
   }
 }

--- a/src/validators/foreigncoowner.js
+++ b/src/validators/foreigncoowner.js
@@ -8,8 +8,8 @@ export const foreignCoOwnersModel = {
   },
 }
 
-export const validateForeignCoOwner = data => validateModel(data, foreignCoOwner) === true
-export const validateForeignCoOwners = data => validateModel(data, foreignCoOwnersModel) === true
+export const validateForeignCoOwner = data => validateModel(data, foreignCoOwner)
+export const validateForeignCoOwners = data => validateModel(data, foreignCoOwnersModel)
 
 export default class ForeignCoOwnersValidator {
   constructor(data = {}) {
@@ -17,7 +17,7 @@ export default class ForeignCoOwnersValidator {
   }
 
   isValid() {
-    return validateForeignCoOwners(this.data)
+    return validateForeignCoOwners(this.data) === true
   }
 }
 
@@ -33,6 +33,6 @@ export class ForeignCoOwnerValidator {
   }
 
   isValid() {
-    return validateForeignCoOwner(this.data)
+    return validateForeignCoOwner(this.data) === true
   }
 }

--- a/src/validators/foreigndirectactivity.js
+++ b/src/validators/foreigndirectactivity.js
@@ -16,7 +16,7 @@ export const validateForeignDirectActivity = (data) => {
     },
   }
 
-  return validateModel(data, foreignDirectActivityModel) === true
+  return validateModel(data, foreignDirectActivityModel)
 }
 
 export default class ForeignDirectActivityValidator {
@@ -25,6 +25,6 @@ export default class ForeignDirectActivityValidator {
   }
 
   isValid() {
-    return validateForeignDirectActivity(this.data)
+    return validateForeignDirectActivity(this.data) === true
   }
 }

--- a/src/validators/foreigndirectinterest.js
+++ b/src/validators/foreigndirectinterest.js
@@ -2,7 +2,8 @@ import { validateModel } from 'models/validate'
 import foreignDirectInterest from 'models/foreignDirectInterest'
 
 export const validateForeignDirectInterest = data => (
-  validateModel(data, foreignDirectInterest) === true)
+  validateModel(data, foreignDirectInterest)
+)
 
 export default class ForeignDirectInterestValidator {
   constructor(data = {}) {
@@ -16,6 +17,6 @@ export default class ForeignDirectInterestValidator {
   }
 
   isValid() {
-    return validateForeignDirectInterest(this.data)
+    return validateForeignDirectInterest(this.data) === true
   }
 }

--- a/src/validators/foreignindirectactivity.js
+++ b/src/validators/foreignindirectactivity.js
@@ -16,7 +16,7 @@ export const validateForeignIndirectActivity = (data) => {
     },
   }
 
-  return validateModel(data, foreignIndirectActivityModel) === true
+  return validateModel(data, foreignIndirectActivityModel)
 }
 
 export default class ForeignIndirectActivityValidator {
@@ -25,6 +25,6 @@ export default class ForeignIndirectActivityValidator {
   }
 
   isValid() {
-    return validateForeignIndirectActivity(this.data)
+    return validateForeignIndirectActivity(this.data) === true
   }
 }

--- a/src/validators/foreignindirectinterest.js
+++ b/src/validators/foreignindirectinterest.js
@@ -2,7 +2,8 @@ import { validateModel } from 'models/validate'
 import foreignIndirectInterest from 'models/foreignIndirectInterest'
 
 export const validateForeignIndirectInterest = data => (
-  validateModel(data, foreignIndirectInterest) === true)
+  validateModel(data, foreignIndirectInterest)
+)
 
 export default class ForeignIndirectInterestValidator {
   constructor(data = {}) {
@@ -10,6 +11,6 @@ export default class ForeignIndirectInterestValidator {
   }
 
   isValid() {
-    return validateForeignIndirectInterest(this.data)
+    return validateForeignIndirectInterest(this.data) === true
   }
 }

--- a/src/validators/foreignrealestateactivity.js
+++ b/src/validators/foreignrealestateactivity.js
@@ -16,7 +16,7 @@ export const validateForeignRealEstateActivity = (data) => {
     },
   }
 
-  return validateModel(data, foreignRealEstateActivityModel) === true
+  return validateModel(data, foreignRealEstateActivityModel)
 }
 
 export default class ForeignRealEstateActivityValidator {
@@ -25,6 +25,6 @@ export default class ForeignRealEstateActivityValidator {
   }
 
   isValid() {
-    return validateForeignRealEstateActivity(this.data)
+    return validateForeignRealEstateActivity(this.data) === true
   }
 }

--- a/src/validators/foreignrealestateinterest.js
+++ b/src/validators/foreignrealestateinterest.js
@@ -2,7 +2,8 @@ import { validateModel } from 'models/validate'
 import foreignRealEstateInterest from 'models/foreignRealEstateInterest'
 
 export const validateForeignRealEstateInterest = data => (
-  validateModel(data, foreignRealEstateInterest) === true)
+  validateModel(data, foreignRealEstateInterest)
+)
 
 export default class ForeignRealEstateInterestValidator {
   constructor(data = {}) {
@@ -16,6 +17,6 @@ export default class ForeignRealEstateInterestValidator {
   }
 
   isValid() {
-    return validateForeignRealEstateInterest(this.data)
+    return validateForeignRealEstateInterest(this.data) === true
   }
 }

--- a/src/validators/foreignsupport.js
+++ b/src/validators/foreignsupport.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import foreignSupport from 'models/foreignSupport'
 
 export const validateSupport = data => (
-  validateModel(data, foreignSupport) === true
+  validateModel(data, foreignSupport)
 )
 
 export const validateForeignActivitiesSupport = (data) => {
@@ -20,7 +20,7 @@ export const validateForeignActivitiesSupport = (data) => {
     },
   }
 
-  return validateModel(data, foreignActivitiesSupportModel) === true
+  return validateModel(data, foreignActivitiesSupportModel)
 }
 
 export default class ForeignActivitiesSupportValidator {
@@ -29,7 +29,7 @@ export default class ForeignActivitiesSupportValidator {
   }
 
   isValid() {
-    return validateForeignActivitiesSupport(this.data)
+    return validateForeignActivitiesSupport(this.data) === true
   }
 }
 
@@ -75,6 +75,6 @@ export class SupportValidator {
   }
 
   isValid() {
-    return validateSupport(this.data)
+    return validateSupport(this.data) === true
   }
 }

--- a/src/validators/foreigntravel.js
+++ b/src/validators/foreigntravel.js
@@ -17,7 +17,7 @@ export const validateTravel = (data, formType = formTypes.SF86) => {
     requireForeignSensitiveInformation: requireForeignSensitiveInformation(formType),
     requireForeignThreatened: requireForeignThreatened(formType),
   }
-  return validateModel(data, foreignTravel, options) === true
+  return validateModel(data, foreignTravel, options)
 }
 
 export const validateForeignTravel = (data, formType) => {
@@ -51,7 +51,7 @@ export const validateForeignTravel = (data, formType) => {
     },
   }
 
-  return validateModel(data, foreignTravelModel, options) === true
+  return validateModel(data, foreignTravelModel, options)
 }
 
 export default class ForeignTravelValidator {
@@ -63,7 +63,7 @@ export default class ForeignTravelValidator {
   }
 
   isValid() {
-    return validateForeignTravel(this.data, this.formType)
+    return validateForeignTravel(this.data, this.formType) === true
   }
 }
 
@@ -157,6 +157,6 @@ export class TravelValidator {
   }
 
   isValid() {
-    return validateTravel(this.data, this.formType)
+    return validateTravel(this.data, this.formType) === true
   }
 }

--- a/src/validators/gambling.js
+++ b/src/validators/gambling.js
@@ -19,7 +19,7 @@ const financialGamblingModel = {
 }
 
 export const validateFinancialGambling = data => (
-  validateModel(data, financialGamblingModel) === true
+  validateModel(data, financialGamblingModel)
 )
 
 export default class GamblingValidator {
@@ -44,12 +44,12 @@ export default class GamblingValidator {
    * Validates section of gambling debt
    */
   isValid() {
-    return validateFinancialGambling(this.data)
+    return validateFinancialGambling(this.data) === true
   }
 }
 
 export const validateFinancialGamblingItem = data => (
-  validateModel(data, financialGambling) === true
+  validateModel(data, financialGambling)
 )
 
 export class GamblingItemValidator {
@@ -58,6 +58,6 @@ export class GamblingItemValidator {
   }
 
   isValid() {
-    return validateFinancialGamblingItem(this.data)
+    return validateFinancialGamblingItem(this.data) === true
   }
 }

--- a/src/validators/hospitalization.js
+++ b/src/validators/hospitalization.js
@@ -15,11 +15,11 @@ const hospitalizationsModel = {
 }
 
 export const validateHospitalization = data => (
-  validateModel(data, hospitalization) === true
+  validateModel(data, hospitalization)
 )
 
 export const validateHospitalizations = data => (
-  validateModel(data, hospitalizationsModel) === true
+  validateModel(data, hospitalizationsModel)
 )
 
 export default class HospitalizationsValidator {
@@ -34,7 +34,7 @@ export default class HospitalizationsValidator {
   }
 
   isValid() {
-    return validateHospitalizations(this.data)
+    return validateHospitalizations(this.data) === true
   }
 }
 
@@ -51,6 +51,6 @@ export class HospitalizationValidator {
   }
 
   isValid() {
-    return validateHospitalization(this.data)
+    return validateHospitalization(this.data) === true
   }
 }

--- a/src/validators/identificationbirthdate.js
+++ b/src/validators/identificationbirthdate.js
@@ -9,7 +9,7 @@ export const validateIdentificationBirthDate = (data) => {
     },
   }
 
-  return validateModel(data, applicantBirthDateModel) === true
+  return validateModel(data, applicantBirthDateModel)
 }
 
 export default class IdentificationBirthDateValidator {
@@ -18,6 +18,6 @@ export default class IdentificationBirthDateValidator {
   }
 
   isValid() {
-    return validateIdentificationBirthDate(this.data)
+    return validateIdentificationBirthDate(this.data) === true
   }
 }

--- a/src/validators/identificationbirthdate.test.js
+++ b/src/validators/identificationbirthdate.test.js
@@ -60,7 +60,10 @@ describe('The validateIdentificationBirthdate function', () => {
       },
     }
 
-    expect(validateIdentificationBirthDate(testData)).toBe(false)
+    expect(validateIdentificationBirthDate(testData))
+      .toEqual(expect.arrayContaining([
+        'Date.date.month.presence.REQUIRED',
+      ]))
   })
 
   it('should fail a birthdate that is too young', () => {
@@ -72,6 +75,9 @@ describe('The validateIdentificationBirthdate function', () => {
       },
     }
 
-    expect(validateIdentificationBirthDate(testData)).toBe(false)
+    expect(validateIdentificationBirthDate(testData))
+      .toEqual(expect.arrayContaining([
+        'Date.date.date.datetime.DATE_TOO_LATE',
+      ]))
   })
 })

--- a/src/validators/identificationbirthplace.js
+++ b/src/validators/identificationbirthplace.js
@@ -9,7 +9,7 @@ export const validateIdentificationBirthPlace = (data) => {
     },
   }
 
-  return validateModel(data, applicantBirthPlaceModel) === true
+  return validateModel(data, applicantBirthPlaceModel)
 }
 
 export default class IdentificationBirthPlaceValidator {
@@ -18,6 +18,6 @@ export default class IdentificationBirthPlaceValidator {
   }
 
   isValid() {
-    return validateIdentificationBirthPlace(this.data)
+    return validateIdentificationBirthPlace(this.data) === true
   }
 }

--- a/src/validators/identificationbirthplace.test.js
+++ b/src/validators/identificationbirthplace.test.js
@@ -76,6 +76,11 @@ describe('The validateIdentificationBirthPlace function', () => {
       },
     }
 
-    expect(validateIdentificationBirthPlace(testData)).toBe(false)
+    expect(validateIdentificationBirthPlace(testData))
+      .toEqual(expect.arrayContaining([
+        'Location.location.city.presence.REQUIRED',
+        'Location.location.country.presence.REQUIRED',
+        'Location.location.county.presence.REQUIRED',
+      ]))
   })
 })

--- a/src/validators/identificationcontacts.js
+++ b/src/validators/identificationcontacts.js
@@ -66,7 +66,7 @@ export default class IdentificationContactInformationValidator {
    * Validates emails and phone numbers
    */
   isValid() {
-    return validateIdentificationContactInformation(this.data)
+    return validateIdentificationContactInformation(this.data) === true
   }
 }
 
@@ -76,6 +76,6 @@ export class ContactPhoneNumberValidator {
   }
 
   isValid() {
-    return validateContactPhoneNumber(this.data)
+    return validateContactPhoneNumber(this.data) === true
   }
 }

--- a/src/validators/identificationcontacts.js
+++ b/src/validators/identificationcontacts.js
@@ -2,19 +2,21 @@ import { validateModel } from 'models/validate'
 import phone from 'models/shared/phone'
 import email from 'models/shared/email'
 
+// TODO
+
 export const validateContactEmail = data => (
-  validateModel(data, email) === true
+  validateModel(data, email)
 )
 
 export const validateContactPhoneNumber = (data = {}) => {
   const { Telephone } = data
-  return validateModel(Telephone, phone, { requireNumberType: true }) === true
+  return validateModel(Telephone, phone, { requireNumberType: true })
 }
 
 // Requires at least one valid phone number item
 export const validateContactPhoneNumbers = (data = []) => (
   data && data.length > 0
-    && data.some(i => validateContactPhoneNumber(i.Item))
+    && data.some(i => validateContactPhoneNumber(i.Item) === true)
 )
 
 // There can only be one of each phone number type (Cell, Home, Work)
@@ -40,8 +42,8 @@ export const validateIdentificationContactInformation = (data = {}) => {
   const validEmailPresent = (HomeEmail && validateContactEmail(HomeEmail))
     || (WorkEmail && validateContactEmail(WorkEmail))
 
-  return validateContactPhoneNumbers(PhoneNumbers.items)
-    && validateContactPhoneTypes(PhoneNumbers.items)
+  return validateContactPhoneNumbers(PhoneNumbers.items) === true
+    && validateContactPhoneTypes(PhoneNumbers.items) === true
     && validEmailPresent
 }
 

--- a/src/validators/identificationname.js
+++ b/src/validators/identificationname.js
@@ -9,7 +9,7 @@ export const validateIdentificationName = (data) => {
     },
   }
 
-  return validateModel(data, applicantNameModel) === true
+  return validateModel(data, applicantNameModel)
 }
 
 /** LEGACY */
@@ -19,6 +19,6 @@ export default class IdentificationNameValidator {
   }
 
   isValid() {
-    return validateIdentificationName(this.data)
+    return validateIdentificationName(this.data) === true
   }
 }

--- a/src/validators/identificationothernames.js
+++ b/src/validators/identificationothernames.js
@@ -26,11 +26,11 @@ const otherNamesModel = {
 }
 
 export const validateOtherName = data => (
-  validateModel(data, otherNameModel) === true
+  validateModel(data, otherNameModel)
 )
 
 export const validateOtherNames = data => (
-  validateModel(data, otherNamesModel) === true
+  validateModel(data, otherNamesModel)
 )
 
 export default class OtherNamesValidator {
@@ -58,7 +58,7 @@ export default class OtherNamesValidator {
    * Validates the branching hasOtherNames property and all other name values
    */
   isValid() {
-    return validateOtherNames(this.data)
+    return validateOtherNames(this.data) === true
   }
 }
 
@@ -99,6 +99,6 @@ export class OtherNameValidator {
    * Validates all portions of an other name
    */
   isValid() {
-    return validateOtherName(this.data)
+    return validateOtherName(this.data) === true
   }
 }

--- a/src/validators/identificationphysical.js
+++ b/src/validators/identificationphysical.js
@@ -30,7 +30,7 @@ export default class PhysicalValidator {
    * Validates all physical attributes
    */
   isValid() {
-    return validateIdentificationPhysical(this.data)
+    return validateIdentificationPhysical(this.data) === true
   }
 
   validHeight() {

--- a/src/validators/identificationphysical.js
+++ b/src/validators/identificationphysical.js
@@ -6,6 +6,8 @@ import height from 'models/shared/height'
 import sex from 'models/shared/sex'
 import weight from 'models/shared/weight'
 
+// TODO
+
 export const validateIdentificationPhysical = (data) => {
   const physicalModel = {
     Height: { presence: true, model: { validator: height } },
@@ -15,7 +17,7 @@ export const validateIdentificationPhysical = (data) => {
     Sex: { presence: true, model: { validator: sex } },
   }
 
-  return validateModel(data, physicalModel) === true
+  return validateModel(data, physicalModel)
 }
 
 /** LEGACY */

--- a/src/validators/identificationssn.js
+++ b/src/validators/identificationssn.js
@@ -1,5 +1,6 @@
 import { validateModel } from 'models/validate'
 
+// TODO
 export const validateIdentificationSSN = (data) => {
   const { verified, ssn } = data
 
@@ -16,7 +17,7 @@ export const validateIdentificationSSN = (data) => {
     },
   }
 
-  return validateModel({ ssn }, ssnModel) === true
+  return validateModel({ ssn }, ssnModel)
 }
 
 /** LEGACY */
@@ -26,6 +27,6 @@ export default class IdentificationSSNValidator {
   }
 
   isValid() {
-    return validateIdentificationSSN(this.data)
+    return validateIdentificationSSN(this.data) === true
   }
 }

--- a/src/validators/legalassociationsactivities.js
+++ b/src/validators/legalassociationsactivities.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import activitiesOverthrow from 'models/activitiesOverthrow'
 
 export const validateActivities = data => (
-  validateModel(data, activitiesOverthrow) === true
+  validateModel(data, activitiesOverthrow)
 )
 
 export const validateLegalAssociationActivities = (data) => {
@@ -20,7 +20,7 @@ export const validateLegalAssociationActivities = (data) => {
     },
   }
 
-  return validateModel(data, legalAssociationActivitiesModel) === true
+  return validateModel(data, legalAssociationActivitiesModel)
 }
 
 export default class LegalAssociationActivitiesValidator {
@@ -29,7 +29,7 @@ export default class LegalAssociationActivitiesValidator {
   }
 
   isValid() {
-    return validateLegalAssociationActivities(this.data)
+    return validateLegalAssociationActivities(this.data) === true
   }
 }
 
@@ -51,6 +51,6 @@ export class ActivitiesValidator {
   }
 
   isValid() {
-    return validateActivities(this.data)
+    return validateActivities(this.data) === true
   }
 }

--- a/src/validators/legalassociationsadvocating.js
+++ b/src/validators/legalassociationsadvocating.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import terrorismAdvocate from 'models/terrorismAdvocate'
 
 export const validateAdvocate = data => (
-  validateModel(data, terrorismAdvocate) === true
+  validateModel(data, terrorismAdvocate)
 )
 
 export const validateLegalAssociationAdvocate = (data) => {
@@ -20,7 +20,7 @@ export const validateLegalAssociationAdvocate = (data) => {
     },
   }
 
-  return validateModel(data, legalAssociationAdvocateModel) === true
+  return validateModel(data, legalAssociationAdvocateModel)
 }
 
 export default class LegalAssociationAdvocatingValidator {
@@ -29,7 +29,7 @@ export default class LegalAssociationAdvocatingValidator {
   }
 
   isValid() {
-    return validateLegalAssociationAdvocate(this.data)
+    return validateLegalAssociationAdvocate(this.data) === true
   }
 }
 
@@ -51,6 +51,6 @@ export class AdvocatingValidator {
   }
 
   isValid() {
-    return validateAdvocate(this.data)
+    return validateAdvocate(this.data) === true
   }
 }

--- a/src/validators/legalassociationsengaged.js
+++ b/src/validators/legalassociationsengaged.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import terrorismEngaged from 'models/terrorismEngaged'
 
 export const validateEngaged = data => (
-  validateModel(data, terrorismEngaged) === true
+  validateModel(data, terrorismEngaged)
 )
 
 export const validateLegalAssociationEngaged = (data) => {
@@ -20,7 +20,7 @@ export const validateLegalAssociationEngaged = (data) => {
     },
   }
 
-  return validateModel(data, legalAssociationEngagedModel) === true
+  return validateModel(data, legalAssociationEngagedModel)
 }
 
 export default class LegalAssociationEngagedValidator {
@@ -29,7 +29,7 @@ export default class LegalAssociationEngagedValidator {
   }
 
   isValid() {
-    return validateLegalAssociationEngaged(this.data)
+    return validateLegalAssociationEngaged(this.data) === true
   }
 }
 
@@ -51,6 +51,6 @@ export class EngagedValidator {
   }
 
   isValid() {
-    return validateEngaged(this.data)
+    return validateEngaged(this.data) === true
   }
 }

--- a/src/validators/legalassociationsoverthrow.js
+++ b/src/validators/legalassociationsoverthrow.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import overthrow from 'models/overthrow'
 
 export const validateOverthrow = data => (
-  validateModel(data, overthrow) === true
+  validateModel(data, overthrow)
 )
 
 export const validateLegalOverthrow = (data) => {
@@ -19,7 +19,7 @@ export const validateLegalOverthrow = (data) => {
     },
   }
 
-  return validateModel(data, legalOverthrowModel) === true
+  return validateModel(data, legalOverthrowModel)
 }
 
 export default class LegalAssociationOverthrowValidator {
@@ -28,7 +28,7 @@ export default class LegalAssociationOverthrowValidator {
   }
 
   isValid() {
-    return validateLegalOverthrow(this.data)
+    return validateLegalOverthrow(this.data) === true
   }
 }
 
@@ -74,6 +74,6 @@ export class OverthrowValidator {
   }
 
   isValid() {
-    return validateOverthrow(this.data)
+    return validateOverthrow(this.data) === true
   }
 }

--- a/src/validators/legalassociationsterrorism.js
+++ b/src/validators/legalassociationsterrorism.js
@@ -2,7 +2,7 @@ import { validateModel } from 'models/validate'
 import terrorism from 'models/terrorism'
 
 export const validateLegalAssociationTerrorism = data => (
-  validateModel(data, terrorism) === true
+  validateModel(data, terrorism)
 )
 
 export default class LegalAssociationTerrorismValidator {
@@ -11,6 +11,6 @@ export default class LegalAssociationTerrorismValidator {
   }
 
   isValid() {
-    return validateLegalAssociationTerrorism(this.data)
+    return validateLegalAssociationTerrorism(this.data) === true
   }
 }

--- a/src/validators/legalassociationsterrorist.js
+++ b/src/validators/legalassociationsterrorist.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import terrorist from 'models/terrorist'
 
 export const validateTerrorist = data => (
-  validateModel(data, terrorist) === true
+  validateModel(data, terrorist)
 )
 
 export const validateLegalTerrorist = (data) => {
@@ -19,7 +19,7 @@ export const validateLegalTerrorist = (data) => {
     },
   }
 
-  return validateModel(data, legalTerroristModel) === true
+  return validateModel(data, legalTerroristModel)
 }
 
 export default class LegalTerroristValidator {
@@ -28,7 +28,7 @@ export default class LegalTerroristValidator {
   }
 
   isValid() {
-    return validateLegalTerrorist(this.data)
+    return validateLegalTerrorist(this.data) === true
   }
 }
 
@@ -74,6 +74,6 @@ export class TerroristValidator {
   }
 
   isValid() {
-    return validateTerrorist(this.data)
+    return validateTerrorist(this.data) === true
   }
 }

--- a/src/validators/legalassociationsviolence.js
+++ b/src/validators/legalassociationsviolence.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import violence from 'models/violence'
 
 export const validateViolence = data => (
-  validateModel(data, violence) === true
+  validateModel(data, violence)
 )
 
 export const validateLegalViolence = (data) => {
@@ -19,7 +19,7 @@ export const validateLegalViolence = (data) => {
     },
   }
 
-  return validateModel(data, legalViolenceModel) === true
+  return validateModel(data, legalViolenceModel)
 }
 
 export default class LegalAssociationViolenceValidator {
@@ -28,7 +28,7 @@ export default class LegalAssociationViolenceValidator {
   }
 
   isValid() {
-    return validateLegalViolence(this.data)
+    return validateLegalViolence(this.data) === true
   }
 }
 
@@ -74,6 +74,6 @@ export class ViolenceValidator {
   }
 
   isValid() {
-    return validateViolence(this.data)
+    return validateViolence(this.data) === true
   }
 }

--- a/src/validators/legalinvestigationsdebarred.js
+++ b/src/validators/legalinvestigationsdebarred.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import debarred from 'models/debarred'
 
 export const validateDebarred = data => (
-  validateModel(data, debarred) === true
+  validateModel(data, debarred)
 )
 
 export const validateLegalInvestigationsDebarred = (data) => {
@@ -19,7 +19,7 @@ export const validateLegalInvestigationsDebarred = (data) => {
     },
   }
 
-  return validateModel(data, legalInvestigationsDebarredModel) === true
+  return validateModel(data, legalInvestigationsDebarredModel)
 }
 
 export default class LegalInvestigationsDebarredValidator {
@@ -28,7 +28,7 @@ export default class LegalInvestigationsDebarredValidator {
   }
 
   isValid() {
-    return validateLegalInvestigationsDebarred(this.data)
+    return validateLegalInvestigationsDebarred(this.data) === true
   }
 }
 
@@ -56,6 +56,6 @@ export class DebarredValidator {
   }
 
   isValid() {
-    return validateDebarred(this.data)
+    return validateDebarred(this.data) === true
   }
 }

--- a/src/validators/legalinvestigationshistory.js
+++ b/src/validators/legalinvestigationshistory.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import investigation from 'models/investigation'
 
 export const validateInvestigation = data => (
-  validateModel(data, investigation) === true
+  validateModel(data, investigation)
 )
 
 export const validateLegalInvestigationsHistory = (data) => {
@@ -19,7 +19,7 @@ export const validateLegalInvestigationsHistory = (data) => {
     },
   }
 
-  return validateModel(data, legalInvestigationsHistoryModel) === true
+  return validateModel(data, legalInvestigationsHistoryModel)
 }
 
 export default class LegalInvestigationsHistoryValidator {
@@ -30,7 +30,7 @@ export default class LegalInvestigationsHistoryValidator {
   }
 
   isValid() {
-    return validateLegalInvestigationsHistory(this.data)
+    return validateLegalInvestigationsHistory(this.data) === true
   }
 }
 
@@ -65,6 +65,6 @@ export class HistoryValidator {
   }
 
   isValid() {
-    return validateInvestigation(this.data)
+    return validateInvestigation(this.data) === true
   }
 }

--- a/src/validators/legalinvestigationsrevoked.js
+++ b/src/validators/legalinvestigationsrevoked.js
@@ -3,7 +3,7 @@ import revoked from 'models/revoked'
 
 
 export const validateLegalInvestigationsRevokedItem = data => (
-  validateModel(data, revoked) === true
+  validateModel(data, revoked)
 )
 
 export const validateLegalInvestigationsRevoked = (data) => {
@@ -25,7 +25,7 @@ export const validateLegalInvestigationsRevoked = (data) => {
     },
   }
 
-  return validateModel(data, revokedModel) === true
+  return validateModel(data, revokedModel)
 }
 
 export default class LegalInvestigationsRevokedValidator {
@@ -34,7 +34,7 @@ export default class LegalInvestigationsRevokedValidator {
   }
 
   isValid() {
-    return validateLegalInvestigationsRevoked(this.data)
+    return validateLegalInvestigationsRevoked(this.data) === true
   }
 }
 
@@ -44,6 +44,6 @@ export class RevokedItemValidator {
   }
 
   isValid() {
-    return validateLegalInvestigationsRevokedItem(this.data)
+    return validateLegalInvestigationsRevokedItem(this.data) === true
   }
 }

--- a/src/validators/legalnoncriminalcourtactions.js
+++ b/src/validators/legalnoncriminalcourtactions.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import nonCriminalCourtAction from 'models/nonCriminalCourtAction'
 
 export const validateNonCriminalCourtAction = data => (
-  validateModel(data, nonCriminalCourtAction) === true
+  validateModel(data, nonCriminalCourtAction)
 )
 
 export const validateLegalNonCriminalCourtActions = (data) => {
@@ -19,7 +19,7 @@ export const validateLegalNonCriminalCourtActions = (data) => {
     },
   }
 
-  return validateModel(data, legalNonCriminalCourtActionsModel) === true
+  return validateModel(data, legalNonCriminalCourtActionsModel)
 }
 
 export default class NonCriminalCourtActionsValidator {
@@ -28,7 +28,7 @@ export default class NonCriminalCourtActionsValidator {
   }
 
   isValid() {
-    return validateLegalNonCriminalCourtActions(this.data)
+    return validateLegalNonCriminalCourtActions(this.data) === true
   }
 }
 
@@ -38,6 +38,6 @@ export class NonCriminalCourtActionValidator {
   }
 
   isValid() {
-    return validateNonCriminalCourtAction(this.data)
+    return validateNonCriminalCourtAction(this.data) === true
   }
 }

--- a/src/validators/legaltechnologymanipulating.js
+++ b/src/validators/legaltechnologymanipulating.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import manipulatingTech from 'models/manipulatingTech'
 
 export const validateManipulatingTech = data => (
-  validateModel(data, manipulatingTech) === true
+  validateModel(data, manipulatingTech)
 )
 
 export const validateLegalTechnologyManipulating = (data) => {
@@ -19,7 +19,7 @@ export const validateLegalTechnologyManipulating = (data) => {
     },
   }
 
-  return validateModel(data, legalTechnologyManipulatingModel) === true
+  return validateModel(data, legalTechnologyManipulatingModel)
 }
 
 export default class LegalTechnologyManipulatingValidator {
@@ -28,7 +28,7 @@ export default class LegalTechnologyManipulatingValidator {
   }
 
   isValid() {
-    return validateLegalTechnologyManipulating(this.data)
+    return validateLegalTechnologyManipulating(this.data) === true
   }
 }
 
@@ -62,6 +62,6 @@ export class ManipulatingValidator {
   }
 
   isValid() {
-    return validateManipulatingTech(this.data)
+    return validateManipulatingTech(this.data) === true
   }
 }

--- a/src/validators/legaltechnologyunauthorized.js
+++ b/src/validators/legaltechnologyunauthorized.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import unauthorizedTech from 'models/unauthorizedTech'
 
 export const validateUnauthorizedTech = data => (
-  validateModel(data, unauthorizedTech) === true
+  validateModel(data, unauthorizedTech)
 )
 
 export const validateLegalTechnologyUnauthorized = (data) => {
@@ -19,7 +19,7 @@ export const validateLegalTechnologyUnauthorized = (data) => {
     },
   }
 
-  return validateModel(data, legalTechnologyUnauthorizedModel) === true
+  return validateModel(data, legalTechnologyUnauthorizedModel)
 }
 
 export default class LegalTechnologyUnauthorizedValidator {
@@ -28,7 +28,7 @@ export default class LegalTechnologyUnauthorizedValidator {
   }
 
   isValid() {
-    return validateLegalTechnologyUnauthorized(this.data)
+    return validateLegalTechnologyUnauthorized(this.data) === true
   }
 }
 
@@ -62,6 +62,6 @@ export class UnauthorizedValidator {
   }
 
   isValid() {
-    return validateUnauthorizedTech(this.data)
+    return validateUnauthorizedTech(this.data) === true
   }
 }

--- a/src/validators/legaltechnologyunlawful.js
+++ b/src/validators/legaltechnologyunlawful.js
@@ -2,7 +2,7 @@ import { validateModel, hasYesOrNo } from 'models/validate'
 import unlawfulTech from 'models/unlawfulTech'
 
 export const validateUnlawfulTech = data => (
-  validateModel(data, unlawfulTech) === true
+  validateModel(data, unlawfulTech)
 )
 
 export const validateLegalTechnologyUnlawful = (data) => {
@@ -19,7 +19,7 @@ export const validateLegalTechnologyUnlawful = (data) => {
     },
   }
 
-  return validateModel(data, legalTechnologyUnlawfulModel) === true
+  return validateModel(data, legalTechnologyUnlawfulModel)
 }
 
 export default class LegalTechnologyUnlawfulValidator {
@@ -28,7 +28,7 @@ export default class LegalTechnologyUnlawfulValidator {
   }
 
   isValid() {
-    return validateLegalTechnologyUnlawful(this.data)
+    return validateLegalTechnologyUnlawful(this.data) === true
   }
 }
 
@@ -62,6 +62,6 @@ export class UnlawfulValidator {
   }
 
   isValid() {
-    return validateUnlawfulTech(this.data)
+    return validateUnlawfulTech(this.data) === true
   }
 }

--- a/src/validators/marital.js
+++ b/src/validators/marital.js
@@ -58,7 +58,7 @@ export const validateMarital = (data, formType = formTypes.SF86) => {
     requireForeignBornDocExpiration: isForeignBornDocExpirationRequired,
     requireRelationshipMaritalDivorcePhoneNumber: isDivorceePhoneNumberRequired,
   }
-  return validateModel(data, maritalModel, options) === true
+  return validateModel(data, maritalModel, options)
 }
 
 export default class MaritalValidator {
@@ -81,6 +81,6 @@ export default class MaritalValidator {
   }
 
   isValid() {
-    return validateMarital(this.data, this.formType)
+    return validateMarital(this.data, this.formType) === true
   }
 }

--- a/src/validators/militarydisciplinary.js
+++ b/src/validators/militarydisciplinary.js
@@ -23,7 +23,7 @@ const militaryDisciplinaryProceduresModel = {
 }
 
 export const validateMilitaryDisciplinaryProcedures = data => (
-  validateModel(data, militaryDisciplinaryProceduresModel) === true
+  validateModel(data, militaryDisciplinaryProceduresModel)
 )
 
 export class ProcedureValidator {
@@ -71,6 +71,6 @@ export default class MilitaryDisciplinaryValidator {
   }
 
   isValid() {
-    return validateMilitaryDisciplinaryProcedures(this.data)
+    return validateMilitaryDisciplinaryProcedures(this.data) === true
   }
 }

--- a/src/validators/militaryforeign.js
+++ b/src/validators/militaryforeign.js
@@ -5,7 +5,7 @@ import * as formTypes from 'constants/formTypes'
 import { requireForeignMilitaryMaintainsContact } from 'helpers/branches'
 
 const validateForeignContact = data => (
-  validateModel(data, foreignMilitaryContact) === true
+  validateModel(data, foreignMilitaryContact)
 )
 export class ForeignContactValidator {
   constructor(data) {
@@ -13,7 +13,7 @@ export class ForeignContactValidator {
   }
 
   isValid() {
-    return validateForeignContact(this.data)
+    return validateForeignContact(this.data) === true
   }
 }
 
@@ -44,7 +44,7 @@ const militaryForeignModel = {
 export const validateMilitaryForeign = (data, formType = formTypes.SF86) => (
   validateModel(data, militaryForeignModel, {
     requireForeignMilitaryMaintainsContact: requireForeignMilitaryMaintainsContact(formType),
-  }) === true
+  })
 )
 
 export default class MilitaryForeignValidator {
@@ -56,6 +56,6 @@ export default class MilitaryForeignValidator {
   }
 
   isValid() {
-    return validateMilitaryForeign(this.data, this.formType)
+    return validateMilitaryForeign(this.data, this.formType) === true
   }
 }

--- a/src/validators/militaryhistory.js
+++ b/src/validators/militaryhistory.js
@@ -3,11 +3,11 @@ import militaryHistory from 'models/militaryHistory'
 import { validateModel } from 'models/validate'
 
 export const validateMilitaryHistory = data => (
-  validateModel(data, militaryHistory) === true
+  validateModel(data, militaryHistory)
 )
 
 export const validateMilitaryService = data => (
-  validateModel(data, militaryService) === true
+  validateModel(data, militaryService)
 )
 
 export default class MilitaryHistoryValidator {
@@ -26,7 +26,7 @@ export default class MilitaryHistoryValidator {
   }
 
   isValid() {
-    return validateMilitaryHistory(this.data)
+    return validateMilitaryHistory(this.data) === true
   }
 }
 
@@ -36,6 +36,6 @@ export class MilitaryServiceValidator {
   }
 
   isValid() {
-    return validateMilitaryService(this.data)
+    return validateMilitaryService(this.data) === true
   }
 }

--- a/src/validators/nonpayment.js
+++ b/src/validators/nonpayment.js
@@ -19,7 +19,7 @@ const nonpaymentModel = {
 }
 
 export const validateFinancialNonpayment = data => (
-  validateModel(data, nonpaymentModel) === true
+  validateModel(data, nonpaymentModel)
 )
 
 export default class NonpaymentValidator {
@@ -36,12 +36,12 @@ export default class NonpaymentValidator {
   }
 
   isValid() {
-    return validateFinancialNonpayment(this.data)
+    return validateFinancialNonpayment(this.data) === true
   }
 }
 
 const validateNonpaymentItem = data => (
-  validateModel(data, financialNonpayment) === true
+  validateModel(data, financialNonpayment)
 )
 
 export class NonpaymentItemValidator {
@@ -90,6 +90,6 @@ export class NonpaymentItemValidator {
   }
 
   isValid() {
-    return validateNonpaymentItem(this.data)
+    return validateNonpaymentItem(this.data) === true
   }
 }

--- a/src/validators/order.js
+++ b/src/validators/order.js
@@ -2,7 +2,7 @@ import { validateModel } from 'models/validate'
 import order from 'models/shared/order'
 
 export const validateOrder = (data, requireDisposition = true) => (
-  validateModel(data, order, { requireDisposition }) === true
+  validateModel(data, order, { requireDisposition })
 )
 
 export default class OrderValidator {
@@ -37,7 +37,7 @@ export default class OrderValidator {
   }
 
   isValid() {
-    return validateOrder(this.data, this.prefix !== 'competence')
+    return validateOrder(this.data, this.prefix !== 'competence') === true
   }
 }
 

--- a/src/validators/otheroffense.js
+++ b/src/validators/otheroffense.js
@@ -12,7 +12,7 @@ const options = formType => (
 )
 
 export const validateOtherOffense = (data, formType) => (
-  validateModel(data, otherOffense, options(formType)) === true
+  validateModel(data, otherOffense, options(formType))
 )
 
 export default class OtherOffenseValidator {
@@ -104,6 +104,6 @@ export default class OtherOffenseValidator {
   }
 
   isValid() {
-    return validateOtherOffense(this.data, this.formType)
+    return validateOtherOffense(this.data, this.formType) === true
   }
 }

--- a/src/validators/passport.js
+++ b/src/validators/passport.js
@@ -2,12 +2,12 @@ import { validateModel, checkValue } from 'models/validate'
 import usPassport from 'models/usPassport'
 
 export const validateUsPassport = data => (
-  validateModel(data, usPassport) === true
+  validateModel(data, usPassport)
 )
 
 export const hasValidUSPassport = (data = {}) => {
   const { HasPassports = {} } = data
-  return checkValue(HasPassports, 'Yes') && validateUsPassport(data)
+  return checkValue(HasPassports, 'Yes') && validateUsPassport(data) === true
 }
 
 /**
@@ -50,6 +50,6 @@ export default class PassportValidator {
   }
 
   isValid() {
-    return validateUsPassport(this.data)
+    return validateUsPassport(this.data) === true
   }
 }

--- a/src/validators/people.js
+++ b/src/validators/people.js
@@ -18,7 +18,7 @@ export const validatePeople = (data) => {
     },
   }
 
-  return validateModel(data, peopleModel) === true
+  return validateModel(data, peopleModel)
 }
 
 export default class PeopleValidator {
@@ -32,6 +32,6 @@ export default class PeopleValidator {
   }
 
   isValid() {
-    return validatePeople(this.data)
+    return validatePeople(this.data) === true
   }
 }

--- a/src/validators/person.js
+++ b/src/validators/person.js
@@ -1,7 +1,7 @@
 import { validateModel } from 'models/validate'
 import person from 'models/person'
 
-export const validatePerson = data => validateModel(data, person) === true
+export const validatePerson = data => validateModel(data, person)
 
 /** Object Validators (as classes) - legacy */
 export default class PersonValidator {
@@ -44,6 +44,6 @@ export default class PersonValidator {
   }
 
   isValid() {
-    return validatePerson(this.data)
+    return validatePerson(this.data) === true
   }
 }

--- a/src/validators/policeotheroffenses.js
+++ b/src/validators/policeotheroffenses.js
@@ -21,7 +21,7 @@ export const validatePoliceOtherOffenses = (data, formType) => {
     ),
   }
 
-  return validateModel(data, policeOtherOffensesModel, options) === true
+  return validateModel(data, policeOtherOffensesModel, options)
 }
 
 export default class PoliceOtherOffensesValidator {
@@ -33,6 +33,6 @@ export default class PoliceOtherOffensesValidator {
   }
 
   isValid() {
-    return validatePoliceOtherOffenses(this.data, this.formType)
+    return validatePoliceOtherOffenses(this.data, this.formType) === true
   }
 }

--- a/src/validators/relatives.js
+++ b/src/validators/relatives.js
@@ -21,10 +21,10 @@ export const validateRelative = (data, formType) => (
       requireRelationshipRelativesForeignBornDoc: requireRelationshipRelativesForeignBornDoc(formType),
       requireRelationshipRelativesUSResidenceDoc: requireRelationshipRelativesUSResidenceDoc(formType),
     },
-  ) === true
+  )
 )
 
-export const validateAlias = data => validateModel(data, alias) === true
+export const validateAlias = data => validateModel(data, alias)
 
 export const getMaritalStatus = () => {
   const state = store.getState()
@@ -65,7 +65,7 @@ export const validateRelatives = (data, formType) => {
       requireRelationshipRelativesForeignBornDoc: requireRelationshipRelativesForeignBornDoc(formType),
       requireRelationshipRelativesUSResidenceDoc: requireRelationshipRelativesUSResidenceDoc(formType),
     },
-  ) === true
+  )
 }
 
 export default class RelativesValidator {
@@ -120,7 +120,7 @@ export default class RelativesValidator {
   }
 
   isValid() {
-    return validateRelatives(this.data, this.formType)
+    return validateRelatives(this.data, this.formType) === true
   }
 }
 
@@ -254,7 +254,7 @@ export class RelativeValidator {
   }
 
   isValid() {
-    return validateRelative(this.data, this.formType, this.options)
+    return validateRelative(this.data, this.formType, this.options) === true
   }
 }
 
@@ -264,6 +264,6 @@ export class AliasValidator {
   }
 
   isValid() {
-    return validateAlias(this.data)
+    return validateAlias(this.data) === true
   }
 }

--- a/src/validators/residence.js
+++ b/src/validators/residence.js
@@ -1,7 +1,7 @@
 import { validateModel } from 'models/validate'
 import residence from 'models/residence'
 
-export const validateResidence = data => validateModel(data, residence) === true
+export const validateResidence = data => validateModel(data, residence)
 
 export const validateHistoryResidence = (data) => {
   const historyResidenceModel = {
@@ -11,7 +11,7 @@ export const validateHistoryResidence = (data) => {
     },
   }
 
-  return validateModel(data, historyResidenceModel) === true
+  return validateModel(data, historyResidenceModel)
 }
 
 export class ResidenceValidator {
@@ -20,7 +20,7 @@ export class ResidenceValidator {
   }
 
   isValid() {
-    return validateResidence(this.data)
+    return validateResidence(this.data) === true
   }
 }
 
@@ -30,6 +30,6 @@ export default class HistoryResidenceValidator {
   }
 
   isValid() {
-    return validateHistoryResidence(this.data)
+    return validateHistoryResidence(this.data) === true
   }
 }

--- a/src/validators/selectiveservice.js
+++ b/src/validators/selectiveservice.js
@@ -11,7 +11,7 @@ export const hideSelectiveService = (store = {}) => {
 }
 
 export const validateSelectiveService = data => (
-  validateModel(data, selectiveService) === true
+  validateModel(data, selectiveService)
 )
 
 export default class SelectiveServiceValidator {
@@ -36,6 +36,6 @@ export default class SelectiveServiceValidator {
   }
 
   isValid() {
-    return validateSelectiveService(this.data)
+    return validateSelectiveService(this.data) === true
   }
 }

--- a/src/validators/taxes.js
+++ b/src/validators/taxes.js
@@ -19,7 +19,7 @@ const financialTaxesModel = {
 }
 
 export const validateFinancialTaxes = data => (
-  validateModel(data, financialTaxesModel) === true
+  validateModel(data, financialTaxesModel)
 )
 
 export default class TaxesValidator {
@@ -36,7 +36,7 @@ export default class TaxesValidator {
   }
 
   isValid() {
-    return validateFinancialTaxes(this.data)
+    return validateFinancialTaxes(this.data) === true
   }
 }
 
@@ -82,6 +82,6 @@ export class TaxValidator {
   }
 
   isValid() {
-    return validateTaxItem(this.data)
+    return validateTaxItem(this.data) === true
   }
 }

--- a/src/validators/treatment.js
+++ b/src/validators/treatment.js
@@ -1,7 +1,7 @@
 import { validateModel } from 'models/validate'
 import treatment from 'models/treatment'
 
-export const validateTreatment = data => validateModel(data, treatment) === true
+export const validateTreatment = data => validateModel(data, treatment)
 
 export default class TreatmentValidator {
   constructor(data = {}) {
@@ -9,6 +9,6 @@ export default class TreatmentValidator {
   }
 
   isValid() {
-    return validateTreatment(this.data)
+    return validateTreatment(this.data) === true
   }
 }


### PR DESCRIPTION
## Description

_Note:_ This PR completes the work started in https://github.com/18F/e-QIP-prototype/pull/1796. These PRs should be merged into `develop` together.

- Populate form data into the new `state.form` store on login
- Move `=== true` checks out of new validator functions so they can return the full error details instead
- Ensure legacy usage of validator classes/functions explicitly checks for `=== true` since failed validations will return an array of errors instead (which is truthy)

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
