### PR TITLE
Bump birthdates a year for 2020

### DIFF
--- a/src/components/Section/History/helpers.test.js
+++ b/src/components/Section/History/helpers.test.js
@@ -17,7 +17,7 @@ describe('the totalYears function', () => {
   })
 
   describe('if birthdate is less than 2 years older than 18', () => {
-    const birthdate = new Date('1/1/2000')
+    const birthdate = new Date('1/1/2001')
 
     it('returns the minimum of 2 years', () => {
       expect(totalYears(birthdate)).toEqual(2)
@@ -25,7 +25,7 @@ describe('the totalYears function', () => {
   })
 
   describe('if birthdate is less than the years param older than 18', () => {
-    const birthdate = new Date('1/1/1995')
+    const birthdate = new Date('1/1/1996')
 
     it('returns the difference between age and years param', () => {
       expect(totalYears(birthdate, 10)).toEqual(7)


### PR DESCRIPTION
These date-oriented tests aren't written well and are tied to the present year from the system clock vs a fixed clock being passed into the test. This is a minimum viable change to get the tests to pass again. 

If it's not properly fixed, the tests will have to be changed again in 2021, etc.